### PR TITLE
GGRC-6213 Reviewers should be in plural on UI 

### DIFF
--- a/src/ggrc/migrations/versions/20190306113217_adf7bdb8996e_rename_reviewer_to_reviewers.py
+++ b/src/ggrc/migrations/versions/20190306113217_adf7bdb8996e_rename_reviewer_to_reviewers.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Rename reviewer to reviewers
+
+Create Date: 2019-03-06 11:32:17.054147
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'adf7bdb8996e'
+down_revision = '42afbc0e6c09'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  conn = op.get_bind()
+  conn.execute("UPDATE access_control_roles SET name='Reviewers'\
+                  WHERE parent_id is NULL and name='Reviewer'")
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""

--- a/src/ggrc/migrations/versions/20190306113217_adf7bdb8996e_rename_reviewer_to_reviewers.py
+++ b/src/ggrc/migrations/versions/20190306113217_adf7bdb8996e_rename_reviewer_to_reviewers.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'adf7bdb8996e'
-down_revision = '42afbc0e6c09'
+down_revision = 'f53a6dc80a57'
 
 
 def upgrade():

--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -62,7 +62,7 @@ class Reviewable(rest_handable.WithPutHandable,
   def reviewers(self):
     """Return list of reviewer persons"""
     if self.review:
-      return self.review.get_persons_for_rolename('Reviewer')
+      return self.review.get_persons_for_rolename('Reviewers')
     return []
 
   @builder.simple_property

--- a/test/integration/ggrc/access_control/acl_propagation/test_review_reviewer.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_review_reviewer.py
@@ -147,7 +147,7 @@ class TestReviewersPropagation(base.TestACLPropagation):
     """
     self.setup_people()
     reviewer_acr = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer",
+        name="Reviewers",
         object_type="Review",
     ).one()
 

--- a/test/integration/ggrc/converters/test_export_import_reviewable.py
+++ b/test/integration/ggrc/converters/test_export_import_reviewable.py
@@ -25,8 +25,8 @@ class TestExportReviewable(TestCase):
       risk = factories.RiskFactory(title="Test risk")
       review = factories.ReviewFactory(reviewable=risk)
 
-      review.add_person_with_role_name(person1, 'Reviewer')
-      review.add_person_with_role_name(person2, 'Reviewer')
+      review.add_person_with_role_name(person1, 'Reviewers')
+      review.add_person_with_role_name(person2, 'Reviewers')
 
     self.client.get("/login")
 

--- a/test/integration/ggrc/notifications/test_review_notiffications.py
+++ b/test/integration/ggrc/notifications/test_review_notiffications.py
@@ -226,7 +226,7 @@ class TestReviewNotification(TestCase):
     """Reviewer should receive email notification"""
     reviewer = factories.PersonFactory()
     reviewer_role_id = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer",
+        name="Reviewers",
         object_type="Review",
     ).one().id
     program = factories.ProgramFactory()
@@ -277,7 +277,7 @@ class TestReviewNotification(TestCase):
         email="user@example.com"
     ).one()
     reviewer_role_id = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer",
+        name="Reviewers",
         object_type="Review",
     ).one().id
     program = factories.ProgramFactory()
@@ -323,9 +323,9 @@ class TestReviewNotification(TestCase):
     primary contacts, secondary contacts,
     if object is reverted to 'Unreviewed'.
     """
-    reviewer = factories.PersonFactory(name='reviewer')
+    reviewer = factories.PersonFactory(name='reviewers')
     reviewer_role_id = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer",
+        name="Reviewers",
         object_type="Review",
     ).one().id
 
@@ -388,7 +388,7 @@ class TestReviewNotification(TestCase):
 
     reviewer = factories.PersonFactory()
     reviewer_role_id = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer",
+        name="Reviewers",
         object_type="Review",
     ).one().id
 

--- a/test/integration/ggrc/review/__init__.py
+++ b/test/integration/ggrc/review/__init__.py
@@ -9,7 +9,7 @@ def build_reviewer_acl(acr_id=None, user_id=None):
   """Build reviewer acl list from passed values of create new user"""
   if not acr_id:
     acr_id = all_models.AccessControlRole.query.filter_by(
-        name="Reviewer", object_type="Review"
+        name="Reviewers", object_type="Review"
     ).one().id
 
   if not user_id:

--- a/test/selenium/src/lib/constants/roles.py
+++ b/test/selenium/src/lib/constants/roles.py
@@ -156,7 +156,7 @@ class ACLRolesIDsMetaClass(type):
 
   @property
   def REVIEWERS(cls):
-    return cls.id_of_role(object_type="Review", name="Reviewer")
+    return cls.id_of_role(object_type="Review", name="Reviewers")
 
 
 class ACLRolesIDs(object):

--- a/test/selenium/src/lib/page/widget/page_mixins.py
+++ b/test/selenium/src/lib/page/widget/page_mixins.py
@@ -82,7 +82,7 @@ class WithObjectReview(base.WithBrowser):
   @property
   def reviewers(self):
     """Return page element with reviewers emails."""
-    return self._related_people_list("Reviewer", self._review_root)
+    return self._related_people_list("Reviewers", self._review_root)
 
   def open_submit_for_review_popup(self):
     """Open submit for control popup by clicking on corresponding button."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Reviewer' field is displayed on "Request Review" pop-up which should be re-named as 'Reviewers' in all places on UI for all objects that have review.

# Steps to test the changes

Go to My Work page
Click "Controls" tab.
Click on a control raw.
Click "Request Review" button.
- "Reviewer' field is displayed on "Request Review" pop-up.

# Solution description

Update the file "/vagrant/src/ggrc/migrations/versions/20190306113217_adf7bdb8996e_rename_reviewer_to_reviewers.py" with the below sql query:
Query : UPDATE access_control_roles SET name = 'REVIEWERS' WHERE parent_id is NULL and name = "REVIEWER";

Note: If the file is not editable change the permissions by logging out of the docker container.

Run the below command in order to execute the sql changes:
python src/ggrc/migrate.py revision -m "Rename reviewer to reviewers" 

Run the below query to verify that the changes were made successfully:
select * from access_control_roles where parent_id is NULL and name = "REVIEWERS";

Once the changes are verified, run the command:
 - db_reset

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
