### PR TITLE
GGRC-6497 Fixing propagation tree for Control Operators and Control Owners

### DIFF
--- a/src/ggrc/migrations/versions/20190311140106_0d7a3a0aa3da_update_propagation_tree_for_control_.py
+++ b/src/ggrc/migrations/versions/20190311140106_0d7a3a0aa3da_update_propagation_tree_for_control_.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fixing propagation tree for Control Operators and Control Owners
+
+Create Date: 2019-03-11 14:01:06.461613
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from ggrc.migrations.utils.acr_propagation import update_acr_propagation_tree
+
+# revision identifiers, used by Alembic.
+revision = '0d7a3a0aa3da'
+down_revision = 'e6f8ba2075a4'
+
+
+CONTROL_COMMENTS_PERMISSIONS = {
+    "Relationship R": {
+        "Review RU": {},
+        "Comment R": {},
+        "Document RU": {
+            "Relationship R": {
+                "Comment R": {},
+                "ExternalComment R": {},
+            }
+        },
+
+        "Proposal RU": {},
+        "ExternalComment R": {},
+    },
+}
+
+NEW_ROLES_PROPAGATION = {
+    "Control Operators": CONTROL_COMMENTS_PERMISSIONS,
+    "Control Owners": CONTROL_COMMENTS_PERMISSIONS,
+}
+
+CONTROL_PROPAGATION = {
+    "Control": NEW_ROLES_PROPAGATION
+}
+
+OLD_CONTROL_PROPAGATION = {
+    "Control": NEW_ROLES_PROPAGATION
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  update_acr_propagation_tree(OLD_CONTROL_PROPAGATION, CONTROL_PROPAGATION)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported.")


### PR DESCRIPTION
# Issue description

The propagation tree is not valid for Control Owners / Operators in Control

# Steps to test the changes

To test locally:
1. Make two files via utility print_tree --as_dict 
2. Compare result via 'deepdiff' library 

# Labels

*  migration
*  propagate_acl
*  reindex


# Solution description 

1.  Created new migration with update_acr_propagation_tree()method
2.  Applied new migration


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".