### PR TITLE
GGRC 6929 Allow GE to remove evidence on assessment if GE not in ACL.

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -558,6 +558,7 @@ class Resource(ModelView):
 
   @staticmethod
   def json_update(obj, src):
+    """Update object `obj` with data from JSON `src`."""
     ggrc.builder.json.update(obj, src)
 
   def patch(self):
@@ -1407,6 +1408,7 @@ class Resource(ModelView):
     return resource
 
   def object_for_json(self, obj, model_name=None, properties_to_include=None):
+    """Serialize obj in JSON format."""
     model_name = model_name or self.model._inflector.table_singular
     json_obj = ggrc.builder.json.publish(
         obj, properties_to_include or [], inclusion_filter)
@@ -1429,6 +1431,8 @@ class Resource(ModelView):
   def json_success_response(self, response_object, last_modified=None,
                             status=200, id=None, cache_op=None,
                             obj_etag=None):
+    """Prepare success JSON response and set required headers."""
+    # pylint: disable=redefined-builtin
     headers = [('Content-Type', 'application/json')]
     if last_modified:
       headers.append(('Last-Modified', self.http_timestamp(last_modified)))

--- a/src/ggrc_basic_permissions/roles/Editor.py
+++ b/src/ggrc_basic_permissions/roles/Editor.py
@@ -208,6 +208,7 @@ permissions = {
         "AssessmentTemplate",
         "Issue",
         "DataAsset",
+        "Evidence",
         "AccessGroup",
         "Directive",
         "Contract",

--- a/test/integration/ggrc/access_control/acl_propagation/test_asmt_roles.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_asmt_roles.py
@@ -255,7 +255,7 @@ class TestAsmtRolesPropagation(base.TestACLPropagation):
                   "create_and_map": True,
                   "read": True,
                   "update": True,
-                  "delete": False,
+                  "delete": True,
                   "read_comments": True,
                   "add_comment": True,
               },
@@ -297,6 +297,7 @@ class TestAsmtRolesPropagation(base.TestACLPropagation):
     return rbac_factory(self.people[role].id, acr, parent)
 
   @helpers.unwrap(PERMISSIONS, unwrap_keys=True)
+  # pylint: disable=too-many-arguments
   def test_access(self, role, model, acr_name, action_name, expected_result):
     """{0:<7}: On {1:<20} as {2:<9} test {3:<20} - Expected {4:<2} """
     self.runtest(role, model, action_name, expected_result, acr_name=acr_name)

--- a/test/integration/ggrc/access_control/acl_propagation/test_audit_captains.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_audit_captains.py
@@ -271,7 +271,7 @@ class TestAuditorsPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "read_comments": True,
               "add_comment": True
           },
@@ -279,7 +279,7 @@ class TestAuditorsPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "read_comments": True,
               "add_comment": True
           }
@@ -308,4 +308,5 @@ class TestAuditorsPropagation(base.TestACLPropagation):
 
   @helpers.unwrap(PERMISSIONS)
   def test_access(self, role, model, action_name, expected_result):
+    """Audit Captains {0:<7}: On {1:<20} test {2:<20} - Expected {3:<2} """
     self.runtest(role, model, action_name, expected_result)

--- a/test/integration/ggrc/access_control/acl_propagation/test_auditors.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_auditors.py
@@ -271,7 +271,7 @@ class TestAuditorsPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },

--- a/test/integration/ggrc/access_control/acl_propagation/test_program_editors.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_program_editors.py
@@ -328,7 +328,7 @@ class TestProgramEditorsPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },
@@ -336,7 +336,7 @@ class TestProgramEditorsPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },

--- a/test/integration/ggrc/access_control/acl_propagation/test_program_managers.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_program_managers.py
@@ -328,7 +328,7 @@ class TestProgramManagersPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },
@@ -336,7 +336,7 @@ class TestProgramManagersPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },

--- a/test/integration/ggrc/access_control/acl_propagation/test_program_readers.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_program_readers.py
@@ -326,7 +326,7 @@ class TestProgramReadersPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },
@@ -334,7 +334,7 @@ class TestProgramReadersPropagation(base.TestACLPropagation):
               "create_and_map": True,
               "read": True,
               "update": True,
-              "delete": False,
+              "delete": True,
               "add_comment": True,
               "read_comments": True
           },

--- a/test/integration/ggrc/models/test_assessment_file_url_and_status_put.py
+++ b/test/integration/ggrc/models/test_assessment_file_url_and_status_put.py
@@ -40,6 +40,26 @@ class TestAssessmentCompleteWithAction(ggrc.TestCase):
         attribute_value="value_2",
     )
 
+  @staticmethod
+  def _map(evid, asmt):
+    """Helper function to map two objects."""
+    with factories.single_commit():
+      factories.RelationshipFactory(
+          source=asmt,
+          destination=evid,
+      )
+
+  @staticmethod
+  def _create_person_with_sys_role(sys_role):
+    """Helper function to create person with specific system role."""
+    with factories.single_commit():
+      person = factories.PersonFactory()
+      system_role = all_models.Role.query.filter(
+          all_models.Role.name == sys_role,
+      ).one()
+      rbac_factories.UserRoleFactory(role=system_role, person=person)
+    return person
+
   @ddt.data(("In Review", "In Review"),
             ("Verified", "Completed"),
             ("Completed", "Completed"),
@@ -169,32 +189,43 @@ class TestAssessmentCompleteWithAction(ggrc.TestCase):
     relationship = all_models.Relationship.query.get(rel_id)
     self.assertIsNone(relationship)
 
-  @ddt.data("Creator", "Editor", "Reader")
+  @ddt.data("Editor")
   # pylint: disable=invalid-name
-  def test_remove_related_forbidden_for_system_roles(self, system_role):
-    """Test `system_role` without ACR isn't allowed to delete evidence."""
+  def test_remove_related_no_acr_allowed(self, system_role):
+    """Test delete evidence for `system_role` without ACR is allowed."""
     asmt_id = self.asmt.id
-    with factories.single_commit():
-      self._prepare_mandatory_evidence_cad()
-      factories.RelationshipFactory(
-          source=self.asmt,
-          destination=self.evidence,
-      )
-      person = factories.PersonFactory()
-      system_role = all_models.Role.query.filter(
-          all_models.Role.name == system_role,
-      ).one()
-      rbac_factories.UserRoleFactory(role=system_role, person=person)
-
     evid_id = self.evidence.id
+    self._map(self.evidence, self.asmt)
+    person = self._create_person_with_sys_role(system_role)
+
     self.api.set_user(person)
     response = self.api.put(all_models.Assessment.query.get(asmt_id), {
         "actions": {"remove_related": [{"id": evid_id,
                                         "type": "Evidence"}]},
     })
+
+    self.assert200(response)
+    evid_removed = all_models.Assessment.query.get(asmt_id).evidences == []
+    self.assertTrue(evid_removed)
+
+  @ddt.data("Creator", "Reader")
+  # pylint: disable=invalid-name
+  def test_remove_related_no_acr_forbidden(self, system_role):
+    """Test delete evidence for `system_role` without ACR is forbidden."""
+    asmt_id = self.asmt.id
+    evid_id = self.evidence.id
+    self._map(self.evidence, self.asmt)
+    person = self._create_person_with_sys_role(system_role)
+
+    self.api.set_user(person)
+    response = self.api.put(all_models.Assessment.query.get(asmt_id), {
+        "actions": {"remove_related": [{"id": evid_id,
+                                        "type": "Evidence"}]},
+    })
+
     self.assert403(response)
-    evidence = all_models.Evidence.query.get(evid_id)
-    self.assertIsNotNone(evidence)
+    evid_removed = all_models.Assessment.query.get(asmt_id).evidences == []
+    self.assertFalse(evid_removed)
 
   @ddt.data(
       *itertools.product(("Assignees", "Creators", "Verifiers"),
@@ -205,28 +236,19 @@ class TestAssessmentCompleteWithAction(ggrc.TestCase):
   def test_remove_evidence_allowed(self, role, system_role):
     """Test `system_role` with ACR `role` is allowed to delete evidence."""
     asmt_id = self.asmt.id
-    with factories.single_commit():
-      self._prepare_mandatory_evidence_cad()
-      rel = factories.RelationshipFactory(
-          source=self.asmt,
-          destination=self.evidence,
-      )
-      rel_id = rel.id
-      person = factories.PersonFactory()
-      creator_role = all_models.Role.query.filter(
-          all_models.Role.name == system_role
-      ).one()
-      rbac_factories.UserRoleFactory(role=creator_role, person=person)
-      factories.AccessControlPersonFactory(
-          ac_list=self.asmt.acr_name_acl_map[role],
-          person=person,
-      )
     evid_id = self.evidence.id
+    self._map(self.evidence, self.asmt)
+    person = self._create_person_with_sys_role(system_role)
+    factories.AccessControlPersonFactory(
+        ac_list=self.asmt.acr_name_acl_map[role],
+        person=person,
+    )
+
     self.api.set_user(person)
     response = self.api.put(all_models.Assessment.query.get(asmt_id), {
         "actions": {"remove_related": [{"id": evid_id,
                                         "type": "Evidence"}]},
     })
     self.assert200(response)
-    relationship = all_models.Relationship.query.get(rel_id)
-    self.assertIsNone(relationship)
+    evid_removed = all_models.Assessment.query.get(asmt_id).evidences == []
+    self.assertTrue(evid_removed)

--- a/test/integration/ggrc/services/test_query/test_basic.py
+++ b/test/integration/ggrc/services/test_query/test_basic.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-locals
 
 """Tests for /query api endpoint."""
 import random


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If Global Editor user is not present in audit/assessment ACL, he cannot remove evidence file/url for assessment, but he should be able to.

# Steps to test the changes

1. Log in as Global Editor;
2. Open any audit (Global Editor should not be present in ACL of that audit);
3. Open any assessment or create a new one (Global Editor should not be present in ACL of that assessment);
4. Add file/url evidence to assessment and try to delete file/url.

Expected Result: Global Editor should be able to remove file/url evidence from assessment.

# Solution description

Solution consists of adding Evidence in delete section of Global Editor permissions specified in `ggrc_basic_permissions.roles.Editor` module.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
