### PR TITLE
GGRC-6714 Remove confirmation popup for Assessments in 'Deprecate' state while inline edit

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/confirm-edit-action.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/confirm-edit-action.js
@@ -6,6 +6,9 @@
 import '../../inline/base-inline-control-title';
 import {confirm} from '../../../plugins/utils/modals';
 
+const EDITABLE_STATES = [
+  'In Progress', 'Not Started', 'Rework Needed', 'Deprecated'];
+
 export default can.Component.extend({
   tag: 'confirm-edit-action',
   leakScope: true,
@@ -24,8 +27,7 @@ export default can.Component.extend({
       }.bind(this));
     },
     isInEditableState: function () {
-      let editableStates = ['In Progress', 'Not Started', 'Rework Needed'];
-      return _.includes(editableStates, this.attr('instance.status'));
+      return _.includes(EDITABLE_STATES, this.attr('instance.status'));
     },
     showConfirm: function () {
       let self = this;

--- a/src/ggrc-client/js/components/assessment/tests/confirm-edit-action_spec.js
+++ b/src/ggrc-client/js/components/assessment/tests/confirm-edit-action_spec.js
@@ -40,13 +40,14 @@ describe('confirm-edit-action component', function () {
 
   describe('isInEditableState() method', function () {
     it('returns true if instance state is ' +
-    '"In Progress", "Not Started" or "Rework Needed"',
+    '"In Progress", "Not Started", "Rework Needed" or "Deprecated"',
     function functionName() {
-      ['In Progress', 'Not Started', 'Rework Needed'].forEach(function (state) {
-        viewModel.attr('instance.status', state);
+      ['In Progress', 'Not Started', 'Rework Needed', 'Deprecated'].forEach(
+        function (state) {
+          viewModel.attr('instance.status', state);
 
-        expect(viewModel.isInEditableState()).toBe(true);
-      });
+          expect(viewModel.isInEditableState()).toBe(true);
+        });
     });
 
     it('returns false if instance state is not "In Progress" or "Not Started"',


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Editing some properties for deprecated Assessment via inline edit functionality moves it to 'In Progress' state while the same actions performed in 'Edit' modal doesn't.

# Steps to test the changes
 - Open any Assessment
 - Move Assessment to 'Deprecated' state
 - Edit Assessment title via inline edit

Actual result: Confirm moving Assessment to 'In Progress' state popup appears
Expected result: No confirmation popup should appear, title is changed without affect on Deprecated status.

# Solution description

Add 'Deprecated' state to states list for which confirmation popup is not displayed while inline editing.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
