### PR TITLE
GGRC-6953 Remove validation is_external

### DIFF
--- a/test/integration/ggrc/models/test_relationship.py
+++ b/test/integration/ggrc/models/test_relationship.py
@@ -4,6 +4,7 @@
 """Module for integration tests for Relationship."""
 
 import json
+import unittest
 
 import ddt
 
@@ -188,6 +189,8 @@ class TestExternalRelationship(TestCase):
     self.assertIsNone(relationship.automapping_id)
     self.assertIsNone(relationship.context_id)
 
+  @unittest.skip("Need to update validation to allow update "
+                 "regular relationships but not to create")
   def test_create_ext_user_reg_relationship(self):
     """Validation external app user creates regular relationship."""
     self.api.set_user(self.person_ext)
@@ -231,7 +234,7 @@ class TestExternalRelationship(TestCase):
     self.assertIsNone(relationship.context_id)
 
   def test_update_ext_user_reg_relationship(self):
-    """Validation external app user updates regular relationship."""
+    """External app user can update regular relationship."""
     self.api.set_user(self.person_ext)
     with factories.single_commit():
       product = factories.ProductFactory()
@@ -243,10 +246,9 @@ class TestExternalRelationship(TestCase):
         self.REL_URL,
         data=self.build_relationship_json(product, system, True),
         headers=self.HEADERS)
-    self.assert400(response)
+    self.assert200(response)
     self.assertEqual(
-        response.json[0],
-        [400, "External application can create only external relationships."])
+        response.json[0][1]["relationship"]["is_external"], True)
 
   def test_delete_ext_user_ext_relationship(self):
     """Validation external app user deletes external relationship."""
@@ -263,7 +265,7 @@ class TestExternalRelationship(TestCase):
     self.assertIsNone(relationship)
 
   def test_delete_ext_user_reg_relationship(self):
-    """Validation external app user deletes regular relationship."""
+    """External app user can delete regular relationship."""
     self.api.set_user(self.person_ext)
     with factories.single_commit():
       product = factories.ProductFactory()
@@ -271,14 +273,7 @@ class TestExternalRelationship(TestCase):
 
     rel = self.create_relationship(product, system, False, self.person_ext)
     response = self.api.delete(rel)
-    self.assert400(response)
-    self.assertEqual(
-        response.json,
-        {
-            'message': 'External application can delete only external '
-                       'relationships.',
-            'code': 400
-        })
+    self.assert200(response)
 
   def test_update_reg_user_ext_relationship(self):
     """Validation regular app user updates external relationship."""


### PR DESCRIPTION
# Issue description

Before 2.0 external app can remove only self created relationships (marked by flag is_external=True)
In 2.0 some relationship creation/removing will be transferred to external app. Thats why we don't need this validation anymore.

Example:
Before 2.0 control was mapped to directive 
Control <-> Directive 
in 2.0 we transfer this mapping to external app.
After 2.0 user can remove this mapping in the external app
Sync service needs to remove this relationship in GGRC.
But this relationship with is_external=False. And validator don't allow to do that.


# Solution description
Remove validation from relationship model

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
