### PR TITLE
GGRC-4516 Global Creator Can See All Labels

### DIFF
--- a/src/ggrc_basic_permissions/roles/Creator.py
+++ b/src/ggrc_basic_permissions/roles/Creator.py
@@ -34,7 +34,7 @@ owner_read = owner_base + [
         "terms": {
             "property_name": "instance",
             "action": "read",
-        }
+        },
     },
     {
         "type": "CycleTaskEntry",
@@ -42,7 +42,7 @@ owner_read = owner_base + [
         "terms": {
             "property_name": "cycle_task_group_object_task",
             "action": "update",
-        }
+        },
     },
     "Role",
     "Comment",
@@ -50,6 +50,8 @@ owner_read = owner_base + [
     "Context",
     "Person",
     "PersonProfile",
+    "Label",
+    "ObjectLabel",
 ]
 
 owner_delete = owner_base + [
@@ -75,7 +77,7 @@ owner_delete = owner_base + [
         "terms": {
             "property_name": "instance",
             "action": "update",
-        }
+        },
     },
 ]
 
@@ -92,7 +94,7 @@ permissions = {
             "terms": {
                 "property_name": "program",
                 "action": "update",
-            }
+            },
         },
         {
             "type": "Snapshot",
@@ -100,7 +102,7 @@ permissions = {
             "terms": {
                 "property_name": "parent",
                 "action": "update",
-            }
+            },
         },
         "AssessmentTemplate",
         "BackgroundTask",
@@ -125,7 +127,7 @@ permissions = {
             "terms": {
                 "property_name": "cycle_task_group_object_task",
                 "action": "update",
-            }
+            },
         },
         {
             "type": "TaskGroupObject",
@@ -166,7 +168,7 @@ permissions = {
             "terms": {
                 "property_name": "instance",
                 "action": "read",
-            }
+            },
         },
         "Project",
         {

--- a/test/integration/ggrc/models/mixins/test_labeled.py
+++ b/test/integration/ggrc/models/mixins/test_labeled.py
@@ -13,6 +13,8 @@ from integration.ggrc import TestCase
 from integration.ggrc.models import factories
 from ggrc import db
 from ggrc.models import all_models
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
 
 
 @ddt.ddt
@@ -260,3 +262,39 @@ class TestLabeledMixin(WithQueryApi, TestCase):
     self.assertEqual(labels['count'], 10)
     response_ids = {label['id'] for label in labels['values']}
     self.assertSetEqual(response_ids, expected_ids)
+
+  def test_label_in_new_tab(self):
+    """Test labels created by global creator in new tab"""
+
+    with factories.single_commit():
+      role = "Creator"
+      role_name = "Creators"
+      person = factories.PersonFactory()
+      creator_role = all_models.Role.query.filter(
+          all_models.Role.name == role
+      ).one()
+      rbac_factories.UserRoleFactory(role=creator_role, person=person)
+    self.api.set_user(person)
+
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      factories.AccessControlPersonFactory(
+          ac_list=assessment.acr_name_acl_map[role_name],
+          person=person,
+      )
+
+    label_name = "Test Label"
+    response = self.api.put(assessment, {
+        'labels': [{
+            'name': label_name,
+            'id': None,
+            'type': 'Label'
+        }]
+    })
+    self.assert200(response)
+    response = self.api.get(assessment, assessment.id)
+    self.assert200(response)
+    labels = response.json['assessment']['labels']
+
+    self.assertEqual(len(labels), 1)
+    self.assertEqual(labels[0]['name'], label_name)

--- a/test/integration/ggrc/models/mixins/test_labeled.py
+++ b/test/integration/ggrc/models/mixins/test_labeled.py
@@ -6,13 +6,11 @@
 import collections
 import ddt
 
-from integration.ggrc import api_helper
-from integration.ggrc.query_helper import WithQueryApi
-
-from integration.ggrc import TestCase
-from integration.ggrc.models import factories
 from ggrc import db
 from ggrc.models import all_models
+from integration.ggrc import api_helper, TestCase
+from integration.ggrc.query_helper import WithQueryApi
+from integration.ggrc.models import factories
 from integration.ggrc_basic_permissions.models \
     import factories as rbac_factories
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

GlobalCreator could not see labels in new tab 

# Steps to test the changes

1. As Admin open audit Info page and assigned Global Creator as auditor
2. Log as Global Creator and open audit page
3. Create Assessment and add label to assessment (when you start typing to add label you can see all created labels that match your characters)
4. Open created Assessment in a new tab and look at the label

Expected Result: Global creator as auditor should see his labels on Assessment Info page

# Solution description

GlobalCreator has been granted to see all labels

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
