### PR TITLE
GGRC-5942/GGRC-5617/GGRC-6633 Do not allow to autogenerate Tickets at Ticket Tracker for Issues and Assessments in some statuses

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane-issue-tracker-fields.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane-issue-tracker-fields.js
@@ -11,6 +11,15 @@ export default can.Component.extend({
   view: can.stache(template),
   leakScope: true,
   viewModel: can.Map.extend({
+    define: {
+      isTicketIdMandatory: {
+        get() {
+          let instance = this.attr('instance');
+          return instance.class.unchangeableIssueTrackerIdStatuses
+            .includes(instance.attr('status'));
+        },
+      },
+    },
     instance: {},
   }),
 });

--- a/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
@@ -67,12 +67,22 @@
       onStateChangeDfd:from="onStateChangeDfd"
       isEditIconDenied:from="isEditDenied"
       value:from="instance.issue_tracker.issue_id"
+      mandatory:from="isTicketIdMandatory"
       instance:from="instance">
         <div>
-          <div class="ggrc-form__title">Ticket ID</div>
+          <div class="ggrc-form__title">
+            Ticket ID
+            {{#if isTicketIdMandatory}}
+              <i class="fa fa-asterisk"></i>
+            {{/if}}
+          </div>
           <div class="ggrc-form-item__small-text">
             <small>
-              <em>If you would like to keep the existing bug linked to this assessment do not edit this attribute. If you would like to link to a different ticket, either clear this attribute to generate new or provide an existing ticket number.</em>
+              {{#if isTicketIdMandatory}} 
+                <em>You are not allowed to generate new ticket for Issues at statuses &quot;In Review&quot;, &quot;Completed (no verification)&quot;, &quot;Completed and Verified&quot; and &quot;Deprecated&quot;, only manual linking is allowed to perform. If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number.</em>
+              {{else}}
+                <em>Please leave this empty for a new ticket to be generated and linked to this assessment. If you would like to link to an existing ticket please provide the ticket number.</em>
+              {{/if}}
             </small>
           </div>
         </div>

--- a/src/ggrc-client/js/components/assessment/info-pane/templates/ticket-id-checker.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/templates/ticket-id-checker.stache
@@ -20,10 +20,15 @@
     <div class="simple-modal__body">
         <div class="simple-modal__section simple-modal__sub-header-section">
             <p>
-                Provide the existing Ticket ID if don't want to create a new one.
+                Provide the existing Ticket ID{{^if mandatory}} if don't want to create a new one {{/if}}.
             </p>
         </div>
-        <div class="simple-modal__section {{^isValid}} field-failure {{/isValid}}">    
+        <div class="simple-modal__section {{^isValid}} field-failure {{/isValid}}">
+          {{#if mandatory}}
+            <p class="simple-modal__note">
+              You are not allowed to generate new ticket for Issues at statuses &quot;In Review&quot;, &quot;Completed (no verification)&quot;, &quot;Completed and Verified&quot; and &quot;Deprecated&quot;, only manual linking is allowed to perform.
+            </p>
+          {{/if}}
           <numberbox-component
             placeholder:from="'Enter Ticket ID'"
             value:bind="ticketId">
@@ -37,10 +42,12 @@
                     on:el:click="linkWithExistingTicket">
                 Link with existing Ticket
             </button>
-            <button type="button" class="btn btn-small btn-link simple-modal__toolbar-item"
-                    on:el:click="generateNewTicket">
-                Generate new Ticket
-            </button>
+            {{^if mandatory}}
+              <button type="button" class="btn btn-small btn-link simple-modal__toolbar-item"
+                      on:el:click="generateNewTicket">
+                  Generate new Ticket
+              </button>
+            {{/if}}
         </div>
     </div>
 </simple-modal>

--- a/src/ggrc-client/js/components/assessment/info-pane/ticket-id-checker.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/ticket-id-checker.js
@@ -10,6 +10,15 @@ export default can.Component.extend({
   view: can.stache(template),
   leakScope: true,
   viewModel: can.Map.extend({
+    define: {
+      mandatory: {
+        get() {
+          let instance = this.attr('instance');
+          return instance.constructor.unchangeableIssueTrackerIdStatuses
+            .includes(instance.attr('status'));
+        },
+      },
+    },
     instance: null,
     ticketId: null,
     isValid: true,

--- a/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
+++ b/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
@@ -15,15 +15,16 @@ export default can.Component.extend({
     instance: {},
     note: '',
     linkingNote: '',
+    mandatoryTicketIdNote: '',
     setIssueTitle: false,
     allowToChangeId: false,
     isTicketIdMandatory: false,
     setTicketIdMandatory() {
       let instance = this.attr('instance');
 
-      if (instance.class.model_singular === 'Issue') {
+      if (instance.class.unchangeableIssueTrackerIdStatuses) {
         this.attr('isTicketIdMandatory',
-          ['Fixed', 'Fixed and Verified', 'Deprecated']
+          instance.class.unchangeableIssueTrackerIdStatuses
             .includes(instance.attr('status')));
       }
     },

--- a/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
@@ -56,7 +56,11 @@
         </label>
         <div class="ggrc-form-item__multiple-row--double">
           <div class="ggrc-form-item__note">
-            {{{linkingNote}}}
+            {{^if isTicketIdMandatory}}
+              {{{linkingNote}}}
+            {{else}}
+              {{{mandatoryTicketIdNote}}}
+            {{/if}}
           </div>
         </div>
         <div class="ggrc-form-item__multiple-row {{^isValidAttr instance "issue_tracker.issue_id"}}field-failure{{/isValidAttr}}">

--- a/src/ggrc-client/js/models/business-models/assessment.js
+++ b/src/ggrc-client/js/models/business-models/assessment.js
@@ -45,6 +45,8 @@ export default Cacheable.extend({
   },
   statuses: ['Not Started', 'In Progress', 'In Review',
     'Verified', 'Completed', 'Deprecated', 'Rework Needed'],
+  unchangeableIssueTrackerIdStatuses: ['In Review', 'Verified', 'Completed',
+    'Deprecated'],
   tree_view_options: {
     add_item_view: 'assessments/tree_add_item',
     attr_list: [{
@@ -228,6 +230,9 @@ export default Cacheable.extend({
       validate: {
         validateAssessmentIssueTracker: true,
         validateIssueTrackerTitle: true,
+        validateIssueTrackerIssueId() {
+          return this.constructor.unchangeableIssueTrackerIdStatuses;
+        },
       },
     },
   },

--- a/src/ggrc-client/js/models/business-models/issue.js
+++ b/src/ggrc-client/js/models/business-models/issue.js
@@ -69,6 +69,8 @@ export default Cacheable.extend({
     status: 'Draft',
   },
   statuses: ['Draft', 'Deprecated', 'Active', 'Fixed', 'Fixed and Verified'],
+  unchangeableIssueTrackerIdStatuses:
+    ['Fixed', 'Fixed and Verified', 'Deprecated'],
   buildIssueTrackerConfig(instance) {
     return {
       hotlist_id: '1498476',
@@ -99,7 +101,9 @@ export default Cacheable.extend({
       validate: {
         validateIssueTracker: true,
         validateIssueTrackerTitle: true,
-        validateIssueTrackerIssueId: true,
+        validateIssueTrackerIssueId() {
+          return this.constructor.unchangeableIssueTrackerIdStatuses;
+        },
       },
     },
   },

--- a/src/ggrc-client/js/plugins/tests/validation-extensions/validate-issue-tracker-issue-id_spec.js
+++ b/src/ggrc-client/js/plugins/tests/validation-extensions/validate-issue-tracker-issue-id_spec.js
@@ -10,12 +10,16 @@ describe('validateIssueTrackerIssueId extension', () => {
   let TestModel;
 
   beforeAll(() => {
-    TestModel = CanModel.extend({}, {
+    TestModel = CanModel.extend({
+      unchangeableIssueTrackerIdStatuses: ['Fixed'],
+    }, {
       define: {
         issue_tracker: {
           value: {},
           validate: {
-            validateIssueTrackerIssueId: true,
+            validateIssueTrackerIssueId() {
+              return this.constructor.unchangeableIssueTrackerIdStatuses;
+            },
           },
         },
       },

--- a/src/ggrc-client/js/plugins/validation-extensions.js
+++ b/src/ggrc-client/js/plugins/validation-extensions.js
@@ -145,9 +145,8 @@ validatejs.validators.validateDefaultVerifiers = (value) => {
 };
 
 validatejs.validators.validateIssueTrackerIssueId = (value,
-  options, key, attributes) => {
-  if (!['Fixed', 'Fixed and Verified', 'Deprecated']
-    .includes(attributes.status)) {
+  statuses, key, attributes) => {
+  if (!statuses.includes(attributes.status)) {
     return;
   }
 

--- a/src/ggrc-client/js/templates/assessments/modal_content.stache
+++ b/src/ggrc-client/js/templates/assessments/modal_content.stache
@@ -231,6 +231,7 @@
                 instance:from="instance"
                 allowToChangeId:from="true"
                 linkingNote:from="'Please leave this empty for a new ticket to be generated and linked to this assessment. If you would like to link to an existing ticket please provide the ticket number.'"
+                mandatoryTicketIdNote:from="'You are not allowed to generate new ticket for Issues at statuses &quot;In Review&quot;, &quot;Completed (no verification)&quot;, &quot;Completed and Verified&quot; and &quot;Deprecated&quot;, only manual linking is allowed to perform. If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number.'"
                 setIssueTitle:from="setIssueTitle"
                 note:from="'Turns on Ticket Tracker integration.'">
               </modal-issue-tracker-fields>

--- a/src/ggrc-client/js/templates/issues/modal_content.stache
+++ b/src/ggrc-client/js/templates/issues/modal_content.stache
@@ -192,7 +192,8 @@
             <modal-issue-tracker-fields
               instance:from="instance"
               allowToChangeId:from="true"
-              linkingNote:from="'If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number. You are not allowed to generate new ticket for Issues at statuses &quot;Fixed&quot;, &quot;Fixed and Verified&quot; and &quot;Deprecated&quot;.'"
+              linkingNote:from="'Please leave this empty for a new ticket to be generated and linked to this issue. If you would like to link to an existing ticket please provide the ticket number.'"
+              mandatoryTicketIdNote:from="'You are not allowed to generate new ticket for Issues at statuses &quot;Fixed&quot;, &quot;Fixed and Verified&quot; and &quot;Deprecated&quot;, only manual linking is allowed to perform. If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number.'"
               setIssueTitle:from="setIssueTitle"
               note:from="'Turns on Ticket Tracker integration. Any subsequent updates to admins, primary contacts, secondary contacts and state fields should be made through tracking system and will be synced automatically to GGRC.'">
             </modal-issue-tracker-fields>

--- a/src/ggrc-client/styles/components/simple-modal/_simple-modal.scss
+++ b/src/ggrc-client/styles/components/simple-modal/_simple-modal.scss
@@ -145,6 +145,10 @@ simple-modal {
     color: $infoWidgetHeader;
   }
 
+  &__note {
+    font-size: 13px;
+  }
+
   &__footer {
     border-top: 1px solid $border-color;
     box-sizing: border-box;

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -70,11 +70,21 @@ WRONG_REQUIRED_VALUE = (u"Line {line}: Required field {column_name} contains"
                         u" invalid data '{value}'. The default value will be"
                         u" used.")
 
-WRONG_TICKET_STATUS = (u"Line {line}: You are not allowed to autogenerate "
-                       u"tickets at Ticket Tracker for Issues at statuses "
-                       u"'Fixed', 'Fixed and Verified' and 'Deprecated'. "
-                       u"Column '{column_name}' will be set to 'Off'. Please "
-                       u"use a manual linking option instead.")
+WRONG_ISSUE_TICKET_STATUS = (u"Line {line}: You are not allowed to "
+                             u"autogenerate tickets at Ticket Tracker for "
+                             u"Issues at statuses 'Fixed', 'Fixed and "
+                             u"Verified' and 'Deprecated'. Column "
+                             u"'{column_name}' will be set to 'Off'. Please "
+                             u"use a manual linking option instead.")
+
+WRONG_ASSESSMENT_TICKET_STATUS = (u"Line {line}: You are not allowed to "
+                                  u"autogenerate tickets at Ticket Tracker "
+                                  u"for Assessments at statuses 'In Review', "
+                                  u"'Completed (no verification)', 'Completed "
+                                  u"and Verified' and 'Deprecated' statuses. "
+                                  u"Column '{column_name}' will be ignored. "
+                                  u"Please use a manual linking option "
+                                  u"instead.")
 
 MISSING_VALUE_WARNING = (u"Line {line}: Field '{column_name}' is required. "
                          u"The default value '{default_value}' will be used.")


### PR DESCRIPTION

# Issue description

User can trigger new ticket autogeneration for assessments and issues in completed statuses. There is a restriction on Ticket Tracker API side, it allows to create tickets only in 'New' or 'Assigned' statuses. It means that, if Assessment is in 'Completed and Verified' status, the ticket linked to such assessment will have 'Assigned' status, until cron job will change it to Fixed (Verified). This can cause confusions for users, who already completed an assessment and then receive a notification from Ticket Tracker system, that it is required to complete the same assessment.

**SOLUTION:**

Do not allow to autogenerate tickets for assessments that are in 'In Review', 'Completed (no verification)', 'Completed and Verified' and 'Deprecated' statuses.

**ACCEPTANCE CRITERIA:**
**Via UI:** 

For assessments at statuses 'In Review', 'Completed (no verification)', 'Completed and Verified' and 'Deprecated':
1. Change help text near TICKET ID field to:
You are not allowed to generate new ticket for Assessments at statuses "In Review", "Completed (no verification)", "Completed and Verified" and "Deprecated", only manual linking is allowed to perform. If you would like to keep the existing ticket linked to this assessment do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number.
2. Ticket ID field should become mandatory and can not be empty
3. If user clicks 'Save and Close' he should see an error near Ticket ID field (can not be blank) and no tickets autogeneration should happen
4. For assessments at other statuses use usual UI and autogeneration logic. 
5. Update `Ticket ID` modal for Ticket Tracker inline editing.

**Via import:** 

1. If user decided to import Assessments at statuses 'In Review', 'Completed (no verification)', 'Completed and Verified' and 'Deprecated'
- On Import page show Warning:
Line <X>: You are not allowed to autogenerate tickets at Ticket Tracker for Assessments at statuses 'In Review', 'Completed (no verification)', 'Completed and Verified' and 'Deprecated' statuses.  Column '<Y>' will be ignored. Please use a manual linking option instead.
where X - Number of the row at import file where the assessment at this statuses appear
Y - Number of the column "Ticket Tracker Switch" at import file 
-  User can click 'Proceed in spite of warnings' , the cell value should be ignored, no tickets autogeneration should happen for this assessment.

# Steps to test the changes

1. Try to import new assessment without status column (Default 'Draft' value should be applied) and Ticket Tracker integration turned ON. Check if ticket was generated and no warnings were occurred.
2. Try to import new assessment with status column in the In Review state and Ticket Tracker integration turned ON. Check if there were appropriate warning and ticket wasn't generated and integration was turned OFF. 
3. Create assessment via UI with integration turned OFF in 'Draft' or 'Active' status. Turn Ticket Tracker integration ON via import for this Issue. Check if ticket were generated and no warnings occurred.
4. Create issue via UI with integration turned OFF in  'In Review', 'Completed (no verification)', 'Completed and Verified' status. Turn Ticket Tracker integration ON via import for this assessment.  Check if there were appropriate warning and ticket wasn't generated and integration was turned OFF. 

# Solution description

FE: In scope of #8909 PR were lost changes for Issue. So these changes are added to this PR.
Add validation rule for ticket Id field for Assessment object.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
