### PR TITLE
QUICK-FIX Remove person GCADs from selenium tests.

### DIFF
--- a/test/selenium/conftest.py
+++ b/test/selenium/conftest.py
@@ -708,7 +708,7 @@ def gcads_for_asmt():
   """Creates GCADs of all types for Assessment."""
   return [rest_facade.create_gcad(definition_type="assessment",
                                   attribute_type=ca_type)
-          for ca_type in element.AdminWidgetCustomAttributes.ALL_CA_TYPES]
+          for ca_type in element.AdminWidgetCustomAttributes.ALL_GCA_TYPES]
 
 
 @pytest.fixture()

--- a/test/selenium/src/lib/constants/element.py
+++ b/test/selenium/src/lib/constants/element.py
@@ -125,6 +125,7 @@ class AdminWidgetCustomAttributes(object):
   DROPDOWN = "Dropdown"
   PERSON = "Map:Person"
   ALL_CA_TYPES = (TEXT, RICH_TEXT, DATE, CHECKBOX, DROPDOWN, PERSON)
+  ALL_GCA_TYPES = (TEXT, RICH_TEXT, DATE, CHECKBOX, DROPDOWN)
 
 
 class Base(object):

--- a/test/selenium/src/lib/service/rest_facade.py
+++ b/test/selenium/src/lib/service/rest_facade.py
@@ -99,7 +99,7 @@ def create_gcad_for_control():
   from lib.constants import element
   return [create_gcad(definition_type="control",
                       attribute_type=ca_type)
-          for ca_type in element.AdminWidgetCustomAttributes.ALL_CA_TYPES]
+          for ca_type in element.AdminWidgetCustomAttributes.ALL_GCA_TYPES]
 
 
 def create_issue(obj=None):

--- a/test/selenium/src/tests/test_admin_dashboard_page.py
+++ b/test/selenium/src/tests/test_admin_dashboard_page.py
@@ -80,7 +80,7 @@ class TestAdminDashboardPage(base.Test):
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize(
       "ca_type",
-      AdminWidgetCustomAttributes.ALL_CA_TYPES
+      AdminWidgetCustomAttributes.ALL_GCA_TYPES
   )
   def test_add_global_ca(self, admin_dashboard, ca_type):
     """Create different types of Custom Attribute on Admin Dashboard."""


### PR DESCRIPTION
# Issue description
As we delete `Map: Person` global custom attribute in scope of https://github.com/google/ggrc-core/pull/9075 we should fix our selenium tests factories. They shouldn't produce people GCA neither for assessments nor for controls. 

# Steps to test the changes
Check if selenium tests are OK now. 
These changes were run successfully with merged @zidarsk8 changes. (You can look through build №9833)
# Solution description
I've added separate GCA list constant to keep object types for GCA. (please take a look at this because I don't know exact flow for such situations in selenium code.)

Also I've fixed fixtures for GCA and GCA related test parametrization that uses constant for LCA. 

## Notes
- I can't put these changes to @zidarsk8 branch cause it contradicts our flow as I review changes.
- I'm not sure but can it happen that my changes affect Workflow functionality? I've seen next randomly failed tests: (`TestWorkflowSetupTab::()::test_create_task_group_task`, `TestActiveCyclesTab::()::test_add_cycle_task_assignee[Reader]`, `TestWorkflowSetupTab::()::test_add_obj_to_task_group` (this one is TOP-1 randomly failed test.)) Also one time `TestProposals::()::test_check_proposals_applying[risk_creator]::setup` failed.