### PR TITLE
QUICK-FIX remove '*' symbol from generated ACR name for selenium tests.

### DIFF
--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -72,7 +72,8 @@ class EntitiesFactory(object):
         is_allow_none=False, **attrs)
 
   @classmethod
-  def generate_string(cls, first_part,
+  def generate_string(cls,
+                      first_part,
                       allowed_chars=StringMethods.ALLOWED_CHARS):
     """Generate random string in unicode format according to object type.
     Symbols allowed in random part may be specified by

--- a/test/selenium/src/lib/service/rest_service.py
+++ b/test/selenium/src/lib/service/rest_service.py
@@ -15,7 +15,7 @@ from lib.entities.entities_factory import (
     AccessControlRolesFactory)
 from lib.entities.entity import Representation
 from lib.service.rest import client, query
-from lib.utils import help_utils, test_utils
+from lib.utils import help_utils, test_utils, string_utils
 
 
 class BaseRestService(object):
@@ -273,7 +273,11 @@ class AccessControlRolesService(BaseRestService):
   def create_acl_role(self, **attrs):
     """Create ACL role."""
     acl_factory = AccessControlRolesFactory()
-    acr_name = acl_factory.generate_string(attrs["object_type"])
+    allowed_name_chars = string_utils.Symbols(additional_exclude='*')
+    acr_name = acl_factory.generate_string(
+        attrs["object_type"],
+        allowed_chars=allowed_name_chars.standard_chars
+    )
     return self.create_obj(
         acl_factory.create(name=acr_name, **attrs).__dict__)
 

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -24,11 +24,24 @@ class Symbols(object):
   BACKSLASH = "\\"
   PIPE = "|"
 
-  def __init__(self):
+  def __init__(self, additional_exclude=''):
+    """Create symbols sets.
+
+    Provide next symbol sets:
+      exclude_char: Chars that shouldn't participate in string generation. We
+        should exclude some symbols i.e. to prevent raising coding/encoding
+        issues.
+      special_chars: set of allowable special symbols.
+      standard_chars = set of allowable symbols.
+    Args:
+      additional_exclude: symbols that should be additionally excluded from
+        generation.
+    """
     # need exclude to prevent raising coding (encoding) issues
     self.exclude_chars = self.BLANK.join(
         (self.COMMA, self.LESS, self.MORE, self.DOUBLE_QUOTES,
          self.SINGLE_QUOTE, self.BACK_QUOTE, self.BACKSLASH, self.PIPE))
+    self.exclude_chars += additional_exclude
     self.special_chars = self.BLANK.join(
         symbol for symbol in string.punctuation.encode("string-escape")
         if symbol not in self.exclude_chars)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

'*' symbol is forbidden for ACR name cause we use it for our roles propagation. 
Some tests are fails and rerun because of this symbol in role name. It causes additional time for selenium tests.
i.e. TestEventLogTabDestructive::()::test_chronological_sequence_1st_page::setup:

> E         ContentDecodingError: Server request body:
E         [{"access_control_role": {"name": "Objective_99688ef8-55d6_j5;Vt-g\*eoO\*i", "modal_title": "Add Custom Role to type Control", "read": true, "object_type": "Objective", "update": true, "context": {"id": null}, "delete": true}}]
E         Server response text:
E         code: 400, message: Attribute name contains unsupported symbol '*'

# Steps to test the changes

- Сheck if selenium tests are ok.
- Check if there are reruns because of this errors.

# Solution description

I've changed allowed symbols arg for generate_string method called from ACR factory.
Also I've added additional functionality to exclude specified symbols to our Symbols class.
