### PR TITLE
GGRC-5635 GGRC-7024 No validation during creating GCA with title "map:person" or "*"

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -133,6 +133,7 @@ class AccessControlRole(attributevalidator.AttributeValidator,
 
     return value
 
+
 def invalidate_acr_caches(mapper, content, target):
   # pylint: disable=unused-argument
   """Clear `global_role_names` if ACR created or update or deleted."""

--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -94,7 +94,7 @@ class AccessControlRole(attributevalidator.AttributeValidator,
     Custom Role names need to follow 3 uniqueness rules:
       1) Names must not match any attribute name on any existing object.
       2) Object level CAD names must not match any global CAD name.
-      3) Names should not contains "*" symbol
+      3) Names should not contains special values (.validate_name_correct)
 
     This validator should check for name collisions for 1st and 2nd rule.
 
@@ -111,7 +111,7 @@ class AccessControlRole(attributevalidator.AttributeValidator,
     value = value.strip()
 
     if key == "name":
-      self._validate_name_correct(value)
+      validators.validate_name_correctness(value)
 
     if key == "name" and self.object_type:
       name = value
@@ -132,13 +132,6 @@ class AccessControlRole(attributevalidator.AttributeValidator,
                        .format(name))
 
     return value
-
-  @staticmethod
-  def _validate_name_correct(name):
-    """Validate name does not contain "*" symbol"""
-    if "*" in name:
-      raise ValueError(u"Attribute name contains unsupported symbol '*'")
-
 
 def invalidate_acr_caches(mapper, content, target):
   # pylint: disable=unused-argument

--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -127,7 +127,7 @@ class AccessControlRole(attributevalidator.AttributeValidator,
                        u"already exists for this object type"
                        .format(name))
 
-    if key == "name" and "*" in name:
+    if "*" in name:
       raise ValueError(u"Attribute name contains unsupported symbol '*'")
 
     return value

--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -109,6 +109,10 @@ class AccessControlRole(attributevalidator.AttributeValidator,
       value if the name passes all uniqueness checks.
     """
     value = value.strip()
+
+    if key == "name":
+      self._validate_name_correct(value)
+
     if key == "name" and self.object_type:
       name = value
       object_type = self.object_type
@@ -127,10 +131,13 @@ class AccessControlRole(attributevalidator.AttributeValidator,
                        u"already exists for this object type"
                        .format(name))
 
+    return value
+
+  @staticmethod
+  def _validate_name_correct(name):
+    """Validate name does not contain "*" symbol"""
     if "*" in name:
       raise ValueError(u"Attribute name contains unsupported symbol '*'")
-
-    return value
 
 
 def invalidate_acr_caches(mapper, content, target):

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -277,7 +277,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     """Validate CAD title/name uniqueness.
 
     Note: title field is used for storing CAD names.
-    CAD names need to follow 6 uniqueness rules:
+    CAD names need to follow 7 uniqueness rules:
       1) Names must not match any attribute name on any existing object.
       2) Object level CAD names must not match any global CAD name.
       3) Object level CAD names can clash, but not for the same Object
@@ -286,6 +286,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
       4) Names must not match any existing custom attribute role name
       5) Names should not contains "*" symbol
       6) Names should be stripped
+      7) Names should not start with 'map:' or 'unmap:'
 
     Third rule is handled by the database with unique key uq_custom_attribute
     (`definition_type`,`definition_id`,`title`).
@@ -333,6 +334,11 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
 
     if key == "title" and "*" in name:
       raise ValueError(u"Attribute title contains unsupported symbol '*'")
+
+    if key == "title" and (name.startswith("map:") or
+                           name.startswith("unmap:")):
+      raise ValueError(u"Custom attribute title should not starts with 'map:' "
+                       u"or 'unmap:'")
 
     return value
 

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -306,6 +306,9 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
 
     value = value if value is None else re.sub(r"\s+", " ", value).strip()
 
+    if key == "title":
+      self._validate_title_correct(value)
+
     if key == "title" and self.definition_type:
       orig_name = value
       definition_type = self.definition_type
@@ -332,14 +335,21 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     if definition_type == "assessment":
       self.validate_assessment_title(name)
 
-    if "*" in name:
+    return value
+
+  @staticmethod
+  def _validate_title_correct(title):
+    """Validate title is correct
+
+    1) Title does not contain "*" symbol
+    2) Title does not start with "map:" or "unmap:"
+    """
+    if "*" in title:
       raise ValueError(u"Attribute title contains unsupported symbol '*'")
 
-    if name.startswith("map:") or name.startswith("unmap:"):
+    if title.startswith("map:") or title.startswith("unmap:"):
       raise ValueError(u"Custom attribute title should not starts "
                        u"with 'map:' or 'unmap:'")
-
-    return value
 
   def log_json(self):
     """Add extra fields to be logged in CADs."""

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -332,13 +332,12 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     if definition_type == "assessment":
       self.validate_assessment_title(name)
 
-    if key == "title" and "*" in name:
+    if "*" in name:
       raise ValueError(u"Attribute title contains unsupported symbol '*'")
 
-    if key == "title" and (name.startswith("map:") or
-                           name.startswith("unmap:")):
-      raise ValueError(u"Custom attribute title should not starts with 'map:' "
-                       u"or 'unmap:'")
+    if name.startswith("map:") or name.startswith("unmap:"):
+      raise ValueError(u"Custom attribute title should not starts "
+                       u"with 'map:' or 'unmap:'")
 
     return value
 

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -277,16 +277,15 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     """Validate CAD title/name uniqueness.
 
     Note: title field is used for storing CAD names.
-    CAD names need to follow 7 uniqueness rules:
+    CAD names need to follow 6 uniqueness rules:
       1) Names must not match any attribute name on any existing object.
       2) Object level CAD names must not match any global CAD name.
       3) Object level CAD names can clash, but not for the same Object
          instance. This means we can have two CAD with a name "my cad", with
          different attributable_id fields.
       4) Names must not match any existing custom attribute role name
-      5) Names should not contains "*" symbol
+      5) Names should not contains special values (.validate_name_correct)
       6) Names should be stripped
-      7) Names should not start with 'map:' or 'unmap:'
 
     Third rule is handled by the database with unique key uq_custom_attribute
     (`definition_type`,`definition_id`,`title`).
@@ -307,7 +306,7 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
     value = value if value is None else re.sub(r"\s+", " ", value).strip()
 
     if key == "title":
-      self._validate_title_correct(value)
+      validators.validate_name_correctness(value)
 
     if key == "title" and self.definition_type:
       orig_name = value
@@ -336,20 +335,6 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
       self.validate_assessment_title(name)
 
     return value
-
-  @staticmethod
-  def _validate_title_correct(title):
-    """Validate title is correct
-
-    1) Title does not contain "*" symbol
-    2) Title does not start with "map:" or "unmap:"
-    """
-    if "*" in title:
-      raise ValueError(u"Attribute title contains unsupported symbol '*'")
-
-    if title.startswith("map:") or title.startswith("unmap:"):
-      raise ValueError(u"Custom attribute title should not starts "
-                       u"with 'map:' or 'unmap:'")
 
   def log_json(self):
     """Add extra fields to be logged in CADs."""

--- a/src/ggrc/utils/validators.py
+++ b/src/ggrc/utils/validators.py
@@ -67,3 +67,25 @@ def validate_definition_type_ggrcq(mapper, content, target):
 
   if should_prevent:
     raise exceptions.MethodNotAllowed()
+
+
+def validate_name_correctness(name):
+  """Validate name does not contains invalid values"""
+  name_to_validate = name.strip().lower()
+
+  names_includes = ["*"]
+  for invalid in names_includes:
+    if invalid in name_to_validate:
+      raise ValueError(u"Name contains unsupported symbol '{}'"
+                       .format(invalid))
+
+  names_starts_with = ["map:", "unmap:"]
+  for invalid in names_starts_with:
+    if name_to_validate.startswith(invalid):
+      raise ValueError(u"Name should not starts with '{}'".format(invalid))
+
+  invalid_names = ["delete"]
+  for invalid in invalid_names:
+    if name_to_validate == invalid:
+      raise ValueError(u"'{}' is reserved word and should not be used as "
+                       u"an name".format(invalid))

--- a/test/selenium/src/lib/entities/entities_factory.py
+++ b/test/selenium/src/lib/entities/entities_factory.py
@@ -339,11 +339,15 @@ class CustomAttributeDefinitionsFactory(EntitiesFactory):
 
   def generate_ca_title(self, first_part):
     """Generate title of custom attribute
-    (same as usual title but without a star as it's disallowed, see GGRC-4954)
+    (same as usual title but
+    - without a star as it's disallowed, see GGRC-4954, GGRC-7024
+    - replacing : with _ in the first part as map:, unmap:, delete are
+    disallowed, see GGRC-5635)
     """
     chars = StringMethods.ALLOWED_CHARS.replace(string_utils.Symbols.STAR,
                                                 string_utils.Symbols.BLANK)
-    return self.generate_string(first_part, allowed_chars=chars)
+    return self.generate_string(
+        first_part.replace(':', '_'), allowed_chars=chars)
 
 
 class ProgramsFactory(EntitiesFactory):

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -47,8 +47,7 @@ class TestAccessControlRoles(unittest.TestCase):
     """Test if raises if name contains * symbol"""
 
     with self.assertRaises(ValueError):
-      name, object_type = "With asterisk *", "Control"
-      self.acr.object_type = object_type
+      name = "With asterisk *"
       self.acr.validates_name("name", name)
 
   def test_if_invalid_ca_check(self):

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -5,8 +5,8 @@
 """Test Access Control Role validation"""
 
 import unittest
-import ddt
 from collections import namedtuple
+import ddt
 from mock import MagicMock
 
 import ggrc.app  # noqa pylint: disable=unused-import
@@ -45,17 +45,14 @@ class TestAccessControlRoles(unittest.TestCase):
       self.acr.name = name
       self.acr.object_type = object_type
 
-  @ddt.data(
-    "title with asterisk*",
-    "map:person",
-    "unmap:person",
-    "delete",
-    "  map:    Market",
-    "mAP:    CONTROL",
-    "UNMAP:  NOTHING",
-    "delete",
-    "DeLeTe",
-  )
+  @ddt.data("role title with asterisk*",
+            "map:object",
+            "unmap:object",
+            "delete",
+            "  map:  Market  ",
+            "UNmAP:  CONTROL ",
+            "DeLeTe",
+            )
   def test_name_with_asterisk_throws(self, name):
     """Test if raises if name contains * symbol"""
     with self.assertRaises(ValueError):

--- a/test/unit/ggrc/models/test_access_control_roles.py
+++ b/test/unit/ggrc/models/test_access_control_roles.py
@@ -5,6 +5,7 @@
 """Test Access Control Role validation"""
 
 import unittest
+import ddt
 from collections import namedtuple
 from mock import MagicMock
 
@@ -13,6 +14,7 @@ from ggrc.models import all_models
 from ggrc.models.hooks.access_control_role import handle_role_acls
 
 
+@ddt.ddt
 class TestAccessControlRoles(unittest.TestCase):
   """Test Access Control Role validation"""
 
@@ -43,11 +45,20 @@ class TestAccessControlRoles(unittest.TestCase):
       self.acr.name = name
       self.acr.object_type = object_type
 
-  def test_name_with_asterisk_throws(self):
+  @ddt.data(
+    "title with asterisk*",
+    "map:person",
+    "unmap:person",
+    "delete",
+    "  map:    Market",
+    "mAP:    CONTROL",
+    "UNMAP:  NOTHING",
+    "delete",
+    "DeLeTe",
+  )
+  def test_name_with_asterisk_throws(self, name):
     """Test if raises if name contains * symbol"""
-
     with self.assertRaises(ValueError):
-      name = "With asterisk *"
       self.acr.validates_name("name", name)
 
   def test_if_invalid_ca_check(self):

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -10,6 +10,7 @@ from mock import MagicMock
 from ggrc.models import all_models
 from ggrc.access_control import role as acr
 
+
 @ddt.ddt
 class TestCustomAttributeDefinition(unittest.TestCase):
   """Test Custom Attribute Definition validation"""
@@ -21,17 +22,16 @@ class TestCustomAttributeDefinition(unittest.TestCase):
     self.cad._get_global_cad_names = MagicMock(return_value={'reg url': 1})
     acr.get_custom_roles_for = MagicMock(return_value=dict())
 
-  @ddt.data(
-    "title with asterisk*",
-    "map:person",
-    "unmap:person",
-    "delete",
-    "  map:    Market",
-    "mAP:    CONTROL",
-    "UNMAP:  NOTHING",
-    "delete",
-    "DeLeTe",
-  )
+  @ddt.data("title with asterisk*",
+            "map:person",
+            "unmap:person",
+            "delete",
+            "  map:    Market",
+            "mAP:    CONTROL",
+            "UNMAP:  NOTHING",
+            "delete",
+            "DeLeTe",
+            )
   def test_title_with_asterisk_throws(self, title):
     """Test if raises if title invalid"""
     with self.assertRaises(ValueError):

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -4,12 +4,13 @@
 """Test Custom Attribute Definition validation"""
 
 import unittest
+import ddt
 from mock import MagicMock
 
 from ggrc.models import all_models
 from ggrc.access_control import role as acr
 
-
+@ddt.ddt
 class TestCustomAttributeDefinition(unittest.TestCase):
   """Test Custom Attribute Definition validation"""
 
@@ -20,20 +21,18 @@ class TestCustomAttributeDefinition(unittest.TestCase):
     self.cad._get_global_cad_names = MagicMock(return_value={'reg url': 1})
     acr.get_custom_roles_for = MagicMock(return_value=dict())
 
-  def test_title_with_asterisk_throws(self):
-    """Test if raises if title contains * symbol"""
+  @ddt.data(
+    "title with asterisk*",
+    "map:person",
+    "unmap:person",
+    "delete",
+    "  map:    Market",
+    "mAP:    CONTROL",
+    "UNMAP:  NOTHING",
+    "delete",
+    "DeLeTe",
+  )
+  def test_title_with_asterisk_throws(self, title):
+    """Test if raises if title invalid"""
     with self.assertRaises(ValueError):
-      title = "Title with asterisk *"
-      self.cad.validate_title("title", title)
-
-  def test_map_in_title_throws(self):
-    """Test if raises if title starts with 'map:'"""
-    with self.assertRaises(ValueError):
-      title = "map:person"
-      self.cad.validate_title("title", title)
-
-  def test_unmap_in_title_throws(self):
-    """Test if raises if title starts with 'unmap:'"""
-    with self.assertRaises(ValueError):
-      title = "unmap:assessment"
       self.cad.validate_title("title", title)

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -29,7 +29,6 @@ class TestCustomAttributeDefinition(unittest.TestCase):
             "  map:    Market",
             "mAP:    CONTROL",
             "UNMAP:  NOTHING",
-            "delete",
             "DeLeTe",
             )
   def test_title_with_asterisk_throws(self, title):

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -24,19 +24,16 @@ class TestCustomAttributeDefinition(unittest.TestCase):
     """Test if raises if title contains * symbol"""
     with self.assertRaises(ValueError):
       title = "Title with asterisk *"
-      self.cad.definition_type = "assessment_template"
       self.cad.validate_title("title", title)
 
   def test_map_in_title_throws(self):
     """Test if raises if title starts with 'map:'"""
     with self.assertRaises(ValueError):
       title = "map:person"
-      self.cad.definition_type = "assessment_template"
       self.cad.validate_title("title", title)
 
   def test_unmap_in_title_throws(self):
     """Test if raises if title starts with 'unmap:'"""
     with self.assertRaises(ValueError):
       title = "unmap:assessment"
-      self.cad.definition_type = "assessment_template"
       self.cad.validate_title("title", title)

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -26,3 +26,17 @@ class TestCustomAttributeDefinition(unittest.TestCase):
       title = "Title with asterisk *"
       self.cad.definition_type = "assessment_template"
       self.cad.validate_title("title", title)
+
+  def test_map_in_title_throws(self):
+    """Test if raises if title starts with 'map:'"""
+    with self.assertRaises(ValueError):
+      title = "map:person"
+      self.cad.definition_type = "assessment_template"
+      self.cad.validate_title("title", title)
+
+  def test_unmap_in_title_throws(self):
+    """Test if raises if title starts with 'unmap:'"""
+    with self.assertRaises(ValueError):
+      title = "unmap:assessment"
+      self.cad.definition_type = "assessment_template"
+      self.cad.validate_title("title", title)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

It is possible to create GCA with title like "map:person". Then when we will try to import such GCA object will not be cteated

# Steps to test the changes

Steps to reproduce:
1. Log in to GGRC as admin user
2. Open Admin page > Custom attributes tab
3. Select an object, e.g. Technology Environment
4. Create GCA with title "map:person"
Actual Result: There is no validation during creating GCA with title "map:person" (as an example)
Expected Result: The system should validate title of gca while creating it.

# Solution description

Add title validation for GCA. We should not allow users create GCA with title starts with "map:" or "unmap:".

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
