### PR TITLE
GGRC-6837 Manual linking with issue doesn't work with users at ticket tracker CC list that do not exist at the system

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/issue_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_integration.py
@@ -8,12 +8,15 @@
 
 import logging
 
+from werkzeug import exceptions as wzg_exceptions
+
 from ggrc import db
 from ggrc.integrations import issues
 from ggrc.integrations import integrations_errors
 from ggrc.models import all_models
 from ggrc.models.hooks.issue_tracker import issue_tracker_params_builder
 from ggrc.models.hooks.issue_tracker import integration_utils
+from ggrc.utils import user_generator
 from ggrc.utils.custom_dict import MissingKeyDict
 from ggrc.integrations.synchronization_jobs.issue_sync_job import \
     ISSUE_STATUS_MAPPING
@@ -52,7 +55,9 @@ def _is_already_linked(ticket_id):
 
 def create_missed_issue_acl(email, role_name, obj):
   """Create missed acl for emails from IssueTracker"""
-  person = all_models.Person.query.filter_by(email=email).first()
+  person = user_generator.find_user(email)
+  if not person:
+    raise wzg_exceptions.Forbidden()
   obj.add_person_with_role_name(person, role_name)
 
 

--- a/src/ggrc/models/hooks/issue_tracker/issue_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/issue_integration.py
@@ -8,8 +8,6 @@
 
 import logging
 
-from werkzeug import exceptions as wzg_exceptions
-
 from ggrc import db
 from ggrc.integrations import issues
 from ggrc.integrations import integrations_errors
@@ -57,7 +55,7 @@ def create_missed_issue_acl(email, role_name, obj):
   """Create missed acl for emails from IssueTracker"""
   person = user_generator.find_user(email)
   if not person:
-    raise wzg_exceptions.Forbidden()
+    return
   obj.add_person_with_role_name(person, role_name)
 
 

--- a/test/integration/ggrc/integrations/test_issue_integration.py
+++ b/test/integration/ggrc/integrations/test_issue_integration.py
@@ -567,6 +567,18 @@ class TestIssueIntegration(ggrc.TestCase):
     ]
     self.assertIn(person.email, role_emails)
 
+  @ddt.data("Primary Contacts", "Admin", "Secondary Contacts")
+  @mock.patch('ggrc.utils.user_generator.find_user', return_value=None)
+  def test_invalid_person_was_skipped(self, role, find_mock):
+    """Invalid users should be skipped"""
+    test_email = "newemail@example.com"
+    issue = factories.IssueFactory()
+    issue_integration.create_missed_issue_acl(test_email, role, issue)
+    db.session.commit()
+    people = all_models.Person.query.filter_by(email=test_email).all()
+    self.assertFalse(people)
+    find_mock.assert_called_once()
+
 
 @ddt.ddt
 class TestDisabledIssueIntegration(ggrc.TestCase):

--- a/test/integration/ggrc/integrations/test_issue_integration.py
+++ b/test/integration/ggrc/integrations/test_issue_integration.py
@@ -553,6 +553,20 @@ class TestIssueIntegration(ggrc.TestCase):
     # Check that issue in Issue Tracker hasn't been updated.
     update_issue_mock.assert_not_called()
 
+  @ddt.data("Primary Contacts", "Admin", "Secondary Contacts")
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='mock')
+  def test_create_missed_issue_acl(self, role):
+    """Test create_missed_issue_acl method"""
+    test_email = "newemail@example.com"
+    issue = factories.IssueFactory()
+    issue_integration.create_missed_issue_acl(test_email, role, issue)
+    db.session.commit()
+    person = all_models.Person.query.filter_by(email=test_email).one()
+    role_emails = [
+        p.email for p in issue.get_persons_for_rolename(role)
+    ]
+    self.assertIn(person.email, role_emails)
+
 
 @ddt.ddt
 class TestDisabledIssueIntegration(ggrc.TestCase):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Our user creation had bugs.

# Steps to test the changes
look through ticket details. 

# Solution description

i've added find_user method from our library.
### Notes
- As this bug was reproduced for new users you can't use my instance for testing cause these users were added to DB.
# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
