### PR TITLE
GGRC-5835 Deleted label in change log

### DIFF
--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -758,13 +758,13 @@ export default can.Model.extend({
     return serial;
   },
   display_name: function () {
-    let displayName = this.title || this.name;
-
-    if (_.isUndefined(displayName)) {
-      return '"' + this.type + ' ID: ' + this.id + '" (DELETED)';
+    if (this.is_deleted()) {
+      return `"${this.type} ID: ${this.id}" (DELETED)`;
     }
-
-    return displayName;
+    return this.title || this.name || `"${this.type} ID: ${this.id}"`;
+  },
+  is_deleted: function () {
+    return !(this.created_at);
   },
   display_type: function () {
     return this.type;

--- a/src/ggrc-client/js_specs/models/cacheable_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_spec.js
@@ -43,6 +43,43 @@ describe('Cacheable model', () => {
     GGRC.custom_attr_defs = origGcaDefs;
   });
 
+  describe('display_name method', () => {
+    it("shouldn't contain DELETED in display_name if object isn't deleted",
+      () => {
+        const instance = new DummyModel();
+        spyOn(instance, 'is_deleted').and.returnValue(false);
+        expect(instance.display_name()).not.toContain('DELETED');
+      }
+    );
+
+    it('should contain DELETED in display_name if object is deleted', () => {
+      const instance = new DummyModel();
+      spyOn(instance, 'is_deleted').and.returnValue(true);
+      expect(instance.display_name()).toContain('DELETED');
+    });
+  });
+
+  it("shouldn't contain DELETED in display_name in created_at is set", () => {
+    const instance = new DummyModel({
+      created_at: '02/20/2019 03:19:57 PM +03:00',
+    });
+    expect(instance.display_name()).not.toContain('DELETED');
+  });
+
+  describe('is_deleted method', () => {
+    it('should return true if created_at is undefined', () => {
+      const instance = new DummyModel();
+      expect(instance.is_deleted()).toBe(true);
+    });
+
+    it('should return false if created_at is defined', () => {
+      const instance = new DummyModel({
+        created_at: '02/20/2019 03:19:57 PM +03:00',
+      });
+      expect(instance.is_deleted()).toBe(false);
+    });
+  });
+
   describe('::setup', () => {
     it('prefers pre-set static names over root object & collection', () => {
       let Model = Cacheable.extend({


### PR DESCRIPTION
# Issue description

Mapping to Proposal shows 'Deleted' in Change Log tab for Control and Risk

# Steps to test the changes

1. Create a risk
2. Propose changes
3. Open Change log tab on the Info panel
4. Look at the Mapping to Proposal: shows DELETED

Actual Result: Mapping to Proposal shows 'Deleted' in Change Log tab for Control and Risk
Expected Result: Mapping to Proposal should not show 'Deleted' in Change Log tab for Control and Risk

# Solution description

The issue was in the Cacheable.display_name method. It supposed the object is deleted if both title and name are undefined. But actually, we do have valid not deleted objects without these both fields. For example Proposal.

So we had to change the way of determinating if the object is deleted. Every not deleted object has created_at property, which is now used for this task.

Also, I had to return something in display_name if both title and name and undefined. So I just return a string with type and id.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".