### PR TITLE
GGRC-7050 Failing half hour cron job on UAT

### DIFF
--- a/src/ggrc/notifications/proposal_helpers.py
+++ b/src/ggrc/notifications/proposal_helpers.py
@@ -32,7 +32,7 @@ def _get_object_presentation(obj_dict):
   - slug
 
   if Nothing is presented in serrialized object
-  than it will return `{tytle}_{id}` presentation.
+  than it will return `{type}_{id}` presentation.
   """
   keys = ("display_name", "title", "name", "slug")
   for key in keys:
@@ -61,7 +61,12 @@ def get_field_single_values(proposal, person_dict, cads_dict):
 
   values_dict.update(
       {
-          k: _get_object_presentation(v)
+          # {id: None, type: None} is passed here since there may be proposals
+          # in DB havind None values for keys in content's mapping_fields. It
+          # could happen if proposable object once had nullable relationship
+          # and poposal for such object was created with empty values for this
+          # relationships (e.g. removing related object).
+          k: _get_object_presentation(v or {"id": None, "type": None})
           for k, v in proposal.content["mapping_fields"].iteritems()
       }
   )


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

We have failing half hour cron job on ggrc-uat instances.

# Steps to test the changes

1. Go to ggrc-uat;
2. Execute half hour cron job;

Expected result: no errors in job logs.

# Solution description

Half hour jobs where failing on ggrc-uat because of the way email body is generated from proposal's content `mapping_fields` field. Before integration with GGRCQ `Control` had nullable relationships `kind`,  `mean` and `verify_frequency`. And there was proposal created with this fields left empty which led to proposal's content `mapping_fields` fields to have `None` values when method responsible for building object representation expects dicts.

The solution is to pass `{"id": None, "type": None}` as default value for method build object representation.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
