### PR TITLE
GGRC-6738 Disable changelog pagination while loading

### DIFF
--- a/src/ggrc-client/js/components/revision-log/revision-log.stache
+++ b/src/ggrc-client/js/components/revision-log/revision-log.stache
@@ -16,7 +16,7 @@
       </div>
     {{/if}}
     <div class="grid-data__toolbar flex-box">
-      <tree-pagination {paging}="{pageInfo}"></tree-pagination>
+      <tree-pagination {paging}="{pageInfo}" {$disabled}="{isLoading}"></tree-pagination>
     </div>
     <revision-page {revisions}="{revisions}"
                    {instance}="{instance}"

--- a/src/ggrc-client/styles/components/tree_pagination/_tree_pagination.scss
+++ b/src/ggrc-client/styles/components/tree_pagination/_tree_pagination.scss
@@ -5,6 +5,11 @@
 tree-pagination {
   text-align: left;
 
+  &[disabled] {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+
   .tree-pagination {
     line-height: 28px;
     font-size: 12px;


### PR DESCRIPTION
# Issue description

ChangeLog paging: multiple "Next page" click is possible 

# Steps to test the changes
1. Open any objective, e.g.: /objectives/148#!info from test DB. 
2. Go to Change Log 
3. In paging, click "Next page" many times fastly. 

Actual result: Many requests sent to BE for each page.
Expected results: Paging becomes disabled while one page is loading.

# Solution description

Disabling is done via CSS pointer-events property applied to the overall tree-pagination component.
We already have isLoading property in revision-log, so it's just passed down to tree-pagination.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
