### PR TITLE
GGRC-6923 Validate title is specified in API calls

### DIFF
--- a/src/ggrc-client/js/models/business-models/cycle.js
+++ b/src/ggrc-client/js/models/business-models/cycle.js
@@ -41,6 +41,9 @@ export default Cacheable.extend({
     modified_by: Stub,
     context: Stub,
   },
+  defaults: {
+    title: '',
+  },
   tree_view_options: {
     attr_list: [{
       attr_title: 'Title',

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -144,8 +144,21 @@ class Audit(Snapshotable,
     to audit itself (auditors, audit firm, context setting,
     custom attribute values, etc.)
     """
-    from ggrc_basic_permissions import create_audit_context
 
+    # NOTE. Currently this function is called from Restful.collection_posted
+    # hook. The following operations are performed:
+    # 1) create new object, call json_create(), where attributes will be set
+    #    with value validation
+    # 2) current function is called from(Restful.collection_posted
+    #    which overrides some attributes, attribute validator for these
+    #    attributes are called
+    # So, validation for those attrs are called twice!
+    # One corner case of this behavior is validation of field "title".
+    # title cannot be None, and because title validation is performed before
+    # this function, API request MUST contain non-empty title in dict,
+    # however the value will be overridden and re-validated in this function!
+
+    from ggrc_basic_permissions import create_audit_context
     data = {
         "title": source_object.generate_attribute("title"),
         "description": source_object.description,

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -53,6 +53,10 @@ class Titled(object):
     """Validates and cleans Title that has leading/trailing spaces"""
     # pylint: disable=unused-argument,no-self-use
 
+    # ensure that value is not None (value was not specified or set to null)
+    # treat empty string or string with spaces as valid - it looks like
+    # such case is valid - some tests check such cases, so empty title might
+    # be valid in production
     if value is None:
       raise ValueError("'title' must be specified")
 

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -52,7 +52,11 @@ class Titled(object):
   def validate_title(self, key, value):
     """Validates and cleans Title that has leading/trailing spaces"""
     # pylint: disable=unused-argument,no-self-use
-    return value if value is None else value.strip()
+
+    if value is None:
+      raise ValueError("'title' must be specified")
+
+    return value.strip()
 
   @declared_attr
   def title(cls):  # pylint: disable=no-self-argument

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -521,6 +521,18 @@ def handle_task_group_task_delete(sender, obj=None, src=None, service=None):  # 
 
 @signals.Restful.model_posted.connect_via(models.TaskGroup)
 def handle_task_group_post(sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+
+  # NOTE. To clone task group the following operations are performed:
+  # 1) create new object, call json_create(), where attributes will be set
+  #    with value validation
+  # 2) This function is called which overrides some attributes,
+  #    attribute validator for these attributes are called
+  # So, validation for those attrs are called twice!
+  # One corner case of this behavior is validation of field "title".
+  # title cannot be None, and because title validation is performed before
+  # this function, API request MUST contain non-empty title in dict,
+  # however the value will be overridden and re-validated in this function!
+
   if src.get('clone'):
     source_task_group_id = src.get('clone')
     source_task_group = models.TaskGroup.query.filter_by(

--- a/test/integration/ggrc/access_control/rbac_factories/audit.py
+++ b/test/integration/ggrc/access_control/rbac_factories/audit.py
@@ -66,6 +66,8 @@ class AuditRBACFactory(base.BaseRBACFactory):
     return self.api.post(all_models.Audit, {
         "audit": {
             "program": {"id": self.program_id, "type": "Program"},
+            # workaround - title is required for validation
+            "title": "",
             "context": None,
             "operation": "clone",
             "cloneOptions": {

--- a/test/integration/ggrc/access_control/rbac_factories/base.py
+++ b/test/integration/ggrc/access_control/rbac_factories/base.py
@@ -77,6 +77,7 @@ class BaseRBACFactory(object):
         "cycle": {
             "context": None,
             "autogenerate": True,
+            "title": factories.random_str(prefix="cycle - "),
             "isOverdue": False,
             "workflow": {
                 "id": workflow_id,

--- a/test/integration/ggrc/access_control/rbac_factories/task_group.py
+++ b/test/integration/ggrc/access_control/rbac_factories/task_group.py
@@ -139,6 +139,8 @@ class TaskGroupRBACFactory(base.BaseRBACFactory):
 
     return self.api.post(all_models.TaskGroup, {
         "task_group": {
+            # workaround - title is required for validation
+            "title": "",
             "clone": self.task_group_id,
             "clone_objects": True,
             "clone_people": True,

--- a/test/integration/ggrc/access_control/rbac_factories/workflow.py
+++ b/test/integration/ggrc/access_control/rbac_factories/workflow.py
@@ -72,6 +72,8 @@ class WorkflowRBACFactory(base.BaseRBACFactory):
 
     return self.api.post(all_models.Workflow, {
         "workflow": {
+            # workaround - title is required for validation
+            "title": "",
             "clone": self.workflow_id,
             "clone_objects": True,
             "clone_people": True,

--- a/test/integration/ggrc/models/mixins/test_titled.py
+++ b/test/integration/ggrc/models/mixins/test_titled.py
@@ -28,8 +28,8 @@ class TestTitledMixin(TestCase):
     self.assert400(response)
     self.assertEqual(response.json, "'title' must be specified")
 
-  def test_post_title_is_none(self):
-    """Test object creation request title=None"""
+  def test_post_title_is_null(self):
+    """Test object creation request title=null"""
     response = self.api.post(
         all_models.Product,
         {'product': {"description": "desc", "title": None}}
@@ -38,11 +38,20 @@ class TestTitledMixin(TestCase):
     self.assert400(response)
     self.assertEqual(response.json, "'title' must be specified")
 
-  def test_post_title_is_empty(self):
-    """Test object creation request title=\"\""""
+  @ddt.data(
+      ('a', 'a'),
+      ('  a  ', 'a'),
+      ('', ''),
+      ('  ', ''),
+  )
+  @ddt.unpack
+  def test_post_title_is_valid(self, title, expected):
+    """Test object creation request title={0!r}"""
     response = self.api.post(
         all_models.Product,
-        {'product': {"description": "desc", "title": ""}}
+        {'product': {"description": "desc", "title": title}}
     )
 
     self.assertStatus(response, 201)
+    product = all_models.Product.query.get(response.json['product']['id'])
+    self.assertEqual(product.title, expected)

--- a/test/integration/ggrc/models/mixins/test_titled.py
+++ b/test/integration/ggrc/models/mixins/test_titled.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration test for Titled mixin"""
+
+import ddt
+
+from ggrc.models import all_models
+
+from integration.ggrc import TestCase
+from integration.ggrc.api_helper import Api
+
+
+@ddt.ddt
+class TestTitledMixin(TestCase):
+  """Test cases for Labeled mixin"""
+
+  def setUp(self):
+    super(TestTitledMixin, self).setUp()
+    self.api = Api()
+    self.api.login_as_normal()
+
+  def test_post_no_title(self):
+    """Test object creation request without title key"""
+    response = self.api.post(all_models.Product,
+                             {'product': {"description": "desc"}})
+
+    self.assert400(response)
+    self.assertEqual(response.json, "'title' must be specified")
+
+  def test_post_title_is_none(self):
+    """Test object creation request title=None"""
+    response = self.api.post(
+        all_models.Product,
+        {'product': {"description": "desc", "title": None}}
+    )
+
+    self.assert400(response)
+    self.assertEqual(response.json, "'title' must be specified")
+
+  def test_post_title_is_empty(self):
+    """Test object creation request title=\"\""""
+    response = self.api.post(
+        all_models.Product,
+        {'product': {"description": "desc", "title": ""}}
+    )
+
+    self.assertStatus(response, 201)

--- a/test/integration/ggrc_workflows/generator.py
+++ b/test/integration/ggrc_workflows/generator.py
@@ -138,6 +138,7 @@ class WorkflowsGenerator(Generator):
 
     obj_dict = {
         obj_name: {
+            "title": factories.random_str(prefix="cycle - "),
             "workflow": {
                 "id": workflow.id,
                 "type": workflow.__class__.__name__,

--- a/test/integration/ggrc_workflows/helpers/workflow_api.py
+++ b/test/integration/ggrc_workflows/helpers/workflow_api.py
@@ -97,6 +97,7 @@ def get_cycle_post_dict(workflow):
   """
   return {
       "cycle": {
+          "title": factories.random_str(prefix="cycle - "),
           "context": utils.create_stub(workflow.context),
           "workflow": utils.create_stub(workflow),
           "autogenerate": True,
@@ -120,6 +121,7 @@ def get_task_group_clone_dict(source_task_group, clone_objects=False,
   return {
       "task_group": {
           "clone": source_task_group.id,
+          "title": source_task_group.title,  # workaround for title validation
           "context": None,
           "clone_objects": clone_objects,
           "clone_tasks": clone_tasks,

--- a/test/integration/ggrc_workflows/test_workflow_api_calls.py
+++ b/test/integration/ggrc_workflows/test_workflow_api_calls.py
@@ -344,14 +344,12 @@ class TestWorkflowsApiPost(TestCase):
                for person, acl in workflow.access_control_list}
     self.assertDictEqual(exp_res, act_res)
 
-  @unittest.skip("enable after GGRC-6923 is fixed")
   def test_send_invalid_data(self):
     """Test send invalid data on Workflow post."""
     data = self.get_workflow_dict()
     del data["workflow"]["title"]
     response = self.api.post(all_models.Workflow, data)
     self.assert400(response)
-    # TODO: check why response.json["message"] is empty
 
   def test_create_one_time_workflows(self):
     """Test simple create one time Workflow over api."""

--- a/test/integration/ggrc_workflows/test_workflow_api_calls.py
+++ b/test/integration/ggrc_workflows/test_workflow_api_calls.py
@@ -552,6 +552,7 @@ class TestWorkflowsApiPost(TestCase):
         "cycle": {
             "autogenerate": True,
             "isOverdue": False,
+            "title": factories.random_str(prefix='cycle - '),
             "workflow": {
                 "id": workflow.id,
                 "type": "Workflow",

--- a/test/selenium/src/lib/rest_services/workflow_rest_service.py
+++ b/test/selenium/src/lib/rest_services/workflow_rest_service.py
@@ -89,6 +89,7 @@ class WorkflowCycleRestService(base_rest_service.ObjectRestService):
   def _map_to_rest_for_create_obj(obj):
     """See superclass."""
     return dict(
+        title=obj.title,
         autogenerate=True,
         context=obj.rest_context,
         workflow=rest_convert.to_basic_rest_obj(obj.workflow)

--- a/test/unit/ggrc_workflows/models/test_task_group.py
+++ b/test/unit/ggrc_workflows/models/test_task_group.py
@@ -28,6 +28,7 @@ class TestTaskGroupTask(unittest.TestCase):
     :return: None
     """
     taskgroup = task_group.TaskGroup()
+    taskgroup.title = 'title'
     taskgroup.contact = 'Person id=0x0000AABBCCDDEEFF'
     result = taskgroup.copy(clone_people=True)
     self.assertEqual(result.contact, taskgroup.contact)
@@ -45,6 +46,7 @@ class TestTaskGroupTask(unittest.TestCase):
         :return: None
         """
     taskgroup = task_group.TaskGroup()
+    taskgroup.title = 'title'
     taskgroup.contact = 'Person id=0x0000AABBCCDDEEFF'
     result = taskgroup.copy(clone_people=False)
     self.assertEqual(result.contact, get_current_user())
@@ -62,6 +64,7 @@ class TestTaskGroupTask(unittest.TestCase):
         :return: None
         """
     taskgroup = task_group.TaskGroup()
+    taskgroup.title = 'title'
     taskgroup.contact = None
     result = taskgroup.copy(clone_people=True)
     self.assertEqual(result.contact, get_current_user())
@@ -79,6 +82,7 @@ class TestTaskGroupTask(unittest.TestCase):
         :return: None
         """
     taskgroup = task_group.TaskGroup()
+    taskgroup.title = 'title'
     taskgroup.contact = None
     result = taskgroup.copy(clone_people=False)
     self.assertEqual(result.contact, get_current_user())


### PR DESCRIPTION
# Issue description

500 HTTP error if API POST request for workflow (and other objects) creation doesn't contain 'title' field.
Root cause: title validator for4 all `Titled` models doesn't raise error if title is None. At the same time, column `title` in DB is not nullable. As result, unexpected `IntegrityError` is raised by SQLAlchemy which leads to 500 HTTP error.

# Steps to test the changes

Make API call to create workflow where title field is not added or value equal to null
Expected result: 400 error with message "'title' must be specified"

# Solution description

Improve title validator

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
