### PR TITLE
QUICK-FIX fix cad query count

### DIFF
--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import validates
 from sqlalchemy.sql.schema import UniqueConstraint
+from sqlalchemy import orm
 
 from ggrc import db
 from ggrc.utils import errors
@@ -136,6 +137,14 @@ class CustomAttributeDefinition(attributevalidator.AttributeValidator,
   ]
 
   _reserved_names = {}
+
+  @classmethod
+  def eager_query(cls):
+    query = super(CustomAttributeDefinition, cls).eager_query()
+    query = query.options(
+        orm.undefer('title'),
+    )
+    return query
 
   def _clone(self, target):
     """Clone custom attribute definitions."""
@@ -389,7 +398,7 @@ def _get_query_for(definition_type, instance_id=None):
   """Returns query for sent args if """
   if not get_cads_counts().get((definition_type, instance_id is None)):
     return []
-  query = CustomAttributeDefinition.query.filter(
+  query = CustomAttributeDefinition.eager_query().filter(
       CustomAttributeDefinition.definition_type == definition_type,
   )
   if instance_id is None:

--- a/src/ggrc/snapshotter/indexer.py
+++ b/src/ggrc/snapshotter/indexer.py
@@ -72,11 +72,11 @@ def _get_custom_attribute_dict():
       getattr(all_models, c)._inflector.table_singular: c for c in Types.all
   }
 
-  query = models.CustomAttributeDefinition.query.filter(
+  query = models.CustomAttributeDefinition.eager_query().filter(
       models.CustomAttributeDefinition.definition_type.in_(
           cadef_klass_names.keys()
       )
-  ).options(orm.undefer('title'))
+  )
   cads = defaultdict(list)
   for cad in query:
     cads[cadef_klass_names[cad.definition_type]].append(cad)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

During opening assessment tab additional queries on CAD titles is generated. 

# Steps to test the changes

1. Open Assessment pop-up on tree view
2. Examine mysql logs

# Solution description

Add eager query for CAD and undefer title query. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
