### PR TITLE
GGRC-6747 Add original_object_deleted field for snapshots from related objects

### DIFF
--- a/src/ggrc/services/resources/assessment.py
+++ b/src/ggrc/services/resources/assessment.py
@@ -117,6 +117,7 @@ class AssessmentResource(mixins.SnapshotCounts, common.ExtendedResource):
             "revisions": [],
             "revision_id": snapshot.revision_id,
             "type": snapshot.type,
+            "original_object_deleted": snapshot.original_object_deleted,
         })
     return data
 


### PR DESCRIPTION
Made original_object_deleted field of snapshots to be returned when requesting related_objects of assessment.

# Issue description

Add original_object_deleted field for snapshots from related objects

Query API response for snapshots contains field `original_object_deleted`. In case of getting snapshots through assessment related objects: api/assessments/#id/related_objects the response for snapshot does not contain this field. Based on this flag FE will be able to identify that link to GGRCQ should be hidden.

# Solution description

Added required data to output returned by related_objects method of AssessmentResource.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".