### PR TITLE
GGRC-6388 Refactor basic csv import

### DIFF
--- a/test/integration/ggrc/__init__.py
+++ b/test/integration/ggrc/__init__.py
@@ -293,14 +293,23 @@ class TestCase(BaseTestCase, object):
     with tempfile.NamedTemporaryFile(dir=cls.CSV_DIR, suffix=".csv") as tmp:
       writer = csv.writer(tmp)
       object_type = None
+      object_len = None
       for data in import_data:
         data = data.copy()
+        data_object_len = len(data)
         data_object_type = data.pop("object_type")
         keys = data.keys()
         if data_object_type != object_type:
           if object_type is not None:
             writer.writerow([])
           object_type = data_object_type
+          object_len = data_object_len
+          writer.writerow(["Object type"])
+          writer.writerow([data_object_type] + keys)
+        elif data_object_len != object_len:
+          if object_len:
+            writer.writerow([])
+          object_len = data_object_len
           writer.writerow(["Object type"])
           writer.writerow([data_object_type] + keys)
         writer.writerow([""] + [data[k] for k in keys])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Refactor Basic CSV Import

# Steps to test the changes
1. Set 'delete' parameter of 'tempfile.NamedTemporaryFile' function in 'import_data' to 'False'. This 'import_data' method is defined in 'test/integration/ggrc/__init__.py'
2. Change the arguments of 'data_block.extend' method in 'test_map_core_objects', present in 'TestBasicCsvImport' class of 'test/integration/ggrc/converters/test_import_csv.py', as specified below.

data_block.extend = [
    OrderedDict([
        ("object_type", "standard"),
        ("Code*", "STANDARD-1"),
        ("title", "Standard-1"),
        ("admin", "user@example.com"),
    ]),
    OrderedDict([
        ("object_type", "standard"),
        ("Code*", "STANDARD-2"),
        ("title", "Standard-2"),
        ("admin", "user@example.com"),
        ("map:regulation", "REGULATION-1"),
        ("map:policy", "POLICY-1"),
        ("map:contract", "CONTRACT-1"),
        ("map:requirement", "REQUIREMENT-1"),
        ("map:standard", "STANDARD-1"),
    ])
]

3. Now run the 'nosetests' with below command from inside 'test' folder.
'nosetests -sv integration.ggrc.converters.test_import_csv:TestBasicCsvImport.test_map_core_objects_1'

4. Open the latest temporary csv file created in The Blocks corresponding to above two objects appear as shown below.

Object type
Standard,Code*,Title*,Admin*
,STANDARD-1,Standard-1,user@example.com

Object type
Standard,Code*,Title*,Admin*,map:regulation,map:policy,map:contract,map:requirement,map:standard
,STANDARD-2,Standard-2,user@example.com,REGULATION-1,POLICY-1,CONTRACT-1,REQUIREMENT-1,STANDARD-1


# Solution description

Modified 'import_data' method, present in 'test/integrations/ggrc/__init__.py', such that multiple objects of same object are written as multiple blocks when their respective number of fields differ.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
