### PR TITLE
GGRC-6717 Remove duplicates from ACP and add unique constraint

### DIFF
--- a/src/ggrc/migrations/versions/20190404_014ddab36256_resolve_duplicates_in_access_control_.py
+++ b/src/ggrc/migrations/versions/20190404_014ddab36256_resolve_duplicates_in_access_control_.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Resolve duplicates in access_control_people
+
+Create Date: 2019-04-04 09:11:21.904685
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import logging
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '014ddab36256'
+down_revision = 'adf7bdb8996e'
+
+
+logger = logging.getLogger(__name__)
+
+
+def remove_duplicates(connection):
+  """Remove duplicates from table if any"""
+
+  # Get list of duplicated IDs fto be removed:
+  # inner SELECT returns MIN IDs (i.e. original ones,
+  # for which duplicates exist)
+  # outer SELECT returns ID which are duplicates (i.e. exclude original ones)
+  dup_items = list(connection.execute(
+      sa.text(
+          """
+          SELECT
+              acp.id, acp.person_id, acp.ac_list_id
+          FROM
+              access_control_people acp
+                  JOIN
+              (SELECT
+                  MIN(acp1.id) AS id,
+                      acp1.person_id AS person_id,
+                      acp1.ac_list_id AS ac_list_id
+              FROM
+                  access_control_people acp1
+              GROUP BY acp1.person_id , acp1.ac_list_id
+              HAVING COUNT(*) > 1) acp2 ON acp.person_id = acp2.person_id
+                  AND acp.ac_list_id = acp2.ac_list_id
+          WHERE
+              acp.id != acp2.id
+          """))
+  )
+
+  if dup_items:
+    logging.warning(
+        '[rev:%s] Duplicated items:\n%s', revision,
+        '\n'.join('id={} person_id={} ac_list_id={}'.format(
+            i.id, i.person_id, i.ac_list_id
+        ) for i in dup_items)
+    )
+  else:
+    logging.warning("[rev:%s] No duplicated items found", revision)
+    return
+
+  dup_ids = list(i.id for i in dup_items)
+
+  # Remove duplicated
+  connection.execute(
+      sa.text("DELETE FROM access_control_people WHERE id IN :orig_ids"),
+      orig_ids=dup_ids
+  )
+
+
+def add_constraint(connection):
+  """Add constraint to make person_id/ac_list_id pair unique in DB"""
+  connection.execute("""
+    ALTER TABLE access_control_people
+    ADD CONSTRAINT uq_access_control_people
+    UNIQUE (person_id, ac_list_id);
+  """)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  connection = op.get_bind()
+
+  remove_duplicates(connection)
+  add_constraint(connection)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")


### PR DESCRIPTION
# Issue description

Table `access_control_people` sometimes contains duplicated records for `person_id`/`ac_list_id` pair. The goal is to remove duplicates from DB and create `UNIQUE CONSTRAINT` for this table

# Steps to test the changes

Migrate DB with and without duplicated records, ensure app works as expected

# Solution description

1. Remove duplicates if any
2. Add constraint

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".