### PR TITLE
GGRC-7097 Use lodash.isEqual instead of can.Object.same

### DIFF
--- a/src/ggrc-client/js/models/conflict-resolution/conflict-resolution.js
+++ b/src/ggrc-client/js/models/conflict-resolution/conflict-resolution.js
@@ -50,10 +50,10 @@ export default function resolveConflict(xhr, obj) {
     let stillHasConflict = false;
     let remoteAttrs = _.merge({}, obj.attr());
 
-    if (can.Object.same(remoteAttrs, attrs)) {
+    if (_.isEqual(remoteAttrs, attrs)) {
       // current state is same as server state -- do nothing.
       return obj;
-    } else if (can.Object.same(remoteAttrs, baseAttrs)) {
+    } else if (_.isEqual(remoteAttrs, baseAttrs)) {
       // base state matches server state -- no incorrect expectations -- save.
       return obj.attr(attrs).save();
     }

--- a/src/ggrc-client/js/models/conflict-resolution/conflict-resolvers.js
+++ b/src/ggrc-client/js/models/conflict-resolution/conflict-resolvers.js
@@ -8,11 +8,11 @@ export function buildChangeDescriptor(
   currentValue,
   remoteValue) {
   // The object attribute was changed on the server
-  let isChangedOnServer = !can.Object.same(previousValue, remoteValue);
+  let isChangedOnServer = !_.isEqual(previousValue, remoteValue);
   // The object attribute was changed on the client
-  let isChangedLocally = !can.Object.same(previousValue, currentValue);
+  let isChangedLocally = !_.isEqual(previousValue, currentValue);
   // The change on the server was not the same as the change on the client
-  let isDifferent = !can.Object.same(currentValue, remoteValue);
+  let isDifferent = !_.isEqual(currentValue, remoteValue);
 
   let hasConflict = (isChangedOnServer && isChangedLocally && isDifferent);
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

**CanJS 3** doesn't support **can.Object.same** function.
It can be replaced with **lodash.isEqual**

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
