### PR TITLE
GGRC-6962 Improve query api performance

### DIFF
--- a/src/ggrc/access_control/role.py
+++ b/src/ggrc/access_control/role.py
@@ -70,9 +70,9 @@ class AccessControlRole(attributevalidator.AttributeValidator,
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
-    return super(AccessControlRole, cls).eager_query()
+    return super(AccessControlRole, cls).eager_query(**kwargs)
 
   _api_attrs = reflection.ApiAttributes(
       "name",

--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -144,9 +144,9 @@ class Roleable(object):
       acl.update_people(persons_by_acl[acl])
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager Query"""
-    query = super(Roleable, cls).eager_query()
+    query = super(Roleable, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload(
             '_access_control_list'

--- a/src/ggrc/app.py
+++ b/src/ggrc/app.py
@@ -3,7 +3,7 @@
 
 """Sets up Flask app."""
 
-
+from datetime import datetime
 import re
 import time
 
@@ -186,12 +186,18 @@ def _set_display_queries(report_type):
 
     # We have to copy the queries list below otherwise queries executed
     # in the for loop will be appended causing an endless loop
-    for query in queries[:]:
+    for i, query in enumerate(list(queries)):
       if report_type == 'slow' and query.duration < slow_threshold:
         continue
       logger.info(
-          "%.8f %s\n%s\n%s",
+          "Query #%s\n"
+          "Duration: %.8f (from %s to %s) in %s\n"
+          "Statement:\n%s\n"
+          "Parameters:\n%s",
+          i + 1,
           query.duration,
+          datetime.fromtimestamp(query.start_time),
+          datetime.fromtimestamp(query.end_time),
           query.context,
           query.statement,
           query.parameters)
@@ -204,6 +210,7 @@ def _set_display_queries(report_type):
           logger.info(tabulate(result.fetchall(), headers=result.keys()))
         except:  # pylint: disable=bare-except
           logger.warning("Statement failed: %s", statement, exc_info=True)
+
     return response
 
 

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -157,8 +157,8 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
     )
 
   @classmethod
-  def eager_query(cls):
-    return cls._populate_query(super(Assessment, cls).eager_query())
+  def eager_query(cls, **kwargs):
+    return cls._populate_query(super(Assessment, cls).eager_query(**kwargs))
 
   @classmethod
   def indexed_query(cls):

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -170,8 +170,8 @@ class AssessmentTemplate(assessment.AuditRelationship,
   }
 
   @classmethod
-  def eager_query(cls):
-    query = super(AssessmentTemplate, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(AssessmentTemplate, cls).eager_query(**kwargs)
     return query.options(
         orm.Load(cls).joinedload("audit").undefer_group("Audit_complete"),
         orm.Load(cls).joinedload("audit").joinedload(

--- a/src/ggrc/models/audit.py
+++ b/src/ggrc/models/audit.py
@@ -218,8 +218,8 @@ class Audit(Snapshotable,
     ).exists()
 
   @classmethod
-  def eager_query(cls):
-    query = super(Audit, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Audit, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('program'),
         orm.subqueryload('object_people').joinedload('person'),

--- a/src/ggrc/models/comment.py
+++ b/src/ggrc/models/comment.py
@@ -112,9 +112,9 @@ class Commentable(object):
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager Query"""
-    query = super(Commentable, cls).eager_query()
+    query = super(Commentable, cls).eager_query(**kwargs)
     return query.options(orm.subqueryload('comments'))
 
   @declared_attr
@@ -258,8 +258,8 @@ class Comment(Roleable, Relatable, Described, Notifiable,
     return ""
 
   @classmethod
-  def eager_query(cls):
-    query = super(Comment, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Comment, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('revision'),
         orm.joinedload('custom_attribute_definition')
@@ -385,9 +385,9 @@ class ExternalCommentable(object):
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager query for ExternalCommentable mixin."""
-    query = super(ExternalCommentable, cls).eager_query()
+    query = super(ExternalCommentable, cls).eager_query(**kwargs)
     return query.options(orm.subqueryload("comments"))
 
   @declared_attr

--- a/src/ggrc/models/context.py
+++ b/src/ggrc/models/context.py
@@ -119,8 +119,8 @@ class HasOwnContext(object):
     ).exists()
 
   @classmethod
-  def eager_query(cls):
-    return super(HasOwnContext, cls).eager_query().options(
+  def eager_query(cls, **kwargs):
+    return super(HasOwnContext, cls).eager_query(**kwargs).options(
         orm.Load(cls).subqueryload(
             "contexts"
         ).undefer_group(

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -174,8 +174,8 @@ class Control(synchronizable.Synchronizable,
   }
 
   @classmethod
-  def eager_query(cls):
-    query = super(Control, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Control, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, Control._include_links).options(
         orm.joinedload('directive'),
     )

--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -101,8 +101,8 @@ class CustomAttributeValue(base.ContextRBAC, Base, Indexed, db.Model):
     )
 
   @classmethod
-  def eager_query(cls):
-    query = super(CustomAttributeValue, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(CustomAttributeValue, cls).eager_query(**kwargs)
     query = query.options(
         orm.subqueryload('_related_revisions'),
         orm.joinedload('custom_attribute'),

--- a/src/ggrc/models/directive.py
+++ b/src/ggrc/models/directive.py
@@ -135,8 +135,8 @@ class Directive(mixins.LastDeprecatedTimeboxed,
     return validate_option(self.__class__.__name__, key, option, key)
 
   @classmethod
-  def eager_query(cls):
-    query = super(Directive, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Directive, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, Directive._include_links).options(
         orm.joinedload('audit_frequency'),
         orm.joinedload('audit_duration'),

--- a/src/ggrc/models/event.py
+++ b/src/ggrc/models/event.py
@@ -42,8 +42,8 @@ class Event(Base, db.Model):
     )
 
   @classmethod
-  def eager_query(cls):
-    query = super(Event, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Event, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload('revisions').undefer_group('Revision_complete'),
     )

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -141,5 +141,5 @@ class Issue(Roleable,
     )
 
   @classmethod
-  def eager_query(cls):
-    return cls._populate_query(super(Issue, cls).eager_query())
+  def eager_query(cls, **kwargs):
+    return cls._populate_query(super(Issue, cls).eager_query(**kwargs))

--- a/src/ggrc/models/issue.py
+++ b/src/ggrc/models/issue.py
@@ -142,4 +142,9 @@ class Issue(Roleable,
 
   @classmethod
   def eager_query(cls, **kwargs):
+    # Ensure that related_destinations and related_sources will be loaded
+    # in subquery. It allows reduce a number of requests to DB when these attrs
+    # are used
+    kwargs['load_related'] = True
+
     return cls._populate_query(super(Issue, cls).eager_query(**kwargs))

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -747,8 +747,8 @@ class WithNetworkZone(object):
         self.__class__.__name__, key, option, 'network_zone')
 
   @classmethod
-  def eager_query(cls):
-    query = super(WithNetworkZone, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(WithNetworkZone, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload(
             "network_zone"

--- a/src/ggrc/models/mixins/attributable.py
+++ b/src/ggrc/models/mixins/attributable.py
@@ -48,9 +48,9 @@ class Attributable(object):
     }
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
-    query = super(Attributable, cls).eager_query()
+    query = super(Attributable, cls).eager_query(**kwargs)
     query = query.options(
         orm.subqueryload('_attributes')
     )

--- a/src/ggrc/models/mixins/base.py
+++ b/src/ggrc/models/mixins/base.py
@@ -69,7 +69,7 @@ class Identifiable(object):
     return self.__class__.__name__
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     mapper_class = cls._sa_class_manager.mapper.base_mapper.class_
     return db.session.query(cls).options(
         db.Load(mapper_class).undefer_group(
@@ -136,10 +136,10 @@ class ContextRBAC(object):
     )
 
   # @classmethod
-  # def eager_query(cls):
+  # def eager_query(cls, **kwargs):
   # from sqlalchemy import orm
 
-  # query = super(ContextRBAC, cls).eager_query()
+  # query = super(ContextRBAC, cls).eager_query(**kwargs)
   # return query.options(
   # orm.subqueryload('context'))
 

--- a/src/ggrc/models/mixins/base.py
+++ b/src/ggrc/models/mixins/base.py
@@ -135,14 +135,6 @@ class ContextRBAC(object):
         orm.Load(cls).load_only("context_id"),
     )
 
-  # @classmethod
-  # def eager_query(cls, **kwargs):
-  # from sqlalchemy import orm
-
-  # query = super(ContextRBAC, cls).eager_query(**kwargs)
-  # return query.options(
-  # orm.subqueryload('context'))
-
 
 class ChangeTracked(object):
 

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -452,9 +452,9 @@ class CustomAttributable(object):
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
-    query = super(CustomAttributable, cls).eager_query()
+    query = super(CustomAttributable, cls).eager_query(**kwargs)
     query = query.options(
         orm.subqueryload('custom_attribute_definitions')
            .undefer_group('CustomAttributeDefinition_complete'),

--- a/src/ggrc/models/mixins/issue_tracker.py
+++ b/src/ggrc/models/mixins/issue_tracker.py
@@ -75,9 +75,9 @@ class IssueTracked(object):
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
-    query = super(IssueTracked, cls).eager_query()
+    query = super(IssueTracked, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('issuetracker_issue')
     )

--- a/src/ggrc/models/mixins/labeled.py
+++ b/src/ggrc/models/mixins/labeled.py
@@ -135,9 +135,9 @@ class Labeled(object):
     return res
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager query classmethod."""
-    return super(Labeled, cls).eager_query().options(
+    return super(Labeled, cls).eager_query(**kwargs).options(
         orm.subqueryload('_object_labels'))
 
   @classmethod

--- a/src/ggrc/models/mixins/with_evidence.py
+++ b/src/ggrc/models/mixins/with_evidence.py
@@ -86,10 +86,10 @@ class WithEvidence(object):
     return self.get_evidences_by_kind(Evidence.FILE)
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager query classmethod."""
     return cls.eager_inclusions(
-        super(WithEvidence, cls).eager_query(),
+        super(WithEvidence, cls).eager_query(**kwargs),
         WithEvidence._include_links,
     ).options(
         sa.orm.subqueryload(

--- a/src/ggrc/models/object_document.py
+++ b/src/ggrc/models/object_document.py
@@ -71,10 +71,10 @@ class Documentable(object):
     return self.get_documents_by_kind(Document.REFERENCE_URL)
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager query classmethod."""
     return cls.eager_inclusions(
-        super(Documentable, cls).eager_query(),
+        super(Documentable, cls).eager_query(**kwargs),
         Documentable._include_links,
     ).options(
         sa.orm.subqueryload(

--- a/src/ggrc/models/object_person.py
+++ b/src/ggrc/models/object_person.py
@@ -56,8 +56,8 @@ class ObjectPerson(Timeboxed, base.ContextRBAC, Base, db.Model):
   ]
 
   @classmethod
-  def eager_query(cls):
-    query = super(ObjectPerson, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(ObjectPerson, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload('person'))
 
@@ -93,7 +93,7 @@ class Personable(object):
   _include_links = []
 
   @classmethod
-  def eager_query(cls):
-    query = super(Personable, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Personable, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, Personable._include_links).options(
         orm.subqueryload('object_people'))

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -171,13 +171,13 @@ class Person(CustomAttributable, CustomAttributeMapable, HasOwnContext,
     return email_re.match(val) if val else False
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     from sqlalchemy import orm
 
-    # query = super(Person, cls).eager_query()
+    # query = super(Person, cls).eager_query(**kwargs)
     # Completely overriding eager_query to avoid eager loading of the
     # modified_by relationship
-    return super(Person, cls).eager_query().options(
+    return super(Person, cls).eager_query(**kwargs).options(
         orm.joinedload('language'),
         orm.joinedload('profile'),
         orm.subqueryload('object_people'),

--- a/src/ggrc/models/product.py
+++ b/src/ggrc/models/product.py
@@ -71,8 +71,8 @@ class Product(Roleable,
     ).exists()
 
   @classmethod
-  def eager_query(cls):
-    query = super(Product, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Product, cls).eager_query(**kwargs)
     return query.options(orm.joinedload('kind'))
 
   @classmethod

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -52,10 +52,10 @@ class Program(review.Reviewable,
   }
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     from sqlalchemy import orm
 
-    query = super(Program, cls).eager_query()
+    query = super(Program, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, Program._include_links).options(
         orm.subqueryload('audits'),
         orm.subqueryload('risk_assessments'),

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -326,7 +326,8 @@ class Relatable(object):
     query = super(Relatable, cls).eager_query(**kwargs)
     query = cls.eager_inclusions(query, Relatable._include_links)
 
-    if kwargs.get('load_related', True):
+    if 'load_related' not in kwargs or kwargs.get('load_related'):
+      # load related in subquery by default or if it's explicitly requested
       return query.options(
           orm.subqueryload('related_sources'),
           orm.subqueryload('related_destinations'))

--- a/src/ggrc/models/relationship.py
+++ b/src/ggrc/models/relationship.py
@@ -234,6 +234,7 @@ class Relatable(object):
 
   @declared_attr
   def related_sources(cls):  # pylint: disable=no-self-argument
+    """List of Relationship where 'source' points to related object"""
     current_type = cls.__name__
 
     joinstr = (
@@ -265,6 +266,7 @@ class Relatable(object):
 
   @declared_attr
   def related_destinations(cls):  # pylint: disable=no-self-argument
+    """List of Relationship where 'destination' points to related object"""
     current_type = cls.__name__
 
     joinstr = (
@@ -318,13 +320,18 @@ class Relatable(object):
   _include_links = []
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     from sqlalchemy import orm
 
-    query = super(Relatable, cls).eager_query()
-    return cls.eager_inclusions(query, Relatable._include_links).options(
-        orm.subqueryload('related_sources'),
-        orm.subqueryload('related_destinations'))
+    query = super(Relatable, cls).eager_query(**kwargs)
+    query = cls.eager_inclusions(query, Relatable._include_links)
+
+    if kwargs.get('load_related', True):
+      return query.options(
+          orm.subqueryload('related_sources'),
+          orm.subqueryload('related_destinations'))
+
+    return query
 
 
 class Stub(collections.namedtuple("Stub", ["type", "id"])):

--- a/src/ggrc/models/requirement.py
+++ b/src/ggrc/models/requirement.py
@@ -56,9 +56,9 @@ class Requirement(Roleable,
   _include_links = []
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Define fields to be loaded eagerly to lower the count of DB queries."""
-    query = super(Requirement, cls).eager_query()
+    query = super(Requirement, cls).eager_query(**kwargs)
     return query.options(orm.undefer('notes'))
 
   @classmethod

--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -93,8 +93,8 @@ class Reviewable(rest_handable.WithPutHandable,
     )
 
   @classmethod
-  def eager_query(cls):
-    return super(Reviewable, cls).eager_query().options(
+  def eager_query(cls, **kwargs):
+    return super(Reviewable, cls).eager_query(**kwargs).options(
         sa.orm.joinedload("review")
     )
 

--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -77,10 +77,10 @@ class Revision(ChangesSynchronized, Filterable, base.ContextRBAC, Base,
   ]
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     from sqlalchemy import orm
 
-    query = super(Revision, cls).eager_query()
+    query = super(Revision, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload('modified_by'),
         orm.subqueryload('event'),  # used in description

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -137,8 +137,8 @@ class Snapshot(rest_handable.WithDeleteHandable,
     return self.revisions and self.revisions[-1].action == "deleted"
 
   @classmethod
-  def eager_query(cls):
-    query = super(Snapshot, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(Snapshot, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, Snapshot._include_links).options(
         orm.subqueryload('revision'),
         orm.subqueryload('revisions'),

--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -279,7 +279,7 @@ class QueryHelper(object):
 
     object_name = object_query["object_name"]
     object_class = inflector.get_model(object_name)
-    query = object_class.eager_query()
+    query = object_class.eager_query(load_related=False)
     query = query.filter(object_class.id.in_(ids))
 
     with benchmark("Get objects by ids: _get_objects -> obj in query"):

--- a/src/ggrc_basic_permissions/models.py
+++ b/src/ggrc_basic_permissions/models.py
@@ -86,10 +86,10 @@ Person._api_attrs.add('user_roles')
 _orig_Person_eager_query = Person.eager_query
 
 
-def _Person_eager_query(cls):
+def _Person_eager_query(cls, **kwargs):
   from sqlalchemy import orm
 
-  return _orig_Person_eager_query().options(
+  return _orig_Person_eager_query(**kwargs).options(
       orm.subqueryload('user_roles'),
       # orm.subqueryload('user_roles').undefer_group('UserRole_complete'),
       # orm.subqueryload('user_roles').joinedload('context'),
@@ -104,10 +104,12 @@ Context._api_attrs.add('user_roles')
 _orig_Context_eager_query = Context.eager_query
 
 
-def _Context_eager_query(cls):
+def _Context_eager_query(cls, **kwargs):
   from sqlalchemy import orm
 
-  return _orig_Context_eager_query().options(orm.subqueryload('user_roles'))
+  return _orig_Context_eager_query(**kwargs).options(
+      orm.subqueryload('user_roles')
+  )
 
 
 Context.eager_query = classmethod(_Context_eager_query)

--- a/src/ggrc_basic_permissions/models.py
+++ b/src/ggrc_basic_permissions/models.py
@@ -145,10 +145,10 @@ class UserRole(base.ContextRBAC, Base, db.Model):
     return assignments_by_user
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     from sqlalchemy import orm
 
-    query = super(UserRole, cls).eager_query()
+    query = super(UserRole, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('role'),
         orm.subqueryload('person'),

--- a/src/ggrc_workflows/models/cycle.py
+++ b/src/ggrc_workflows/models/cycle.py
@@ -206,7 +206,7 @@ class Cycle(roleable.Roleable,
     ).exists()
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Add cycle task groups to cycle eager query
 
     This function adds cycle_task_groups as a join option when fetching cycles,
@@ -216,7 +216,7 @@ class Cycle(roleable.Roleable,
     Returns:
       a query object with cycle_task_groups added to joined load options.
     """
-    query = super(Cycle, cls).eager_query()
+    query = super(Cycle, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('cycle_task_groups'),
         orm.Load(cls).joinedload("workflow").undefer_group(

--- a/src/ggrc_workflows/models/cycle_task_group.py
+++ b/src/ggrc_workflows/models/cycle_task_group.py
@@ -242,7 +242,7 @@ class CycleTaskGroup(roleable.Roleable,
     )
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Add cycle tasks and objects to cycle task group eager query.
 
     Make sure we load all cycle task group relevant data in a single query.
@@ -250,7 +250,7 @@ class CycleTaskGroup(roleable.Roleable,
     Returns:
       a query object with cycle_task_group_tasks added to joined load options.
     """
-    query = super(CycleTaskGroup, cls).eager_query()
+    query = super(CycleTaskGroup, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload("cycle_task_group_tasks"),
         orm.joinedload("cycle").undefer_group("Cycle_complete"),

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from sqlalchemy import orm
 import sqlalchemy as sa
 from sqlalchemy.ext import hybrid
+from sqlalchemy.ext.declarative import declared_attr
 from werkzeug.exceptions import BadRequest
 
 from ggrc import builder
@@ -437,32 +438,45 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
 
 
 class CycleTaskable(object):
-  """ Requires the Relatable mixin, otherwise cycle_task_group_object_tasks
-  fails to fetch related objects
-  """
-  @builder.simple_property
-  def cycle_task_group_object_tasks(self):
-    """ Lists all the cycle tasks related to a certain object
-    """
-    sources = [r.CycleTaskGroupObjectTask_source
-               for r in self.related_sources
-               if r.CycleTaskGroupObjectTask_source is not None]
-    destinations = [r.CycleTaskGroupObjectTask_destination
-                    for r in self.related_destinations
-                    if r.CycleTaskGroupObjectTask_destination is not None]
-    return sources + destinations
+  """CycleTaskable mixin"""
+
+  # The following attribute will be used to add sqlalchemy properties
+  # to mapper after Mixin is injected to existing Model class.
+  # Do not forget add new sqlalchemy attrs to the list. These aatrs will be
+  # added to mapper after mixin injection
+  _mapper_inject_properties = [
+      'cycle_task_group_object_tasks',
+  ]
+
+  @declared_attr
+  def cycle_task_group_object_tasks(cls):  # pylint: disable=no-self-argument
+    return db.relationship(
+        CycleTaskGroupObjectTask,
+        primaryjoin=lambda: sa.or_(
+            sa.and_(
+                cls.id == relationship.Relationship.source_id,
+                relationship.Relationship.source_type == cls.__name__,
+                relationship.Relationship.destination_type ==
+                "CycleTaskGroupObjectTask",
+            ),
+            sa.and_(
+                cls.id == relationship.Relationship.destination_id,
+                relationship.Relationship.destination_type == cls.__name__,
+                relationship.Relationship.source_type ==
+                "CycleTaskGroupObjectTask",
+            )
+        ),
+        secondary=relationship.Relationship.__table__,
+        secondaryjoin=lambda: CycleTaskGroupObjectTask.id == sa.case(
+            [(relationship.Relationship.source_type == cls.__name__,
+              relationship.Relationship.destination_id)],
+            else_=relationship.Relationship.source_id
+        ),
+        viewonly=True
+    )
 
   @classmethod
   def eager_query(cls, **kwargs):
     """Eager query for objects with cycle tasks."""
     query = super(CycleTaskable, cls).eager_query(**kwargs)
-    return query.options(
-        orm.subqueryload('related_sources')
-           .joinedload('CycleTaskGroupObjectTask_source')
-           .undefer_group('CycleTaskGroupObjectTask_complete')
-           .joinedload('cycle'),
-        orm.subqueryload('related_destinations')
-           .joinedload('CycleTaskGroupObjectTask_destination')
-           .undefer_group('CycleTaskGroupObjectTask_complete')
-           .joinedload('cycle')
-    )
+    return query.options(orm.subqueryload('cycle_task_group_object_tasks'))

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -321,14 +321,14 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
     ).exists()
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """
     Add related objects to eager query.
 
     This function makes sure that with one query we fetch all cycle task
     related data needed for generating cycle task json for a response.
     """
-    query = super(CycleTaskGroupObjectTask, cls).eager_query()
+    query = super(CycleTaskGroupObjectTask, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('cycle')
            .undefer_group('Cycle_complete'),
@@ -453,9 +453,9 @@ class CycleTaskable(object):
     return sources + destinations
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
     """Eager query for objects with cycle tasks."""
-    query = super(CycleTaskable, cls).eager_query()
+    query = super(CycleTaskable, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload('related_sources')
            .joinedload('CycleTaskGroupObjectTask_source')

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -333,6 +333,8 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
     # Ensure that related_destinations and related_sources will be loaded
     # in subquery. It allows reduce a number of requests to DB when these attrs
     # are used
+    LOGGER.debug("%s.eager_query(): setting flag to load related_sources "
+                 " and related_destinations", cls.__name__)
     kwargs['load_related'] = True
 
     query = super(CycleTaskGroupObjectTask, cls).eager_query(**kwargs)

--- a/src/ggrc_workflows/models/cycle_task_group_object_task.py
+++ b/src/ggrc_workflows/models/cycle_task_group_object_task.py
@@ -329,6 +329,12 @@ class CycleTaskGroupObjectTask(roleable.Roleable,
     This function makes sure that with one query we fetch all cycle task
     related data needed for generating cycle task json for a response.
     """
+
+    # Ensure that related_destinations and related_sources will be loaded
+    # in subquery. It allows reduce a number of requests to DB when these attrs
+    # are used
+    kwargs['load_related'] = True
+
     query = super(CycleTaskGroupObjectTask, cls).eager_query(**kwargs)
     return query.options(
         orm.joinedload('cycle')

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -165,8 +165,8 @@ class TaskGroup(roleable.Roleable,
     return target
 
   @classmethod
-  def eager_query(cls):
-    query = super(TaskGroup, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(TaskGroup, cls).eager_query(**kwargs)
     return query.options(
         orm.Load(cls).subqueryload('task_group_objects'),
         orm.Load(cls).subqueryload('task_group_tasks')

--- a/src/ggrc_workflows/models/task_group_object.py
+++ b/src/ggrc_workflows/models/task_group_object.py
@@ -73,9 +73,9 @@ class TaskGroupObject(roleable.Roleable,
   _sanitize_html = []
 
   @classmethod
-  def eager_query(cls):
+  def eager_query(cls, **kwargs):
 
-    query = super(TaskGroupObject, cls).eager_query()
+    query = super(TaskGroupObject, cls).eager_query(**kwargs)
     return query.options(
         orm.subqueryload('task_group'))
 
@@ -120,7 +120,7 @@ class TaskGroupable(object):
   _include_links = []
 
   @classmethod
-  def eager_query(cls):
-    query = super(TaskGroupable, cls).eager_query()
+  def eager_query(cls, **kwargs):
+    query = super(TaskGroupable, cls).eager_query(**kwargs)
     return cls.eager_inclusions(query, TaskGroupable._include_links).options(
         orm.subqueryload('task_group_objects'))

--- a/src/ggrc_workflows/models/task_group_task.py
+++ b/src/ggrc_workflows/models/task_group_task.py
@@ -193,8 +193,8 @@ class TaskGroupTask(roleable.Roleable,
     )
 
   @classmethod
-  def eager_query(cls):
-    return cls._populate_query(super(TaskGroupTask, cls).eager_query())
+  def eager_query(cls, **kwargs):
+    return cls._populate_query(super(TaskGroupTask, cls).eager_query(**kwargs))
 
   def _display_name(self):
     return self.title + '<->' + self.task_group.display_name

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -417,8 +417,8 @@ class Workflow(roleable.Roleable,
     return target
 
   @classmethod
-  def eager_query(cls):
-    return super(Workflow, cls).eager_query().options(
+  def eager_query(cls, **kwargs):
+    return super(Workflow, cls).eager_query(**kwargs).options(
         orm.subqueryload('cycles').undefer_group('Cycle_complete')
            .subqueryload("cycle_task_group_object_tasks")
            .undefer_group("CycleTaskGroupObjectTask_complete"),

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -36,7 +36,7 @@ class TestAllModels(WithQueryApi, TestCase):
       'CycleTaskGroup': 8,
       'CycleTaskGroupObjectTask': 13,
       'Document': 7,
-      'Issue': 14,
+      'Issue': 15,
       'KeyReport': 13,
       'Market': 13,
       'Objective': 14,

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -41,7 +41,7 @@ class TestAllModels(WithQueryApi, TestCase):
       'Market': 13,
       'Objective': 14,
       'OrgGroup': 13,
-      'Person': 12,
+      'Person': 10,
       'Policy': 14,
       'Process': 13,
       'System': 13,
@@ -112,11 +112,11 @@ class TestAllModels(WithQueryApi, TestCase):
           "limit": [0, obj_count],
           "order_by": [{"name": "updated_at", "desc": True}]
       }])
-      self.assertLessEqual(
+      self.assertEqual(
           counter.get,
           self.QUERY_API_LIMIT[model.__name__],
-          "Eager query of {model} has too much queries: "
-          "{counted} > {expected} for query "
+          "Eager query of {model} has unexpected number of queries: "
+          "actual={counted}, expected={expected} for query "
           "{obj_count} instances".format(
               model=model,
               expected=self.QUERY_API_LIMIT[model.__name__],

--- a/test/integration/ggrc/models/test_query_api_queries.py
+++ b/test/integration/ggrc/models/test_query_api_queries.py
@@ -24,37 +24,37 @@ class TestAllModels(WithQueryApi, TestCase):
     self.api = api_helper.Api()
 
   QUERY_API_LIMIT = {
-      'Assessment': 16,
-      'AssessmentTemplate': 10,
+      'Assessment': 15,
+      'AssessmentTemplate': 8,
       'AccessGroup': 17,
-      'AccountBalance': 14,
-      'Audit': 14,
-      'Comment': 8,
-      'Contract': 15,
-      'Control': 16,
-      'Cycle': 9,
-      'CycleTaskGroup': 10,
+      'AccountBalance': 13,
+      'Audit': 12,
+      'Comment': 6,
+      'Contract': 14,
+      'Control': 15,
+      'Cycle': 7,
+      'CycleTaskGroup': 8,
       'CycleTaskGroupObjectTask': 13,
-      'Document': 9,
+      'Document': 7,
       'Issue': 14,
-      'KeyReport': 14,
-      'Market': 14,
-      'Objective': 15,
-      'OrgGroup': 14,
+      'KeyReport': 13,
+      'Market': 13,
+      'Objective': 14,
+      'OrgGroup': 13,
       'Person': 12,
-      'Policy': 15,
-      'Process': 14,
-      'System': 14,
-      'Program': 17,
-      'Regulation': 15,
-      'TaskGroup': 11,
+      'Policy': 14,
+      'Process': 13,
+      'System': 13,
+      'Program': 16,
+      'Regulation': 14,
+      'TaskGroup': 9,
       'TaskGroupObject': 4,
-      'TaskGroupTask': 9,
-      'Workflow': 14,
+      'TaskGroupTask': 7,
+      'Workflow': 12,
       'TechnologyEnvironment': 8,
-      'Product': 14,
-      'Metric': 14,
-      'ProductGroup': 14,
+      'Product': 13,
+      'Metric': 13,
+      'ProductGroup': 13,
   }
 
   MODEL_FACTORIES = [
@@ -112,11 +112,11 @@ class TestAllModels(WithQueryApi, TestCase):
           "limit": [0, obj_count],
           "order_by": [{"name": "updated_at", "desc": True}]
       }])
-      self.assertEqual(
+      self.assertLessEqual(
           counter.get,
           self.QUERY_API_LIMIT[model.__name__],
           "Eager query of {model} has too much queries: "
-          "{counted} not equal to {expected} for query "
+          "{counted} > {expected} for query "
           "{obj_count} instances".format(
               model=model,
               expected=self.QUERY_API_LIMIT[model.__name__],


### PR DESCRIPTION
# Issue description

Multiple tabs on "All objects" page are loading more than 5+ seconds.

# Steps to test the changes

1. Open "All objects" page
2. Click through all tabs and see how much time required to complete request

# Solution description

Query API uses `eager_query()` to get list of last updated objects, which loads all relationships.
SQL query is quick in this case, but SQLAlchemy requires too much time when it is connecting objects internally - see https://docs.sqlalchemy.org/en/latest/faq/performance.html#result-fetching-slowness-orm
For example, to load 10 audits with 37000 relationships SQL query requires 0.3 sec to execute, and SQLAlchemy takes 5 seconds more to handle returned data!

This PR makes the following changes:
1. Add possibility to turn off some subqueries in  `eager_query()`
2. Turn off relationships loading for query API, because query API returns object representations without a list of related objects. 
3. Add a new `declared_attr` in `CycleTaskable` to limit number of relationships loaded
4. Added workaround to add new `declared_attr` to SQLAlchemy mappers after `CycleTaskable` is injected to already configured Model classes

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
