### PR TITLE
GGRC-7056 Fix evidence reusing of file/url for related assessments

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.js
@@ -448,6 +448,25 @@ export default can.Component.extend({
             tracker.USER_ACTIONS.INFO_PANE.OPEN_INFO_PANE);
         });
     },
+    addReusableEvidence(event) {
+      this.attr('deferredSave').push(() => {
+        event.items.forEach((item) => {
+          let related = {
+            id: item.attr('id'),
+            type: item.attr('type'),
+          };
+
+          this.addAction('add_related', related);
+        });
+      })
+        .done(() => {
+          this.updateItems('urls', 'files');
+          this.refreshCounts(['Evidence']);
+        })
+        .always(() => {
+          this.attr('instance').removeAttr('actions');
+        });
+    },
     initializeFormFields: function () {
       const cavs =
       getCustomAttributes(

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane.stache
@@ -293,8 +293,7 @@
                 <related-assessments
                     {instance}="{instance}"
                     {need-reuse}="{true}"
-                    (refresh-assessment)="{refreshAssessment}"
-                    (after-object-reused)="{updateItems('files', 'urls')}">
+                    (reusable-objects-created)="{addReusableEvidence(%event)}">
                 </related-assessments>
             {{/instance}}
           </tab-panel>

--- a/src/ggrc-client/js/components/gdrive/gdrive_picker_launcher.js
+++ b/src/ggrc-client/js/components/gdrive/gdrive_picker_launcher.js
@@ -170,7 +170,7 @@ export default can.Component.extend({
           title: file.title,
           source_gdrive_id: file.id,
           is_uploaded: file.newUpload,
-          parent_obj: {
+          parent_obj: { // parent object is used for renaming evidence
             id: instanceId,
             type: instanceType,
           },

--- a/src/ggrc-client/js/components/related-objects/related-assessments.js
+++ b/src/ggrc-client/js/components/related-objects/related-assessments.js
@@ -92,6 +92,8 @@ export default can.Component.extend({
       return new Evidence(data);
     },
     reuseSelected: function () {
+      this.attr('isSaving', true);
+
       let reusedObjectList = this.attr('selectedEvidences').map((evidence) => {
         let model = this.buildEvidenceModel(evidence);
 
@@ -100,14 +102,17 @@ export default can.Component.extend({
         });
       });
 
-      this.attr('isSaving', true);
-
-      $.when(...reusedObjectList).always(() => {
-        this.attr('selectedEvidences').replace([]);
-        this.attr('isSaving', false);
-        this.dispatch('afterObjectReused');
-        this.dispatch('refreshAssessment');
-      });
+      $.when(...reusedObjectList)
+        .done((...evidence) => {
+          this.dispatch({
+            type: 'reusableObjectsCreated',
+            items: evidence,
+          });
+        })
+        .always(() => {
+          this.attr('selectedEvidences').replace([]);
+          this.attr('isSaving', false);
+        });
     },
     loadRelatedAssessments() {
       const limits = this.attr('paging.limits');

--- a/src/ggrc-client/js/components/related-objects/tests/related-assessments_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-assessments_spec.js
@@ -277,26 +277,18 @@ describe('related-assessments component', () => {
           });
         });
 
-        it('dispatches "afterObjectReused" event', (done) => {
+        it('dispatches "reusableObjectsCreated" event', (done) => {
           spyOn(viewModel, 'dispatch');
 
           viewModel.reuseSelected();
 
-          saveDfd.resolve().then(() => {
+          let model = {};
+          saveDfd.resolve(model).then(() => {
             expect(viewModel.dispatch)
-              .toHaveBeenCalledWith('afterObjectReused');
-            done();
-          });
-        });
-
-        it('dispatches "refreshAssessment" event on instance', (done) => {
-          spyOn(viewModel, 'dispatch');
-
-          viewModel.reuseSelected();
-
-          saveDfd.resolve().then(() => {
-            expect(viewModel.dispatch)
-              .toHaveBeenCalledWith('refreshAssessment');
+              .toHaveBeenCalledWith({
+                type: 'reusableObjectsCreated',
+                items: [model],
+              });
             done();
           });
         });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Cannot reuse evidence file/url for related assessments

# Steps to test the changes

1. Log in ggrc-app and open any audit page with mapped control snapshot
2. Generate two assessments based on the control snapshot
3. Add evidence file and url to one assessment 
4. Open second assessment info panel > Related assessment tab
5. Reuse evidence file and url screenshot-1.png
6. Click on Assessment tab: evidence file and url are not shown up (even after page reload)

**Actual Result:** Cannot reuse evidence file/url for related assessments
**Expected Result:** User should have a possibility to reuse evidence file/url for related assessments

# Solution description

Issue was introduced in #9199 PR. In this PR mapping of evidence and Assessment was updated. Previously was used `parent_obj` in Evidence object. Now mapping happens through assessment `actions` attribute. And `parent_obj` is not handled on BE for mapping anymore.
So reusable objects functionality is updated to use assessment's `actions` prop instead of `parent_obj`.
Note: `parent_obj` is still sent to BE for renaming purposes.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
