### PR TITLE
GGRC-4994 Remove lock_task_order property for Task Group Task from BE

### DIFF
--- a/src/ggrc/migrations/versions/20190412_cfe397ab518c_remove_lock_task_order_for_task_group_.py
+++ b/src/ggrc/migrations/versions/20190412_cfe397ab518c_remove_lock_task_order_for_task_group_.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+remove_lock_task_order_for_task_group_task
+
+Create Date: 2019-04-12 13:45:53.184163
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'cfe397ab518c'
+down_revision = '42afbc0e6c09'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.drop_column('task_groups', 'lock_task_order')
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -44,7 +44,6 @@ class TaskGroup(roleable.Roleable,
       db.ForeignKey('workflows.id', ondelete="CASCADE"),
       nullable=False,
   )
-  lock_task_order = db.Column(db.Boolean(), nullable=True)
 
   task_group_objects = db.relationship(
       'TaskGroupObject', backref='_task_group', cascade='all, delete-orphan')
@@ -66,7 +65,6 @@ class TaskGroup(roleable.Roleable,
       'task_group_objects',
       reflection.Attribute('objects', create=False, update=False),
       'task_group_tasks',
-      'lock_task_order',
       'sort_index',
       # Intentionally do not include `cycle_task_groups`
       # 'cycle_task_groups',


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

BE Remove lock_task_order property for Task Group Task

# Steps to test the changes

Search for lock_task_order property in the code and delete if any.

Run the build_assets command.
Once the assets are build successfully run the launch_ggrc command in the container.

# Solution description

Removed the lock_task_order property from BE code.
Updated the table task_groups by deleting the lock_task_order column.
Update the file "src/ggrc/migrations/versions/20190412_cfe397ab518c_remove_lock_task_order_for_task_group_.py" with the below query:
Query : op.drop_column('task_groups', 'lock_task_order')

Note: If the file is not editable change the permissions by logging out of the docker container.

Run the below command in order to execute the sql changes:
python migrate.py revision -m "remove_lock_task_order_for_task_group_task"

Run the below query to verify that the changes were made successfully, the lock_task_order column should not be shown in the result :
desc task_groups;

Once the changes are verified, run the command:

db_reset

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
