### PR TITLE
GGRC-7058 Remove custom attribute value api

### DIFF
--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -36,7 +36,6 @@ def contributed_services():
       service('external_comments', models.ExternalComment),
       service('custom_attribute_definitions',
               models.CustomAttributeDefinition),
-      service('custom_attribute_values', models.CustomAttributeValue),
       service('data_assets', models.DataAsset),
       service('directives', models.Directive, common.ReadOnlyResource),
       service('contracts', models.Contract),

--- a/test/integration/ggrc/generator.py
+++ b/test/integration/ggrc/generator.py
@@ -363,21 +363,3 @@ class ObjectGenerator(Generator):
     }
     data[obj_name].update(kwargs)
     return self.generate(models.CustomAttributeDefinition, obj_name, data)
-
-  def generate_custom_attribute_value(self, custom_attribute_id, attributable,
-                                      **kwargs):
-    """Generate a CA value in `attributable` for CA def with certain id."""
-    obj_name = "custom_attribute_value"
-    data = {
-        obj_name: {
-            "title": kwargs.get("title", factories.random_str()),
-            "custom_attribute_id": custom_attribute_id,
-            "attributable_type": attributable.__class__.__name__,
-            "attributable_id": attributable.id,
-            "attribute_value": kwargs.get("attribute_value"),
-            # "attribute_object": not implemented
-            "context": {"id": None},
-        },
-    }
-    data[obj_name].update(kwargs)
-    return self.generate(models.CustomAttributeValue, obj_name, data)

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -305,49 +305,6 @@ class TestSyncServiceControl(TestCase):
     ).one()
     self.assertIsNotNone(revision)
 
-  @ddt.data((" http://www.some.url", " http://www.some.url"),
-            ("<a>http://www.some.url</a>",
-             "<a>http://www.some.url</a>"))
-  @ddt.unpack
-  def test_control_rich_text_validate(self, initial_value, expected_value):
-    """Test rich text validation for control."""
-    response = self.api.post(all_models.Control, {
-        "control": {
-            "id": 11111,
-            "title": "Some title",
-            "context": None,
-            "external_id": factories.SynchronizableExternalId.next(),
-            "external_slug": factories.random_str(),
-            "assertions": '["any assertion"]',
-            "review_status": all_models.Review.STATES.UNREVIEWED,
-            "review_status_display_name": "any status",
-        },
-    })
-    self.assertEqual(response.status_code, 201)
-    control = all_models.Control.query.filter_by(title="Some title").first()
-
-    cad = factories.CustomAttributeDefinitionFactory(
-        definition_type="control",
-        definition_id=control.id,
-        attribute_type="Rich Text",
-        title="CA",
-    )
-
-    response = self.api.post(all_models.CustomAttributeValue, {
-        "custom_attribute_value": {
-            "custom_attribute_id": cad.id,
-            "attributable_type": "control",
-            "attributable_id": control.id,
-            "attribute_value": initial_value,
-            "context": {"id": None},
-        }
-    })
-    self.assertEqual(response.status_code, 201)
-
-    control = all_models.Control.query.filter_by(title="Some title").first()
-    self.assertEqual(control.custom_attribute_values[0].attribute_value,
-                     expected_value)
-
   def test_create_with_assertions(self):
     """Check control creation with assertions pass"""
     response = self.api.post(all_models.Control, {


### PR DESCRIPTION
# Issue description

Custom attribute values on read only objects or archived objects can be edited manually via api requests.

# Steps to test the changes

spoof an api request to /api/custom_attribuet_values/id for a control or any read only object.

# Solution description

Since we never use cav api and all edits should only be done on objects themselves, we removed the entire service. This ensures proper checks on the parent objects will be done if we try to edit a custom attribute value.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
