### PR TITLE
GGRC-6525 Fix display of three dots for rich text fields

### DIFF
--- a/src/ggrc-client/styles/components/unified-mapper/_unified-mapper.scss
+++ b/src/ggrc-client/styles/components/unified-mapper/_unified-mapper.scss
@@ -348,11 +348,7 @@ mapper-results-item-attrs {
   .attr {
     @include cell-styles();
 
-    white-space: normal;
     height: 33px;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
     tree-field {
       div.tree-field__item {
         display: none;


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Three dots are not displayed for rich text fields if content is very long and doesn't have white spaces

# Steps to test the changes

1. Open 'Create Control' or other object modal
2. Fill 'Description' field w/ very long text w/o white spaces (300+ symbols)
3. Fill out all mandatory fields and click 'Save'
4. Open 'Global Search' modal & perform search by 'Control' or the respective object type
5. Add 'Description' to be displayed
Actual behavior: 3 dots are not displayed at the end of 'Description' field content.
Expected behavior: If text is not fully displayed then 3 dots should be displayed at the end of visible content.

# Solution description

Modify css properties in src/ggrc-client/styles/components/unified-mapper/_unified-mapper.scss file

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
