### PR TITLE
GGRC-7067 Allow edit readonly objects for external user

### DIFF
--- a/src/ggrc/services/resources/relationship.py
+++ b/src/ggrc/services/resources/relationship.py
@@ -40,7 +40,7 @@ class RelationshipResource(ggrc.services.common.Resource):
                       "dedicated for SOX needs")
 
   @staticmethod
-  def _validate_readonly_access(obj):
+  def _validate_readonly_access(obj, src):
     """Ensure that relationship is allowed for read-only objects"""
 
     if not isinstance(obj, relationship.Relationship):
@@ -55,13 +55,6 @@ class RelationshipResource(ggrc.services.common.Resource):
 
     if isinstance(obj2, WithReadOnlyAccess):
       RelationshipResource._validate_readonly_relationship(obj2, obj1)
-
-  @staticmethod
-  def _validate_readonly_access_on_post(objects):
-    """Validate read-only access on POST"""
-
-    for obj in objects:
-      RelationshipResource._validate_readonly_access(obj)
 
   @staticmethod
   def _parse_snapshot_data(src):


### PR DESCRIPTION
# Issue description

For now all objects on GGRC side are marked as read-only and we can’t change them through the api. To fix it we need to allow processing requests from external users.

Expected behaviour of GGRC for API requests made by external user:

1. It is not expected that sync service sends any requests to endpoints which start from the following paths: “/api/relationships”, /api/add_folder, /api/remove_folder. No changes will be made to these endpoints, so GGRC will behave for external user the same as for normal user
2. It is not expected that sync service sends DELETE requests to api/systems/<id> endpoint. Behaviour of GGRC will be the same as for normal user.
3. Sync service can send POST/PUT requests to /api/systems and /api/systems/<id> endpoints. GGRC have to allow such requests no matter system is read-only or not.
4. Sync service can set flag readonly for POST request, GGRC accepts this flag. If flag is not set default value false for POST and do not change existing value for PUT.
5. Behaviour of GGRC for requests made by normal user have to be the same as before

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
