### PR TITLE
GGRC-5365 Add valid values for Default Assignees/Verifiers in Assessment Template

### DIFF
--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -3,6 +3,8 @@
 
 
 """A module containing the implementation of the assessment template entity."""
+from collections import OrderedDict
+
 from sqlalchemy import orm
 from sqlalchemy.orm import validates
 from werkzeug.exceptions import Forbidden
@@ -70,18 +72,16 @@ class AssessmentTemplate(assessment.AuditRelationship,
   audit_id = db.Column(db.Integer, db.ForeignKey('audits.id'), nullable=False)
 
   # labels to show to the user in the UI for various default people values
-  DEFAULT_PEOPLE_LABELS = {
-      "Admin": "Object Admins",
-      "Audit Lead": "Audit Captain",
-      "Auditors": "Auditors",
-      "Principal Assignees": "Principal Assignees",
-      "Secondary Assignees": "Secondary Assignees",
-      "Primary Contacts": "Primary Contacts",
-      "Secondary Contacts": "Secondary Contacts",
-      "Control Owners": "Control Owners",
-      "Control Operators": "Control Operators",
-      "Other Contacts": "Other Contacts",
-  }
+  DEFAULT_PEOPLE_LABELS = OrderedDict([
+      ("Admin", "Object Admins"),
+      ("Audit Lead", "Audit Captain"),
+      ("Auditors", "Auditors"),
+      ("Principal Assignees", "Principal Assignees"),
+      ("Secondary Assignees", "Secondary Assignees"),
+      ("Control Operators", "Control Operators"),
+      ("Control Owners", "Control Owners"),
+      ("Other Contacts", "Other Contacts"),
+  ])
 
   _title_uniqueness = False
 
@@ -122,11 +122,17 @@ class AssessmentTemplate(assessment.AuditRelationship,
           "display_name": "Default Assignees",
           "mandatory": True,
           "filter_by": "_nop_filter",
+          "description": "Options are:\n{}\nuser@example.com".format(
+              '\n'.join(DEFAULT_PEOPLE_LABELS.values())
+          ),
       },
       "default_verifier": {
           "display_name": "Default Verifiers",
           "mandatory": False,
           "filter_by": "_nop_filter",
+          "description": "Options are:\n{}\nuser@example.com".format(
+              '\n'.join(DEFAULT_PEOPLE_LABELS.values())
+          ),
       },
       "default_test_plan": {
           "display_name": "Default Assessment Procedure",

--- a/test/integration/ggrc/converters/test_export_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_export_assessment_templates.py
@@ -23,9 +23,7 @@ class TestAssessmentTemplatesExport(TestCase):
       ("Audit Captain", "Audit Lead"),
       ("Auditors", "Auditors"),
       ("Principal Assignees", "Principal Assignees"),
-      ("Secondary Assignees", "Secondary Assignees"),
-      ("Primary Contacts", "Primary Contacts"),
-      ("Secondary Contacts", "Secondary Contacts")
+      ("Secondary Assignees", "Secondary Assignees")
   )
   @ddt.unpack
   def test_people_labels_export(self, title, label):

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -70,15 +70,15 @@ class TestAssessmentTemplatesImport(TestCase):
         ("Code*", slug),
         ("Audit*", "Audit"),
         ("Title", "Title"),
-        ("Object Under Assessment", 'Control'),
-        ("Default Verifiers", "Secondary Contacts")
+        ("Object Under Assessment", "Control"),
+        ("Default Verifiers", "Auditors")
     ]))
     template = models.AssessmentTemplate.query \
         .filter(models.AssessmentTemplate.slug == slug) \
         .first()
     self._check_csv_response(response, {})
-    self.assertEqual(template.default_people['verifiers'],
-                     "Secondary Contacts")
+    self.assertEqual(template.default_people["verifiers"],
+                     "Auditors")
 
   def test_invalid_import(self):
     """Test invalid import."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Valid values for Default Assignees / Default Verifiers should be specified in assessment template import / export files

# Steps to test the changes

1. Download assessment template import template
Actual result: Valid values for Default Assignees / Default Verifiers are not specified
Expected result: They should be specified

# Solution description

1. Modify src/ggrc/models/assessment_template.py to add valid values for Default Assignees and Default Verifiers
2. Modify below test assessment files
/vagrant/test/integration/ggrc/converters/test_export_assessment_templates.py
/vagrant/test/integration/ggrc/converters/test_export_assessment_templates.py

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
