### PR TITLE
GGRC-6967 Fix label in edit Assessment modal

### DIFF
--- a/src/ggrc-client/styles/components/multi-select-label/_multi-select-label.scss
+++ b/src/ggrc-client/styles/components/multi-select-label/_multi-select-label.scss
@@ -24,6 +24,7 @@ multi-select-label {
     border-radius: 3px;
     background-color: $white;
     box-shadow: 0 1px 4px 2px rgba(0, 0, 0, 0.075);
+    z-index: 1;
 
     ul {
       margin: 0;


### PR DESCRIPTION
# Issue description

Cannot select label in Edit Assessment popup

# Steps to test the changes

1. Open Edit Assessment popup
2. Expand Label dropdown list 
Actual Result: Last item in suggestions is overlapped by assignee screenshot-1.png
Expected Result: Last item in suggestions should not be overlapped by an assignee
3. The select label above Assessment Procedure field
Actual Result: Labels cannot be selected since they are displayed above Assessment Procedure rich text (e.g. "Assessment label", "Audit created by auditor1")
Expected Result: Labels can be selected.

# Solution description

Set autocomplete result box z-index to push it upper than other content.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
