### PR TITLE
QUICK-FIX Use jasmine clock separately

### DIFF
--- a/src/ggrc-client/js/components/custom-autocomplete/tests/autocomplete-input_spec.js
+++ b/src/ggrc-client/js/components/custom-autocomplete/tests/autocomplete-input_spec.js
@@ -63,15 +63,6 @@ describe('autocomplete-input component', () => {
   describe('inputLatency() method', () => {
     const msTime = 501;
 
-    beforeEach(() => {
-      jasmine.clock().uninstall(); // required to fix jasmin.clock issue
-      jasmine.clock().install();
-    });
-
-    afterEach(() => {
-      jasmine.clock().uninstall();
-    });
-
     it('should set "isPending" to true before dispatching event', () => {
       const value = 'f';
       viewModel.attr('value', value);
@@ -86,6 +77,8 @@ describe('autocomplete-input component', () => {
     });
 
     it('should notify that value is changed when value is not empty', () => {
+      jasmine.clock().install();
+
       const value = 'f';
       viewModel.attr('value', value);
       spyOn(viewModel, 'dispatch');
@@ -98,9 +91,13 @@ describe('autocomplete-input component', () => {
         type: 'inputChanged',
         value,
       });
+
+      jasmine.clock().uninstall();
     });
 
     it('should not notify that value is changed when value is empty', () => {
+      jasmine.clock().install();
+
       const value = '';
       viewModel.attr('value', value);
       spyOn(viewModel, 'dispatch');
@@ -110,9 +107,13 @@ describe('autocomplete-input component', () => {
       jasmine.clock().tick(msTime);
 
       expect(viewModel.dispatch).not.toHaveBeenCalled();
+
+      jasmine.clock().uninstall();
     });
 
     it('should set "isPending" to false after delay', () => {
+      jasmine.clock().install();
+
       ['any value', null, '', undefined].forEach((value) => {
         viewModel.attr('value', value);
         viewModel.attr('isPending', true);
@@ -122,6 +123,8 @@ describe('autocomplete-input component', () => {
 
         expect(viewModel.attr('isPending')).toBe(false);
       });
+
+      jasmine.clock().uninstall();
     });
   });
 


### PR DESCRIPTION
# Issue description

`jasmine.clock().uninstall()` is used in `autocomplete-input_spec.js` like a workaround for jasmine clock issue. In combination with no usage in one test about 150 tests are failed in migration for CanJS 3.

# Steps to test the changes

Inside the container run: `run_karma`

# Solution description

Install/uninstall clock separately in tests.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
