### PR TITLE
GGRC-7031 Allow global admin unset flag readonly for SOX Systems via import

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -48,6 +48,7 @@ class ImportConverter(BaseConverter):
   priority_columns = [
       "email",
       "slug",
+      "readonly",
       "delete",
       "task_type",
       "audit",

--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -417,8 +417,10 @@ class ImportBlockConverter(BlockConverter):
     Special columns which are primary keys logically or affect the valid set of
     columns go before usual columns.
     """
+
     return [
-        k for k in self.headers if k in self.converter.priority_columns
+        # ensure that columns are ordered according to the priority list
+        k for k in self.converter.priority_columns if k in self.headers
     ] + [
         k for k in self.headers if k not in self.converter.priority_columns
     ]

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -41,6 +41,7 @@ _ALLOWED_ATTRS_FOR_READONLY_ACCESS = (
     'slug',
     'email',
     'comments',
+    'readonly',
 )
 
 

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -215,7 +215,8 @@ READONLY_ACCESS_WARNING = (u"Line {line}: The system is in a "
                            u"The following columns will be ignored: "
                            u"{columns}.")
 
-NON_ADMIN_ACCESS_ERROR = (u"Line {line}: You don't have permissions to make "
-                          u"the {object_type} read-only. Please contact your "
-                          u"administrator if you have any questions. "
-                          u"Column '{column_name}' will be ignored.")
+NON_ADMIN_ACCESS_ERROR = (u"Line {line}: You don't have permissions to use "
+                          u"column '{column_name}' for {object_type}. Please "
+                          u"contact your administrator if you have any "
+                          u"questions. Column '{column_name}' will be "
+                          u"ignored.")

--- a/src/ggrc/converters/handlers/boolean.py
+++ b/src/ggrc/converters/handlers/boolean.py
@@ -91,18 +91,25 @@ class AdminCheckboxColumnHandler(CheckboxColumnHandler):
   and False. Only global Admin can setup such value.
   """
 
-  def set_obj_attr(self):
-    """Handle set object for boolean values by global Admin."""
+  def parse_item(self):
+    """Return parsed column value
+
+    Mark current handler value "not specified" if current user
+    is not global admin
+    """
+
     user = login.get_current_user(use_external_user=False)
     role = getattr(user, 'system_wide_role', None)
     if role in rbac.SystemWideRoles.admins:
-      super(AdminCheckboxColumnHandler, self).set_obj_attr()
-    else:
-      self.add_warning(
-          errors.NON_ADMIN_ACCESS_ERROR,
-          object_type=self.row_converter.obj.type,
-          column_name=self.display_name,
-      )
+      return super(AdminCheckboxColumnHandler, self).parse_item()
+
+    self.add_warning(
+        errors.NON_ADMIN_ACCESS_ERROR,
+        object_type=self.row_converter.obj.type,
+        column_name=self.display_name,
+    )
+    self.set_empty = True
+    return None
 
 
 class KeyControlColumnHandler(CheckboxColumnHandler):


### PR DESCRIPTION
# Issue description

The goal is to allow global admin unset flag `readonly` for Systems

# Steps to test the changes

1. Ensure that global creator who is admin assigned as admin for read-only system cannot unset flag `readonly` via import
2. Ensure that global admin can unset flag `readonly` via import

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
