### PR TITLE
GGRC-5815: Active Cycles/History tabs are not refreshed if Cycle is deprecated or restored

### DIFF
--- a/src/ggrc-client/js/models/business-models/cycle.js
+++ b/src/ggrc-client/js/models/business-models/cycle.js
@@ -8,6 +8,8 @@ import Permission from '../../permission';
 import isOverdue from '../mixins/is-overdue';
 import Stub from '../stub';
 import Workflow from './workflow';
+import {getPageInstance} from '../../plugins/utils/current-page-utils';
+import {REFRESH_MAPPING} from '../../events/eventTypes';
 
 function refreshWorkflow(ev, instance) {
   if (instance instanceof this === false) {
@@ -63,5 +65,13 @@ export default Cacheable.extend({
 }, {
   init: function () {
     this._super(...arguments);
+    this.bind('status', function (ev, newStatus, oldStatus) {
+      if (newStatus === 'Deprecated' || oldStatus === 'Deprecated') {
+        getPageInstance().dispatch({
+          type: `${REFRESH_MAPPING.type}`,
+          destinationType: this.type,
+        });
+      }
+    });
   },
 });

--- a/src/ggrc-client/js/models/business-models/tests/cycle_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/cycle_spec.js
@@ -1,0 +1,45 @@
+/*
+ Copyright (C) 2019 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import Cycle from '../cycle';
+import {makeFakeInstance} from '../../../../js_specs/spec_helpers';
+import * as CurrentPageUtils from '../../../plugins/utils/current-page-utils';
+import {REFRESH_MAPPING} from '../../../events/eventTypes';
+
+describe('Cycle model', () => {
+  let fakeCycleModel;
+  let pageInstance;
+  let expectedEvent;
+
+  beforeEach(() => {
+    fakeCycleModel = makeFakeInstance({model: Cycle}, {status: 'Assigned'})();
+
+    pageInstance = {type: 'Workflow', dispatch: jasmine.createSpy('dispatch')};
+
+    expectedEvent = {
+      type: `${REFRESH_MAPPING.type}`,
+      destinationType: fakeCycleModel.type,
+    };
+
+    spyOn(CurrentPageUtils, 'getPageInstance')
+      .and.returnValue(pageInstance);
+  });
+
+  it('dispatches REFRESH_MAPPING event ' +
+    'if the Cycle status has changed to "Deprecated"', () => {
+    fakeCycleModel.attr('status', 'Deprecated');
+    expect(pageInstance.dispatch).toHaveBeenCalledWith(expectedEvent);
+  });
+
+  it('dispatches REFRESH_MAPPING event each time ' +
+    'if the Cycle status has changed to or from "Deprecated"', () => {
+    fakeCycleModel.attr('status', 'Deprecated');
+    fakeCycleModel.attr('status', 'Assigned');
+    expect(pageInstance.dispatch.calls.allArgs()).toEqual([
+      [expectedEvent],
+      [expectedEvent],
+    ]);
+  });
+});


### PR DESCRIPTION
# Issue description

Active Cycles/History tabs are not refreshed if Cycle is deprecated or restored

# Steps to test the changes

1. Create Repeat off workflow. Need verification TRUE
2. Add 1 task to Task group
3. Activate workflow
4. Open Active Cycles tab and Deprecate Cycle task
5. Click on Active Cycles tab and Look at the History tab: both tabs show 'zero'  

**Actual Result**: Active Cycles/History tabs are not refreshed if Cycle is deprecated or restored  
**Expected result**: Active Cycles/History tabs should be refreshed if Cycle is deprecated or restored

# Solution description

Subscribe to cycle 'status' attribute changes and dispatch event after the Cycle status has changed to or from 'Deprecated' value. In tree-widget-container component listen this event and call the function to refresh tabs.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
