### PR TITLE
GGRC-7222 Add readonly attribute to fulltext

### DIFF
--- a/src/ggrc/models/mixins/with_readonly_access.py
+++ b/src/ggrc/models/mixins/with_readonly_access.py
@@ -9,6 +9,7 @@ It allows to mark objects as read-only
 from sqlalchemy.orm import validates
 
 from ggrc import db
+from ggrc.fulltext import attributes
 from ggrc.models import reflection
 from ggrc.models.exceptions import ValidationError
 
@@ -34,6 +35,15 @@ class WithReadOnlyAccess(object):
           "hidden": True,
       },
   }
+
+  _fulltext_attrs = [
+      attributes.BooleanFullTextAttr(
+          'readonly',
+          'readonly',
+          true_value="yes",
+          false_value="no",
+      )
+  ]
 
   def can_change_relationship_with(self, obj):
     """Check whether relationship from self to obj1 can be changed


### PR DESCRIPTION
# Issue description

We need to load readonly Systems from GGRC by sync service. Loading will be implemented using /query endpoint. To allow filtration by 'readonly' in /query it should be in fulltext.

# Steps to test the changes

Send query request for System model with expression `readonly="yes"/"no"`

# Solution description

Add readonly to _fulltext_attrs.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

