### PR TITLE
GGRC-7223 Add possibility to setup ACL in sync service format on GGRC side

### DIFF
--- a/src/ggrc/models/system.py
+++ b/src/ggrc/models/system.py
@@ -10,6 +10,7 @@ from ggrc.fulltext.mixin import Indexed
 from ggrc.models.comment import ScopedCommentable
 from ggrc.models.deferred import deferred
 from ggrc.models import mixins
+from ggrc.models.mixins import synchronizable
 from ggrc.models.mixins.with_readonly_access import WithReadOnlyAccess
 from ggrc.models.object_document import PublicDocumentable
 from ggrc.models.object_person import Personable
@@ -81,7 +82,7 @@ class SystemOrProcess(ScopedCommentable,
 class System(mixins.CustomAttributable,
              WithReadOnlyAccess,
              Personable,
-             Roleable,
+             synchronizable.RoleableSynchronizable,
              Relatable,
              PublicDocumentable,
              SystemOrProcess,

--- a/test/integration/ggrc/models/test_system.py
+++ b/test/integration/ggrc/models/test_system.py
@@ -1,0 +1,91 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for System model."""
+import mock
+
+from ggrc import db
+from ggrc.models import all_models
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+from integration.ggrc import api_helper
+
+
+@mock.patch(
+    'ggrc.settings.EXTERNAL_APP_USER',
+    new='External App <external_app@example.com>'
+)
+class TestSoxSystem(TestCase):
+  """Tests for Sox System model."""
+
+  def setUp(self):
+    """Test setup method."""
+    super(TestSoxSystem, self).setUp()
+    self.api = api_helper.Api()
+
+    self.app_user_email = "external_app@example.com"
+    self.ext_user_email = "external@example.com"
+
+    custom_headers = {
+        'X-GGRC-user': '{"email": "%s"}' % self.app_user_email,
+        'X-external-user': '{"email": "%s"}' % self.ext_user_email
+    }
+
+    self.api.headers.update(custom_headers)
+    self.api.client.get("/login", headers=self.api.headers)
+
+  def test_system_acl_create(self):
+    """Test creation of SOX system with non empty acl."""
+    response = self.api.post(all_models.System, {
+        "system": {
+            "title": "new_system",
+            "context": None,
+            "access_control_list": {"Admin": [
+                {
+                    "email": "user1@example.com",
+                    "name": "user1",
+                },
+            ]}
+        }
+    })
+
+    self.assertEqual(201, response.status_code)
+
+    system = all_models.System.query.get(response.json["system"]["id"])
+    actual_people = system.get_persons_for_rolename("Admin")
+    expected_people = all_models.Person.query.filter_by(
+        email="user1@example.com"
+    ).all()
+    self.assertItemsEqual(actual_people, expected_people)
+
+  def test_system_acl_update(self):
+    """Test updating of SOX system with non empty acl."""
+    with factories.single_commit():
+      system = factories.SystemFactory()
+      person = factories.PersonFactory()
+      system.add_person_with_role_name(person, "Admin")
+
+    response = self.api.put(system, {
+        "access_control_list": {
+            "Admin": [
+                {
+                    "email": "user1@example.com",
+                    "name": "user1",
+                },
+                {
+                    "email": "user2@example.com",
+                    "name": "user2",
+                },
+            ]
+        },
+    })
+    self.assert200(response)
+    system = all_models.System.query.get(system.id)
+    actual_people_ids = system.get_person_ids_for_rolename("Admin")
+    expected_people_ids = db.session.query(all_models.Person.id).filter(
+        all_models.Person.email.in_(("user1@example.com", "user2@example.com"))
+    ).all()
+    self.assertItemsEqual(
+        actual_people_ids,
+        [i[0] for i in expected_people_ids]
+    )


### PR DESCRIPTION
# Issue description

Sync service send POST/PUT requests (for SOX Systems) where access_control_list is set in format like:
```
{<role name>:[
{"name": <user name>, "email": <user email>}
]}
```
This format differs from GGRC format, so we need to modify ACL setter for GGRC Systems.

# Steps to test the changes

Try to create/update System using new ACL format.

# Solution description

Change Roleable to RoleableSynchronizable (this mixin already contain required logic)

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
