### PR TITLE
GGRC-7466 Add test for editing person authorization

### DIFF
--- a/test/selenium/src/lib/element/info_widget_three_bbs.py
+++ b/test/selenium/src/lib/element/info_widget_three_bbs.py
@@ -89,3 +89,11 @@ class WorkflowInfoWidgetThreeBbbs(InfoWidgetThreeBbbs):
 
 class ControlInfoWidgetThreeBbbs(InfoWidgetThreeBbbs):
   """3bbs element for Control info widget."""
+
+
+class PersonTreeItemThreeBbbs(InfoWidgetThreeBbbs):
+  """3bbs element for Person tree item widget."""
+
+  def select_edit_authorizations(self):
+    """Selects `Edit Authorizations` option."""
+    self._three_bbs.option_by_text("Edit System Authorizations").click()

--- a/test/selenium/src/lib/page/modal/person_modal.py
+++ b/test/selenium/src/lib/page/modal/person_modal.py
@@ -30,3 +30,17 @@ class BasePersonModal(base.Modal):
       getattr(self, field + "_field").value = kwargs[field]
     self.name_field.click()
     self._save_and_close()
+
+
+class UserRoleAssignmentsModal(base.Modal):
+  """Modal window for editing person role."""
+
+  def __init__(self, driver=None):
+    super(UserRoleAssignmentsModal, self).__init__(driver)
+    self.modal = self._browser.div(class_name="modal")
+
+  def select_and_submit_role(self, role):
+    """Click specified role to select it and save."""
+    self.modal.label(text=role.capitalize()).click()
+    self.modal.link(text="Save").click()
+    self.modal.wait_until_not(method=lambda e: e.present)

--- a/test/selenium/src/lib/page/widget/widget_base.py
+++ b/test/selenium/src/lib/page/widget/widget_base.py
@@ -187,7 +187,7 @@ class PeopleItemContent(base.Component):
   def __init__(self, driver=None):
     super(PeopleItemContent, self).__init__(driver)
     self._root = self._browser.element(class_name="info")
-    self._3bbs_menu = info_widget_three_bbs.InfoWidgetThreeBbbs(self._root)
+    self._3bbs_menu = info_widget_three_bbs.PersonTreeItemThreeBbbs(self._root)
 
   def get_person(self):
     """Get person from people tree item."""
@@ -202,3 +202,8 @@ class PeopleItemContent(base.Component):
     """Click "Edit Person" in dropdown menu."""
     self._3bbs_menu.select_edit()
     return person_modal.BasePersonModal(self._driver)
+
+  def open_edit_authorizations_modal(self):
+    """Click "Edit Authorizations" in dropdown menu."""
+    self._3bbs_menu.select_edit_authorizations()
+    return person_modal.UserRoleAssignmentsModal()

--- a/test/selenium/src/lib/service/admin_webui_service.py
+++ b/test/selenium/src/lib/service/admin_webui_service.py
@@ -2,6 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Services for create and manipulate objects via admin UI."""
 
+from nerodia.wait import wait
+
 from lib import url
 from lib.page import dashboard
 from lib.page.modal import person_modal
@@ -19,7 +21,7 @@ class AdminWebUiService(object):
 class PeopleAdminWebUiService(AdminWebUiService):
   """Class for admin people business layer's services objects"""
 
-  def __init__(self, driver):
+  def __init__(self, driver=None):
     super(PeopleAdminWebUiService, self).__init__(driver)
     self.people_widget = self._open_admin_people_tab()
 
@@ -69,3 +71,14 @@ class PeopleAdminWebUiService(AdminWebUiService):
     new_person data."""
     self.expand_found_person(person_to_edit).open_edit_modal()
     self._fill_and_submit_modal_form(new_person)
+
+  def edit_authorizations(self, person, new_role):
+    """Open User Role Assignments Modal window for selected person and apply
+    new role.
+    Return edited person."""
+    people_tree_item = self.expand_found_person(person)
+    people_tree_item.open_edit_authorizations_modal().select_and_submit_role(
+        new_role)
+    wait.Wait.until(
+        lambda: people_tree_item.get_person().system_wide_role == new_role)
+    return self.expand_found_person(person).get_person()

--- a/test/selenium/src/tests/test_admin_dashboard_page.py
+++ b/test/selenium/src/tests/test_admin_dashboard_page.py
@@ -324,3 +324,11 @@ class TestPeopleAdministration(base.Test):
     act_person = ppl_admin_service.expand_found_person(creator).get_person()
     self.general_equal_assert(creator.people_tree_item_representation(),
                               act_person)
+
+  def test_edit_authorizations(self, creator, selenium):
+    """Check that person role can be edited."""
+    exp_person = creator.people_tree_item_representation()
+    exp_person.system_wide_role = roles.ADMINISTRATOR
+    act_person = admin_webui_service.PeopleAdminWebUiService(
+        selenium).edit_authorizations(creator, roles.ADMINISTRATOR)
+    self.general_equal_assert(exp_person, act_person)


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:
- [x] #9330

# Solution description

*Add test to check that edit authorization works on WebUI.*

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
