### PR TITLE
GGRC-6527 Remove xfail handling for selenium tests

### DIFF
--- a/test/selenium/src/tests/test_workflow_page.py
+++ b/test/selenium/src/tests/test_workflow_page.py
@@ -7,7 +7,6 @@
 # pylint: disable=invalid-name
 import datetime
 import pytest
-from nerodia.wait.wait import TimeoutError
 
 from lib import base, url, users
 from lib.app_entity_factory import (
@@ -209,15 +208,8 @@ class TestActivateWorkflow(base.Test):
       workflow_rest_facade.create_task_group_task(
           task_group=task_group, assignees=[assignee], due_date=due_date)
       workflow_rest_service.WorkflowRestService().activate(app_workflow)
-      # handle GGRC-6527 only
-      try:
-        emails = daily_emails_ui_facade.get_emails_by_user_names(
-            [users.current_user().name, assignee.name])
-      except TimeoutError as err:
-        if "digest" in err.message:
-          pytest.xfail("GGRC-6527: Digest is not opened")
-        else:
-          raise err
+      emails = daily_emails_ui_facade.get_emails_by_user_names(
+          [users.current_user().name, assignee.name])
       TestActivateWorkflow._data = {
           "wf": app_workflow,
           "wf_creator_email": emails[users.current_user().name],


### PR DESCRIPTION
# Issue description

*Daily digest is not opened at CI nodes.*

# Steps to test the changes

*Run tests at CI and check that daily digests tests are not xfailed.*

# Solution description

*Remove xfail handling from tests for this issue.*

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
