### PR TITLE
GGRC-7224 Process PUT requests without headers validation for external systems

### DIFF
--- a/src/ggrc/services/__init__.py
+++ b/src/ggrc/services/__init__.py
@@ -5,6 +5,7 @@
 
 from ggrc.services import common
 from ggrc.services.registry import service
+from ggrc.services.resources import external_internal
 
 
 def contributed_services():
@@ -68,7 +69,9 @@ def contributed_services():
       service('systems_or_processes',
               models.SystemOrProcess,
               common.ReadOnlyResource),
-      service('systems', models.System),
+      service('systems',
+              models.System,
+              external_internal.ExternalInternalResource),
       service('processes', models.Process),
       service('metrics', models.Metric),
       service('notification_configs', models.NotificationConfig),

--- a/src/ggrc/services/resources/external_internal.py
+++ b/src/ggrc/services/resources/external_internal.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""API resource for models that can be as external as internal."""
+
+from ggrc import login
+from ggrc.services import common
+
+
+class ExternalInternalResource(common.Resource):
+  """Resource handler for models that can work as external and as internal."""
+  # pylint: disable=abstract-method
+
+  def validate_headers_for_put_or_delete(self, obj):
+    """Check ETAG for internal request and skip for external."""
+    if login.is_external_app_user():
+      return None
+    return super(
+        ExternalInternalResource, self
+    ).validate_headers_for_put_or_delete(obj)


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] https://github.com/google/ggrc-core/pull/9444

# Issue description

GGRC disable PUT request if it doesn't contain If-Match and If-Unmodified-Since headers, but if request comes from sync service it doesn't have such headers (and they are useless there), so headers validation should be skipped.

# Steps to test the changes

Send PUT requests to System endpoint without If-Match/If-Unmodified-Since headers (but with "X-external-user" header)

# Solution description

Inherit base Resource class with overriding header validation method.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
