### PR TITLE
GGRC-7252 Add commentText getter for last-comment

### DIFF
--- a/src/ggrc-client/js/components/last-comment/last-comment.js
+++ b/src/ggrc-client/js/components/last-comment/last-comment.js
@@ -6,7 +6,6 @@
 import template from './last-comment.stache';
 import RefreshQueue from '../../models/refresh_queue';
 import {peopleWithRoleName} from '../../plugins/utils/acl-utils.js';
-import isFunction from 'can-util/js/is-function/is-function';
 import {COMMENT_CREATED} from '../../events/eventTypes';
 import {formatDate} from '../../plugins/utils/date-utils';
 import Comment from '../../models/service-models/comment';
@@ -26,6 +25,20 @@ export default can.Component.extend({
 
           this.attr('comment', comment);
           return instance;
+        },
+      },
+      commentText: {
+        get() {
+          const html = this.attr('comment.description') || '';
+
+          const regexTags = /<[^>]*>?/g;
+          const regexNewLines = /<\/p>?/g;
+
+          let lines = html
+            .replace(regexNewLines, '\n')
+            .replace(regexTags, ' ')
+            .trim();
+          return lines;
         },
       },
     },
@@ -63,19 +76,6 @@ export default can.Component.extend({
     [`{instance} ${COMMENT_CREATED.type}`](instance, {comment}) {
       this.viewModel.attr('comment', comment);
       this.viewModel.getAuthor();
-    },
-  },
-  helpers: {
-    getText(html, options) {
-      let resolvedHtml = isFunction(html) ? html() : html || '';
-      const regexTags = /<[^>]*>?/g;
-      const regexNewLines = /<\/p>?/g;
-
-      let lines = resolvedHtml
-        .replace(regexNewLines, '\n')
-        .replace(regexTags, ' ')
-        .trim();
-      return lines;
     },
   },
 });

--- a/src/ggrc-client/js/components/last-comment/last-comment.stache
+++ b/src/ggrc-client/js/components/last-comment/last-comment.stache
@@ -4,5 +4,5 @@
 }}
 
 <div class="last-comment" rel="tooltip" data-original-title="{{tooltip}}">
-  {{getText comment.description}}
+  {{commentText}}
 </div>

--- a/src/ggrc-client/js/components/last-comment/last-comment_spec.js
+++ b/src/ggrc-client/js/components/last-comment/last-comment_spec.js
@@ -18,6 +18,24 @@ describe('last-comment component', () => {
     vm = getComponentVM(Component);
   });
 
+  describe('"commentText" get', () => {
+    beforeEach(() => {
+      vm.attr('comment', {});
+    });
+
+    it('returns comment description without tags', () => {
+      vm.attr('comment.description', '<a>ara</a>');
+
+      expect(vm.attr('commentText')).toBe('ara');
+    });
+
+    it('returns empty string if no description in comment', () => {
+      vm.attr('comment.description', null);
+
+      expect(vm.attr('commentText')).toBe('');
+    });
+  });
+
   describe('getAuthor() method', () => {
     let person;
 
@@ -39,10 +57,6 @@ describe('last-comment component', () => {
   });
 
   describe('tooltip() method', () => {
-    beforeEach(() => {
-
-    });
-
     describe('returns empty string', () => {
       it('if there is no comment', () => {
         vm.attr('comment', null);


### PR DESCRIPTION
It fixes issue when creating new assessment and there is no last_comment field.

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Uncaught TypeError: Cannot read property 'replace' of null" if select Last comment column in tree view for asmt

# Steps to test the changes

Steps to reproduce:
1. Open audit page
2. Create assessment 
3. Set Last comment column in tree view

Actual Result: "Uncaught TypeError: Cannot read property 'replace' of null" error is displayed, spinner rounds endlessly in tree view
Expected Result: no errors should be displayed, asmt should be displayed in tree view

# Solution description

Rewrite helper `getText` as getter for prop `commentText` using define plugin. Return empty string if there is no `last_comment` field in assessment.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
