### PR TITLE
GGRC-4200/GGRC-4202 Fix titles of copied Workflows & Task Groups

### DIFF
--- a/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
+++ b/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '6d7a0c2baba1'
-down_revision = 'bba307188ef6'
+down_revision = '87fa3c8cb442'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
+++ b/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add parent_id on Workflow and TaskGroup.
+
+Create Date: 2019-05-02 10:03:38.974599
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '6d7a0c2baba1'
+down_revision = '57b14cb4a7b4'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.add_column(
+      'task_groups', sa.Column('parent_id', sa.Integer(), nullable=True)
+  )
+  op.create_foreign_key(
+      None,
+      'task_groups',
+      'task_groups', ['parent_id'], ['id'],
+      ondelete='SET NULL'
+  )
+
+  op.add_column(
+      'workflows', sa.Column('parent_id', sa.Integer(), nullable=True)
+  )
+  op.create_foreign_key(
+      None,
+      'workflows',
+      'workflows', ['parent_id'], ['id'],
+      ondelete='SET NULL'
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  op.drop_column('workflows', 'parent_id')
+  op.drop_column('task_groups', 'parent_id')

--- a/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
+++ b/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '6d7a0c2baba1'
-down_revision = 'f2428adea671'
+down_revision = 'bba307188ef6'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
+++ b/src/ggrc/migrations/versions/20190502100338_6d7a0c2baba1_add_workflow_parent_id.py
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '6d7a0c2baba1'
-down_revision = '57b14cb4a7b4'
+down_revision = 'f2428adea671'
 
 
 def upgrade():

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -109,13 +109,16 @@ def get_copy_title(current_title, used_titles):
       used_titles (List[str]): List of object titles copied from the same
           parent
   """
+  copy_title = ''
   for copy_count in range(1, len(used_titles) + 2):
     title = COPY_TITLE_TEMPLATE % {
         'parent_title': current_title,
         'copy_count': copy_count
     }
     if title not in used_titles:
-      return title
+      copy_title = title
+      break
+  return copy_title
 
 
 def _get_min_next_due_date(due_dated_objects):

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -34,6 +34,7 @@ from ggrc_basic_permissions.contributed_roles import RoleContributions
 # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
 
+COPIED_TITLE_TEMPLATE = '%(parent_title)s (copy %(copy_count)s)'
 
 # Initialize Flask Blueprint for extension
 blueprint = Blueprint(
@@ -96,6 +97,25 @@ def contributed_object_views():
   return [
       object_view(models.Workflow),
   ]
+
+
+def get_copy_title(current_title, used_titles):
+  """Get's first available copy title from the list of titles.
+  In general, the convention is:
+    title = old_title + (copy N)
+
+  Args:
+      current_title (str): Title of the parent object
+      used_titles (List[str]): List of object titles copied from the same
+          parent
+  """
+  for copy_count in range(1, len(used_titles) + 2):
+    title = COPIED_TITLE_TEMPLATE % {
+        'parent_title': current_title,
+        'copy_count': copy_count
+    }
+    if title not in used_titles:
+      return title
 
 
 def _get_min_next_due_date(due_dated_objects):
@@ -547,7 +567,11 @@ def handle_task_group_post(sender, obj=None, src=None, service=None):  # noqa py
         clone_tasks=src.get('clone_tasks', False),
         clone_objects=src.get('clone_objects', False)
     )
-    obj.title = source_task_group.title + ' (copy ' + str(obj.id) + ')'
+
+    copied_task_groups = models.TaskGroup.query.filter_by(
+        parent_id=source_task_group.id).values('title')
+    used_titles = [t.title for t in copied_task_groups]
+    obj.title = get_copy_title(source_task_group.title, used_titles)
 
   obj.ensure_assignee_is_workflow_member()
   calculate_new_next_cycle_start_date(obj.workflow)
@@ -748,7 +772,11 @@ def handle_workflow_post(sender, obj=None, src=None, service=None):
         id=source_workflow_id
     ).first()
     source_workflow.copy(obj, clone_people=src.get('clone_people', False))
-    obj.title = source_workflow.title + ' (copy ' + str(obj.id) + ')'
+
+    copied_workflows = models.Workflow.query.filter_by(
+        parent_id=source_workflow.id).values('title')
+    used_titles = [w.title for w in copied_workflows]
+    obj.title = get_copy_title(source_workflow.title, used_titles)
 
   # get the personal context for this logged in user
   user = get_current_user(use_external_user=False)

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -569,6 +569,7 @@ def handle_task_group_post(sender, obj=None, src=None, service=None):  # noqa py
     )
 
     copied_task_groups = models.TaskGroup.query.filter_by(
+        workflow_id=source_task_group.workflow_id,
         parent_id=source_task_group.id).values('title')
     used_titles = [t.title for t in copied_task_groups]
     obj.title = get_copy_title(source_task_group.title, used_titles)

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -34,7 +34,7 @@ from ggrc_basic_permissions.contributed_roles import RoleContributions
 # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
 
-COPIED_TITLE_TEMPLATE = '%(parent_title)s (copy %(copy_count)s)'
+COPY_TITLE_TEMPLATE = '%(parent_title)s (copy %(copy_count)s)'
 
 # Initialize Flask Blueprint for extension
 blueprint = Blueprint(
@@ -110,7 +110,7 @@ def get_copy_title(current_title, used_titles):
           parent
   """
   for copy_count in range(1, len(used_titles) + 2):
-    title = COPIED_TITLE_TEMPLATE % {
+    title = COPY_TITLE_TEMPLATE % {
         'parent_title': current_title,
         'copy_count': copy_count
     }

--- a/src/ggrc_workflows/models/task_group.py
+++ b/src/ggrc_workflows/models/task_group.py
@@ -36,6 +36,11 @@ class TaskGroup(roleable.Roleable,
   __tablename__ = 'task_groups'
   _title_uniqueness = False
 
+  parent_id = db.Column(
+      db.Integer,
+      db.ForeignKey('task_groups.id', ondelete="SET NULL"),
+      nullable=True,
+  )
   workflow_id = db.Column(
       db.Integer,
       db.ForeignKey('workflows.id', ondelete="CASCADE"),
@@ -100,9 +105,10 @@ class TaskGroup(roleable.Roleable,
 
   def copy(self, _other=None, **kwargs):
     columns = [
-        'title', 'description', 'workflow', 'modified_by',
+        'title', 'description', 'parent_id', 'workflow', 'modified_by',
         'context'
     ]
+    kwargs['parent_id'] = self.id
 
     if kwargs.get('clone_people', False) and getattr(self, "contact"):
       columns.append("contact")

--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -57,6 +57,11 @@ class Workflow(roleable.Roleable,
   def default_status(cls):
     return cls.DRAFT
 
+  parent_id = db.Column(
+      db.Integer,
+      db.ForeignKey('workflows.id', ondelete="SET NULL"),
+      nullable=True,
+  )
   notify_on_change = deferred(
       db.Column(db.Boolean, default=False, nullable=False), 'Workflow')
   notify_custom_message = deferred(
@@ -375,7 +380,9 @@ class Workflow(roleable.Roleable,
                'start_date',
                'repeat_every',
                'unit',
+               'parent_id',
                'is_verification_needed']
+    kwargs['parent_id'] = self.id
     if kwargs.get('clone_people', False):
       access_control_list = [
           {

--- a/test/integration/ggrc_workflows/models/test_task_group.py
+++ b/test/integration/ggrc_workflows/models/test_task_group.py
@@ -2,10 +2,13 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """TaskGroup model related tests."""
 
+from mock import patch
+
 import ddt
 
 from ggrc.models import all_models
 from ggrc_workflows import ac_roles
+from integration.ggrc import generator
 from integration.ggrc.models import factories
 from integration.ggrc_workflows.helpers import rbac_helper
 from integration.ggrc_workflows.helpers import workflow_api
@@ -72,3 +75,32 @@ class TestTaskGroupApiCalls(workflow_test_case.WorkflowTestCase):
     data = workflow_api.get_task_group_clone_dict(task_group)
     response = self.api_helper.post(all_models.TaskGroup, data)
     self.assertEqual(response.status_code, 201)
+
+
+class TestCloneTaskGroup(workflow_test_case.WorkflowTestCase):
+  """Test clone TaskGroup operation."""
+
+  def setUp(self):
+    super(TestCloneTaskGroup, self).setUp()
+    self.object_generator = generator.ObjectGenerator()
+
+  @patch("ggrc_workflows.get_copy_title")
+  def test_clone_task_group(self, get_copy_title_patch):
+    """Check clone tg and if proper copy title set."""
+    expected_title = 'Copy Title'
+    get_copy_title_patch.return_value = expected_title
+
+    with factories.single_commit():
+      workflow = self.setup_helper.setup_workflow((rbac_helper.GC_RNAME,))
+      task_group = wf_factories.TaskGroupFactory(workflow=workflow)
+      cloned_task_group = wf_factories.TaskGroupFactory(
+          parent_id=task_group.id, workflow=workflow)
+
+    cloned_title = cloned_task_group.title
+
+    _, clone_wf = self.object_generator.generate_object(
+        all_models.TaskGroup, {"title": "TG - copy 1", "clone": task_group.id})
+    get_copy_title_patch.assert_called_once_with(
+        task_group.title, [cloned_title])
+    assert clone_wf.title == expected_title
+    assert clone_wf.parent_id == task_group.id

--- a/test/integration/ggrc_workflows/models/test_task_group.py
+++ b/test/integration/ggrc_workflows/models/test_task_group.py
@@ -98,9 +98,9 @@ class TestCloneTaskGroup(workflow_test_case.WorkflowTestCase):
 
     cloned_title = cloned_task_group.title
 
-    _, clone_wf = self.object_generator.generate_object(
+    _, clone_tg = self.object_generator.generate_object(
         all_models.TaskGroup, {"title": "TG - copy 1", "clone": task_group.id})
     get_copy_title_patch.assert_called_once_with(
         task_group.title, [cloned_title])
-    assert clone_wf.title == expected_title
-    assert clone_wf.parent_id == task_group.id
+    self.assertEqual(clone_tg.title, expected_title)
+    self.assertEqual(clone_tg.parent_id, task_group.id)

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -247,7 +247,7 @@ class TestCloneWorkflow(TestCase):
       (all_models.Workflow.WEEK_UNIT, 10),
   )
   @ddt.unpack
-  def test_workflow_copy(self, unit, repeat_every, title_patch):
+  def test_workflow_copy(self, unit, repeat_every):
     """Check clone wf with unit and repeat."""
     with factories.single_commit():
       workflow = wf_factories.WorkflowFactory(unit=unit,
@@ -258,7 +258,7 @@ class TestCloneWorkflow(TestCase):
     self.assertEqual(repeat_every, clone_wf.repeat_every)
 
   @patch("ggrc_workflows.get_copy_title")
-  def test_workflow_proper_copy_title_set(self, get_copy_title_patch):
+  def test_workflow_copy_title(self, get_copy_title_patch):
     """Check if get_copy_title is called with proper arguments."""
     expected_title = 'Copy Title'
     get_copy_title_patch.return_value = expected_title

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -271,8 +271,8 @@ class TestCloneWorkflow(TestCase):
         all_models.Workflow, {"title": "WF - copy 1", "clone": workflow.id})
     get_copy_title_patch.assert_called_once_with(
         workflow.title, [cloned_workflow.title])
-    assert clone_wf.title == expected_title
-    assert clone_wf.parent_id == workflow.id
+    self.assertEqual(clone_wf.title, expected_title)
+    self.assertEqual(clone_wf.parent_id, workflow.id)
 
 
 @ddt.ddt

--- a/test/integration/ggrc_workflows/test_api_calls.py
+++ b/test/integration/ggrc_workflows/test_api_calls.py
@@ -266,11 +266,12 @@ class TestCloneWorkflow(TestCase):
     with factories.single_commit():
       workflow = wf_factories.WorkflowFactory()
       cloned_workflow = wf_factories.WorkflowFactory(parent_id=workflow.id)
+      cloned_title = cloned_workflow.title
 
     _, clone_wf = self.object_generator.generate_object(
         all_models.Workflow, {"title": "WF - copy 1", "clone": workflow.id})
     get_copy_title_patch.assert_called_once_with(
-        workflow.title, [cloned_workflow.title])
+        workflow.title, [cloned_title])
     self.assertEqual(clone_wf.title, expected_title)
     self.assertEqual(clone_wf.parent_id, workflow.id)
 

--- a/test/unit/ggrc_workflows/models/test_workflow.py
+++ b/test/unit/ggrc_workflows/models/test_workflow.py
@@ -134,6 +134,7 @@ class TestWorkflowState(unittest.TestCase):
 
 @ddt.ddt
 class TestWorkflowUtils(unittest.TestCase):
+  """Test case of the workflow's utils file."""
 
   @ddt.data(
       ('Title', [], get_copy_name('Title', 1)),
@@ -142,5 +143,6 @@ class TestWorkflowUtils(unittest.TestCase):
   )
   @ddt.unpack
   def test_get_copy_title(self, current_title, used_titles, expected):
+    """Test if proper title is returned for all the cases."""
     result = get_copy_title(current_title, used_titles)
     self.assertEqual(result, expected)

--- a/test/unit/ggrc_workflows/models/test_workflow.py
+++ b/test/unit/ggrc_workflows/models/test_workflow.py
@@ -11,9 +11,18 @@ import ddt
 from freezegun import freeze_time
 from mock import patch
 
+from ggrc_workflows import COPIED_TITLE_TEMPLATE, get_copy_title
 from ggrc_workflows.models import cycle_task_group_object_task as cycle_task
 from ggrc_workflows.models import cycle
 from ggrc_workflows.models import workflow
+
+
+def get_copy_name(title, copy_count):
+  """Helper function to improve readibility in tests."""
+  return COPIED_TITLE_TEMPLATE % {
+      'parent_title': title,
+      'copy_count': copy_count
+  }
 
 
 @ddt.ddt
@@ -121,3 +130,17 @@ class TestWorkflowState(unittest.TestCase):
           expected,
           workflow.Workflow().calc_next_adjusted_date(setup_date)
       )
+
+
+@ddt.ddt
+class TestWorkflowUtils(unittest.TestCase):
+
+  @ddt.data(
+      ('Title', [], get_copy_name('Title', 1)),
+      ('Title', ['Other Title'], get_copy_name('Title', 1)),
+      ('Title', [get_copy_name('Title', 1)], get_copy_name('Title', 2))
+  )
+  @ddt.unpack
+  def test_get_copy_title(self, current_title, used_titles, expected):
+    result = get_copy_title(current_title, used_titles)
+    self.assertEqual(result, expected)

--- a/test/unit/ggrc_workflows/models/test_workflow.py
+++ b/test/unit/ggrc_workflows/models/test_workflow.py
@@ -11,15 +11,15 @@ import ddt
 from freezegun import freeze_time
 from mock import patch
 
-from ggrc_workflows import COPIED_TITLE_TEMPLATE, get_copy_title
+from ggrc_workflows import COPY_TITLE_TEMPLATE, get_copy_title
 from ggrc_workflows.models import cycle_task_group_object_task as cycle_task
 from ggrc_workflows.models import cycle
 from ggrc_workflows.models import workflow
 
 
 def get_copy_name(title, copy_count):
-  """Helper function to improve readibility in tests."""
-  return COPIED_TITLE_TEMPLATE % {
+  """Helper function to improve readability in tests."""
+  return COPY_TITLE_TEMPLATE % {
       'parent_title': title,
       'copy_count': copy_count
   }


### PR DESCRIPTION
# Issue description
When copied, Task Groups and Workflows were not named properly. After merging those changes, the general convention will be 
`name = old_name + (copy N)`

This PR resolves both  GGRC-4200 and GGRC-4202

# Steps to test the changes
### [GGRC-4200]
1. Create any 'workflow1'
2. In the "workflow info" tab click Clone Workflow in 3 bb's menu
3. Confirm that naming convention is `name = old_name + (copy N)`

### [GGRC-4202]
1. Create any 'workflow1'
2. In the "setup" tab click Clone Task Group in 3 bb's menu
3. Confirm that naming convention is `name = old_name + (copy N)`

# Solution description
Added a ForeignKey field `parent_id` to both Task Group and Workflow models. This field stores a reference to the parent model, from which it was originally copied. 

While naming the new copy, we iterate through all objects from the same parent, picking the first available copy naming, matching our convention `name = old_name + (copy N)`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO
- [x] Add unittests
