### PR TITLE
GGRC-7255 JS error while opening the change log tab

### DIFF
--- a/src/ggrc-client/js/components/revision-log/revision-page.js
+++ b/src/ggrc-client/js/components/revision-log/revision-page.js
@@ -553,6 +553,7 @@ export default can.Component.extend({
       let previous;
       let madeByPersonId;
       let automapping;
+      let person;
 
       if (revision.destination_type === this.attr('instance.type') &&
         revision.destination_id === this.attr('instance.id')) {
@@ -591,8 +592,11 @@ export default can.Component.extend({
         if (automapping.source instanceof Stub) {
           automapping.source = reify(automapping.source);
         }
-        const person = automapping.modified_by.name ||
-          automapping.modified_by.email;
+        if (revision.modified_by) {
+          person = revision.modified_by.name || revision.modified_by.email;
+        } else {
+          person = '"unknown" user';
+        }
         const automappingTitle =
           `(automapping triggered after ${person} mapped ` +
         `${automapping.destination.type} "${automapping.destination.title}"` +


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Change log can not be opened when there is no "modified_by" data in automapping revision.

# Steps to test the changes

***Preconditions:***
 * there is an object with the automapping revision where "modified_by" field is empty (e.g. automapping of issue: raised issue on assessment is automapped to audit)
 * automappings were performed before 2.3 release

***Steps:***

Open the "Change log" tab of the object

*Actual result:* Change log is loading, JS error occurs;
*Expected result:* Change log is displayed without errors;
# Solution description

- Use `modified_by` field from revision (not from automapping);
- Replace user name with `"unknown" user` if `modified_by` is empty;

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
