### PR TITLE
QUICK-FIX Canjs 3 migration fix global search

### DIFF
--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-container.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-container.js
@@ -30,7 +30,11 @@ let viewModel = AdvancedSearchContainer.extend({
       get: function (items) {
         if (this.attr('defaultStatusFilter') && items && !items.length &&
           StateUtils.hasFilter(this.attr('modelName'))) {
-          items.push(AdvancedSearch.create.state());
+          const statusItem = new can.Map(AdvancedSearch.create.state());
+          statusItem.value = AdvancedSearch.setDefaultStatusConfig(
+            statusItem.value, this.attr('modelName')
+          );
+          items.push(statusItem);
         }
         return items;
       },

--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.js
@@ -15,29 +15,10 @@ import {isScopeModel} from '../../plugins/utils/models-utils';
  */
 let viewModel = can.Map.extend({
   define: {
-    /**
-     * Contains criterion's fields: operator, modelName, items.
-     * Initializes fitlterStates.
-     * @type {can.Map}
-     */
-    stateModel: {
-      type: '*',
-      set: function (state) {
-        if (!state.attr('items')) {
-          let defaultStates =
-            StateUtils.getStatesForModel(this.attr('modelName'));
-          state.attr('items', defaultStates);
-        }
-        if (!state.attr('operator')) {
-          state.attr('operator', 'ANY');
-        }
-        state.attr('modelName', this.attr('modelName'));
-
-        let stateLabel = isScopeModel(this.attr('modelName')) ?
+    label: {
+      get() {
+        return isScopeModel(this.attr('modelName')) ?
           'Launch Status' : 'State';
-        state.attr('label', stateLabel);
-
-        return state;
       },
     },
     /**
@@ -83,6 +64,12 @@ let viewModel = can.Map.extend({
       value: true,
     },
   },
+  /**
+   * Contains criterion's fields: operator, modelName, items.
+   * Initializes filterStates.
+   * @type {can.Map}
+  */
+  stateModel: null,
   /**
    * Contains specific model name.
    * @type {string}

--- a/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.stache
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-filter-state.stache
@@ -5,7 +5,7 @@
 
 <div class="filter-state flex-box flex-box-multi">
   <div class="filter-state__name">
-    <h6>{{stateModel.label}}</h6>
+    <h6>{{label}}</h6>
   </div>
   {{#if showOperator}}
   <div class="filter-state__operator">

--- a/src/ggrc-client/js/components/advanced-search/advanced-search-wrapper.js
+++ b/src/ggrc-client/js/components/advanced-search/advanced-search-wrapper.js
@@ -44,12 +44,25 @@ export default can.Component.extend({
     resetFilters: function () {
       this.attr('filterItems', [AdvancedSearch.create.attribute()]);
       this.attr('mappingItems', []);
-      this.attr('statusItem.value', {});
+      this.setDefaultStatusItem();
+    },
+    setDefaultStatusItem: function () {
+      if (this.attr('hasStatusFilter')) {
+        const defaultStatusItem = AdvancedSearch.setDefaultStatusConfig(
+          this.attr('statusItem.value'), this.attr('modelName')
+        );
+        this.attr('statusItem.value', defaultStatusItem);
+      } else {
+        this.attr('statusItem', AdvancedSearch.create.state());
+      }
     },
   }),
   events: {
     '{viewModel} modelName': function () {
       this.viewModel.resetFilters();
     },
+  },
+  init: function () {
+    this.viewModel.setDefaultStatusItem();
   },
 });

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-filter-state_spec.js
@@ -5,8 +5,8 @@
 
 import * as StateUtils from '../../../plugins/utils/state-utils';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
-import * as ModelsUtils from '../../../plugins/utils/models-utils';
 import Component from '../advanced-search-filter-state';
+import * as ModelsUtils from '../../../plugins/utils/models-utils';
 
 describe('advanced-search-filter-state component', function () {
   'use strict';
@@ -17,56 +17,17 @@ describe('advanced-search-filter-state component', function () {
     viewModel = getComponentVM(Component);
   });
 
-  describe('stateModel set() method', function () {
-    let statesSpy;
+  describe('label getter', () => {
+    it('with "Launch Status" if it is scoping object', () => {
+      spyOn(ModelsUtils, 'isScopeModel').and.returnValue(true);
 
-    beforeEach(() => {
-      statesSpy = spyOn(StateUtils, 'getStatesForModel');
+      expect(viewModel.attr('label')).toBe('Launch Status');
     });
 
-    it('assigns states to items of stateModel if items is not defined',
-      function () {
-        let states = ['state1', 'state2', 'state3'];
-        statesSpy.and.returnValue(states);
-        viewModel.attr('modelName', 'Requirement');
+    it('with "State" if it is not scoping object', () => {
+      spyOn(ModelsUtils, 'isScopeModel').and.returnValue(false);
 
-        viewModel.attr('stateModel', new can.Map());
-
-        expect(viewModel.attr('stateModel.items').serialize())
-          .toEqual(states);
-      });
-
-    it('assigns "ANY" to operator if it is not defined', () => {
-      viewModel.attr('stateModel', new can.Map());
-
-      expect(viewModel.attr('stateModel.operator')).toBe('ANY');
-    });
-
-    it('assigns modelName with value from viewModel', () => {
-      let modelName = 'SomeModel';
-      viewModel.attr('modelName', modelName);
-
-      viewModel.attr('stateModel', new can.Map());
-
-      expect(viewModel.attr('stateModel.modelName')).toBe(modelName);
-    });
-
-    describe('assigns label of state', () => {
-      it('with "Launch Status" if it is scoping object', () => {
-        spyOn(ModelsUtils, 'isScopeModel').and.returnValue(true);
-
-        viewModel.attr('stateModel', new can.Map());
-
-        expect(viewModel.attr('stateModel.label')).toBe('Launch Status');
-      });
-
-      it('with "State" if it is not scoping object', () => {
-        spyOn(ModelsUtils, 'isScopeModel').and.returnValue(false);
-
-        viewModel.attr('stateModel', new can.Map());
-
-        expect(viewModel.attr('stateModel.label')).toBe('State');
-      });
+      expect(viewModel.attr('label')).toBe('State');
     });
   });
 

--- a/src/ggrc-client/js/components/advanced-search/tests/advanced-search-wrapper_spec.js
+++ b/src/ggrc-client/js/components/advanced-search/tests/advanced-search-wrapper_spec.js
@@ -5,12 +5,15 @@
 
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../advanced-search-wrapper';
+import * as AdvancedSearch from '../../../plugins/utils/advanced-search-utils';
+import * as StateUtils from '../../../plugins/utils/state-utils';
 
 describe('advanced-search-wrapper component', function () {
   'use strict';
 
   let viewModel;
   let events;
+  let spy;
   beforeEach(() => {
     viewModel = getComponentVM(Component);
     events = Component.prototype.events;
@@ -30,6 +33,24 @@ describe('advanced-search-wrapper component', function () {
       spyOn(viewModel, 'resetFilters');
       handler.call(that);
       expect(viewModel.resetFilters).toHaveBeenCalled();
+    });
+  });
+
+  describe('setDefaultStatusItem method', () => {
+    it('should call setDefaultStatusConfig if hasStatusFilter', () => {
+      spyOn(StateUtils, 'hasFilter').and.returnValue(true);
+      spy = spyOn(AdvancedSearch, 'setDefaultStatusConfig');
+
+      viewModel.setDefaultStatusItem();
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should call create.state if !hasStatusFilter', () => {
+      spyOn(StateUtils, 'hasFilter').and.returnValue(false);
+      spy = spyOn(AdvancedSearch.create, 'state');
+
+      viewModel.setDefaultStatusItem();
+      expect(spy).toHaveBeenCalled();
     });
   });
 });

--- a/src/ggrc-client/js/plugins/tests/advanced-search-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/advanced-search-utils_spec.js
@@ -402,4 +402,32 @@ describe('AdvancedSearch', () => {
       });
     });
   });
+
+  describe('setDefaultStatusConfig() function', () => {
+    let statesSpy;
+    const emptyStatusConfig = new can.Map(AdvancedSearch.create.state());
+    const createDummyStatusConfig = () => (
+      AdvancedSearch.setDefaultStatusConfig(emptyStatusConfig, 'someModel')
+    );
+
+    beforeEach(() => {
+      statesSpy = spyOn(StateUtils, 'getStatesForModel');
+    });
+
+    it("assigns states to items of statusConfig if items aren't defined",
+      () => {
+        let states = ['state1', 'state2', 'state3'];
+        statesSpy.and.returnValue(states);
+        const statusConfig = createDummyStatusConfig();
+
+        expect(statusConfig.attr('items').serialize()).toEqual(states);
+      }
+    );
+
+    it('assigns "ANY" to operator if it is not defined', () => {
+      const statusConfig = createDummyStatusConfig();
+
+      expect(statusConfig.attr('operator')).toBe('ANY');
+    });
+  });
 });

--- a/src/ggrc-client/js/plugins/utils/advanced-search-utils.js
+++ b/src/ggrc-client/js/plugins/utils/advanced-search-utils.js
@@ -200,3 +200,17 @@ export const buildFilter = (data, request) => {
   let result = builders.group(data, request);
   return result;
 };
+
+/**
+ * Fills statusItem with default values for passed modelName.
+ * @param {can.Map} state - Current state.
+ * @param {String} modelName - Name of the model to find states of.
+ * @return {can.Map} - updated state.
+ */
+export const setDefaultStatusConfig = (state, modelName) => {
+  const items = StateUtils.getStatesForModel(modelName);
+  state.attr('items', items);
+  state.attr('operator', 'ANY');
+  state.attr('modelName', modelName);
+  return state;
+};


### PR DESCRIPTION
# Issue description

Search for Cycle Tasks doesn't properly work:
Default selected Status is Deprecated (should be selected all statuses)

# Steps to test the changes

Open global search
Select Cycle Tasks object type

# Solution description

The root cause is the fact, that when we update modelName somehow, stateModel setter is called before modelName is actually updated. Thus in this line we have old modelName, so we get states for old modelName. To fix it, I remove setter, put its code into a separate function, called in search-wrapper and advanced-search-filter-container, which are wrappers for the advanced-search-filter-state

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
