### PR TITLE
GGRC-7057 Fix issue when checkbox becomes unchecked after clicking 'show more' link for reusable objects

### DIFF
--- a/src/ggrc-client/js/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc-client/js/components/reusable-objects/reusable-objects-item.js
@@ -40,7 +40,7 @@ export default can.Component.extend({
         }
       }
     },
-    '{viewModel.selectedList} change'() {
+    '{viewModel.selectedList} length'() {
       this.viewModel.setIsChecked();
     },
   },

--- a/src/ggrc-client/js/components/reusable-objects/reusable-objects-item.js
+++ b/src/ggrc-client/js/components/reusable-objects/reusable-objects-item.js
@@ -15,8 +15,18 @@ export default can.Component.extend({
     instance: {},
     selectedList: [],
     isChecked: false,
+    setIsChecked() {
+      let instance = this.attr('instance');
+      let list = this.attr('selectedList');
+      let index = $.makeArray(list).indexOf(instance);
+
+      this.attr('isChecked', index >= 0);
+    },
   }),
   events: {
+    init() {
+      this.viewModel.setIsChecked();
+    },
     '{viewModel} isChecked'(viewModel, ev, isChecked) {
       let list = viewModel.attr('selectedList');
       let instance = viewModel.attr('instance');
@@ -30,11 +40,8 @@ export default can.Component.extend({
         }
       }
     },
-    '{viewModel.selectedList} change'(list) {
-      let instance = this.viewModel.attr('instance');
-      let index = $.makeArray(list).indexOf(instance);
-
-      this.viewModel.attr('isChecked', index >= 0);
+    '{viewModel.selectedList} change'() {
+      this.viewModel.setIsChecked();
     },
   },
 });

--- a/src/ggrc-client/js/components/reusable-objects/tests/reusable-objects-item_spec.js
+++ b/src/ggrc-client/js/components/reusable-objects/tests/reusable-objects-item_spec.js
@@ -4,22 +4,21 @@
  */
 
 import Component from '../reusable-objects-item.js';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
 
 describe('reusable-object-item component', () => {
   describe('events', () => {
     let viewModel;
     let events;
     beforeEach(() => {
-      viewModel = new can.Map({
-        instance: {},
-      });
+      viewModel = getComponentVM(Component);
       events = Component.prototype.events;
     });
 
     describe('"{viewModel} isChecked" event handler', () => {
       let handler;
       beforeEach(() => {
-        handler = events['{viewModel} isChecked'];
+        handler = events['{viewModel} isChecked'].bind({viewModel});
       });
 
       it('pushes instance to the list if isChecked is true', () => {
@@ -48,10 +47,10 @@ describe('reusable-object-item component', () => {
       });
     });
 
-    describe('"{viewModel.selectedList} change" event handler', () => {
+    describe('"{viewModel.selectedList} length" event handler', () => {
       let handler;
       beforeEach(() => {
-        handler = events['{viewModel.selectedList} change'];
+        handler = events['{viewModel.selectedList} length'].bind({viewModel});
       });
 
       it('turns ON isChecked flag if instance is in list', () => {
@@ -61,8 +60,9 @@ describe('reusable-object-item component', () => {
           {id: 2},
         ];
         viewModel.attr('isChecked', false);
+        viewModel.attr('selectedList', list);
 
-        handler.call({viewModel}, list);
+        handler();
 
         expect(viewModel.attr('isChecked')).toBe(true);
       });
@@ -73,8 +73,9 @@ describe('reusable-object-item component', () => {
           {id: 2},
         ];
         viewModel.attr('isChecked', true);
+        viewModel.attr('selectedList', list);
 
-        handler.call({viewModel}, list);
+        handler();
 
         expect(viewModel.attr('isChecked')).toBe(false);
       });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If select url/file to reuse, checkbox becomes unchecked after clicking 'show more' link

# Steps to test the changes

Steps to reproduce:
1. Log in ggrc-app and open any audit page with mapped control snapshot
2. Generate two assessments based on the control snapshot
3. Add evidence file and url to one assessment 
4. Open second assessment info panel > Related assessment tab
5. Check checkboxes to reuse evidence file and url
6. Click on 'show more' link: checkboxes got unchecked
7. Check one checkbox: the second becomes selected

**Actual Result:** If select url/file to reuse, checkbox becomes unchecked after clicking 'show more' link
**Expected Result:** If select url/file to reuse, checkbox should not be unchecked after clicking 'show more' link

# Solution description

`show-more` component rewrites content on every click on `show more/show less` link. 
So setting `isChecked` on `reusable-objects-item` init fixes the issue.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
