### PR TITLE
QUICK-FIX Improve deferred transaction tests

### DIFF
--- a/src/ggrc-client/js/plugins/tests/utils/deferred-transaction-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/deferred-transaction-utils_spec.js
@@ -34,9 +34,9 @@ describe('DeferredTransaction module', function () {
     });
     setTimeout(function () {
       deferredTransaction.push(action).then(function () {
-        done();
         expect(completeTransactionCount).toBe(1);
         expect(completeActionsCount).toBe(2);
+        done();
       });
     }, 150);
   });
@@ -46,9 +46,9 @@ describe('DeferredTransaction module', function () {
     deferredTransaction.push(action);
     setTimeout(function () {
       deferredTransaction.push(action).then(function () {
-        done();
         expect(completeTransactionCount).toBe(1);
         expect(completeActionsCount).toBe(2);
+        done();
       });
     }, 50);
   });

--- a/src/ggrc-client/js/plugins/tests/utils/deferred-transaction-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/deferred-transaction-utils_spec.js
@@ -61,6 +61,6 @@ describe('DeferredTransaction module', function () {
         expect(completeTransactionCount).toBe(1);
         expect(completeActionsCount).toBe(2);
         done();
-      }, 0);
+      }, 10);
     });
 });


### PR DESCRIPTION
# Issue description

The strange code in deferred transaction tests.

And sometimes the last test fails on my PC.
[Related comment in CanJS 3 migration PR](https://github.com/google/ggrc-core/pull/9198#issuecomment-489145126)

# Steps to test the changes

Run `run_karma` inside container

# Solution description

Move call of the `done` callback after all expectations and increase the timeout in the last test.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".