### PR TITLE
GGRC-203 Filter rich text using '=' and '!=' operators

### DIFF
--- a/test/selenium/src/lib/utils/filter_utils.py
+++ b/test/selenium/src/lib/utils/filter_utils.py
@@ -76,6 +76,11 @@ class FilterUtils(object):
       date_formats = ["%m/%d/%Y", "%m/%Y", "%Y-%m-%d", "%Y-%m", "%Y"]
       date = parser.parse(cav.attribute_value).date()
       values_to_filter = [date.strftime(_format) for _format in date_formats]
+    elif ca_type == AdminWidgetCustomAttributes.RICH_TEXT:
+      if operator == alias.EQUAL_OP:
+        values_to_filter = ['<p>' + cav.attribute_value + '</p>']
+      else:
+        values_to_filter = [cav.attribute_value]
     else:
       values_to_filter = [cav.attribute_value]
     return [self.get_filter_exp(cad.title, operator, [val])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Filtering by RichText attribute doesn't work properly with '=' and '!=' condition operators 

# Steps to test the changes

1. Log in to ggrc app as admin.
2. Create one global custom attribute, of Rich Text field for assessments, such as 'GCA_RICH_TEXT1' .
3. Create three assessments namely: 'My Assessment1',  'My Assessment2', and  'My Assessment3'.
4. For 'My Assessment1', Update values of 'GCA_RICH_TEXT1'  as '123'  and 'Notes' as 'This is notes'
5. For 'My Assessment2', Update values of 'GCA_RICH_TEXT1'  as 'gca rich text' and 'Notes' as 'This is notes'.
6. For 'My Assessment3', Update values of 'GCA_RICH_TEXT1' as '123'.
7. Then try the following queries in the filter:
   a.  GCA_RICH_TEXT1="123"   - It must filter assessments : 'My Assessment1', 'My Assessment3'
   b. GCA_RICH_TEXT1!="123" - It must filter assessments : 'My Assessment2'
   c. notes="This is notes" - It must filter assessments : 'My Assessment1', 'My Assessment2'
   d. notes!="This is notes" - It must filter assessments : 'My Assessment3'

# Solution description

* The function 'build_op_shortcut' in 'src/ggrc/query/custom_operators.py' is modified such that '\<p\>' and '\</p\>' are added to input text, while searching rich text fields using '=' and '!=' operators.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
