### PR TITLE
GGRC-7116 BE: Latency while downloading Assessment CSV import template 

### DIFF
--- a/src/ggrc/converters/import_helper.py
+++ b/src/ggrc/converters/import_helper.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_object_column_definitions(object_class, fields=None,
-                                  include_hidden=False):
+                                  include_hidden=False, template_ids=()):
   """Attach additional info to attribute definitions.
 
   Fetches the attribute info (_aliases) for the given object class and adds
@@ -35,6 +35,8 @@ def get_object_column_definitions(object_class, fields=None,
     include_hidden (bool): Flag which specifies if we should include column
       handlers for hidden attributes (they marked as 'hidden'
       in _aliases dict).
+    template_ids (iterable): for objects that have related templates add
+      attributes filtering by template ids
 
   Returns:
     dict: Updated attribute definitions dict with additional data.
@@ -42,7 +44,8 @@ def get_object_column_definitions(object_class, fields=None,
   attributes = AttributeInfo.get_object_attr_definitions(
       object_class,
       fields=fields,
-      include_hidden=include_hidden
+      include_hidden=include_hidden,
+      template_ids=template_ids,
   )
   column_handlers = model_column_handlers(object_class)
   for key, attr in attributes.iteritems():

--- a/src/ggrc/models/mixins/customattributable.py
+++ b/src/ggrc/models/mixins/customattributable.py
@@ -429,16 +429,45 @@ class CustomAttributable(object):
       # self.custom_attribute_values.append(new_value)
 
   @classmethod
-  def get_custom_attribute_definitions(cls, field_names=None):
-    """Get all applicable CA definitions (even ones without a value yet)."""
+  def get_custom_attribute_definitions(cls, field_names=None, template_ids=()):
+    """
+      Get all applicable CA definitions (even ones without a value yet).
+
+      Arguments:
+
+        cls (db.Model inherited class) - class to find local and global
+          custom attributes for
+        field_name (iterable of strings) - field names to gather (unless
+          mandatory)
+        template_id (iterable of integers) - when gathering fields from
+          local custom attributes use assessment templates with ids from
+          given list
+
+      Returns:
+
+        db.query object with corresponding filters
+    """
     from ggrc.models.custom_attribute_definition import \
         CustomAttributeDefinition as cad
 
     if cls.__name__ == "Assessment":
-      query = cad.query.filter(or_(
+      or_conditions = [
           cad.definition_type == utils.underscore_from_camelcase(cls.__name__),
-          cad.definition_type == "assessment_template",
-      ))
+      ]
+
+      if template_ids:
+        or_conditions.append(
+            and_(
+                cad.definition_type == "assessment_template",
+                cad.definition_id.in_(template_ids),
+            )
+        )
+      else:
+        or_conditions.append(
+            cad.definition_type == "assessment_template",
+        )
+
+      query = cad.query.filter(or_(*or_conditions))
     else:
       query = cad.query.filter(
           cad.definition_type == utils.underscore_from_camelcase(cls.__name__)

--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -397,8 +397,8 @@ class AttributeInfo(object):
     return definitions
 
   @classmethod
-  def get_custom_attr_definitions(cls, object_class,
-                                  ca_cache=None, fields=None):
+  def get_custom_attr_definitions(cls, object_class, ca_cache=None,
+                                  fields=None, template_ids=()):
     """Get column definitions for custom attributes on object_class.
 
     Args:
@@ -417,7 +417,10 @@ class AttributeInfo(object):
     if isinstance(ca_cache, dict) and object_name:
       custom_attributes = ca_cache.get(object_name, [])
     else:
-      custom_attributes = object_class.get_custom_attribute_definitions(fields)
+      custom_attributes = object_class.get_custom_attribute_definitions(
+          fields,
+          template_ids=template_ids,
+      )
     for attr in custom_attributes:
       description = attr.helptext or u""
       if (attr.attribute_type == attr.ValidTypes.DROPDOWN and
@@ -459,8 +462,10 @@ class AttributeInfo(object):
     return set(sum(unique_columns, []))
 
   @classmethod
+  # pylint: disable=too-many-arguments
   def get_object_attr_definitions(cls, object_class, ca_cache=None,
-                                  fields=None, include_hidden=False):
+                                  fields=None, include_hidden=False,
+                                  template_ids=()):
     """Get all column definitions for object_class.
 
     This function joins custom attribute definitions, mapping definitions and
@@ -474,7 +479,6 @@ class AttributeInfo(object):
         in _aliases dict).
     """
     definitions = {}
-
     aliases = AttributeInfo.gather_visible_aliases(object_class).items()
 
     # push the extra delete column at the end to override any custom behavior
@@ -514,9 +518,11 @@ class AttributeInfo(object):
 
     if object_class.__name__ not in EXCLUDE_CUSTOM_ATTRIBUTES:
       definitions.update(cls.get_custom_attr_definitions(
-          object_class, ca_cache=ca_cache, fields=fields
+          object_class,
+          ca_cache=ca_cache,
+          fields=fields,
+          template_ids=template_ids,
       ))
-
     if object_class.__name__ not in EXCLUDE_MAPPINGS:
       definitions.update(cls.get_mapping_definitions(object_class))
 

--- a/src/ggrc/views/converters.py
+++ b/src/ggrc/views/converters.py
@@ -151,11 +151,17 @@ def get_csv_template(objects):
   """Make csv template"""
   for object_data in objects:
     class_name = object_data["object_name"]
+    template_ids = tuple(object_data.get("template_ids", []))
+
     object_class = EXPORTABLES_MAP[class_name]
     ignore_fields = IGNORE_FIELD_IN_TEMPLATE.get(class_name, [])
+
     filtered_fields = [
         field for field in
-        import_helper.get_object_column_definitions(object_class)
+        import_helper.get_object_column_definitions(
+            object_class,
+            template_ids=template_ids,
+        )
         if field not in ignore_fields
     ]
     object_data["fields"] = filtered_fields

--- a/test/integration/ggrc/converters/test_assessment_csv_template.py
+++ b/test/integration/ggrc/converters/test_assessment_csv_template.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2019 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# pylint: disable=invalid-name
 
 """Tests attributes order in csv file for assessments."""
 
@@ -41,3 +42,224 @@ class TestAssessmentCSVTemplate(TestCase):
     objects = [{"object_name": "Assessment"}]
     response = self.export_csv_template(objects)
     self.assertNotIn("Evidence File", response.data)
+
+  def test_generation_with_template_ids_given_0(self):
+    """
+      Test generation of csv file with extra filtering by
+      ids of related assessment templates.
+
+      0 - test that only assessment templates with given
+      ids are used while gathering local custom attribute
+      definitions
+    """
+
+    included_template_ids = []
+
+    with factories.single_commit():
+      included_template = factories.AssessmentTemplateFactory()
+      excluded_template = factories.AssessmentTemplateFactory()
+
+      assessment = factories.AssessmentFactory()
+      assessment.audit = included_template.audit
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD",
+          definition_id=included_template.id,
+      )
+
+      included_template_ids.append(included_template.id)
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 0",
+      )
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Excluded LCAD",
+          definition_id=excluded_template.id
+      )
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 1",
+      )
+
+    objects = [{
+        "object_name": "Assessment",
+        "template_ids": included_template_ids,
+    }]
+
+    response = self.export_csv_template(objects)
+
+    self.assertIn('Included LCAD', response.data)
+    self.assertNotIn("Excluded LCAD", response.data)
+
+  def test_generation_with_template_ids_given_1(self):
+    """
+      Test generation of csv file with extra filtering by
+      ids of related assessment templates.
+
+      1 - test that global custom attribute definitions
+      are not filtered out by template_ids related filter.
+    """
+
+    included_template_ids = []
+
+    with factories.single_commit():
+      included_template = factories.AssessmentTemplateFactory()
+
+      assessment = factories.AssessmentFactory()
+      assessment.audit = included_template.audit
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD",
+          definition_id=included_template.id,
+      )
+
+      included_template_ids.append(included_template.id)
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 0",
+      )
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment",
+          title="Included GCAD",
+          definition_id=None
+      )
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 1",
+      )
+
+    objects = [{
+        "object_name": "Assessment",
+        "template_ids": included_template_ids,
+    }]
+
+    response = self.export_csv_template(objects)
+
+    self.assertIn('Included LCAD', response.data)
+    self.assertIn("Included GCAD", response.data)
+
+  def test_generation_with_template_ids_given_2(self):
+    """
+      Test generation of csv file with extra filtering by
+      ids of related assessment templates.
+
+      2 - test that multiple assessment templates ids are
+      processed properly.
+    """
+
+    included_template_ids = []
+
+    with factories.single_commit():
+      included_template_0 = factories.AssessmentTemplateFactory()
+      included_template_1 = factories.AssessmentTemplateFactory()
+
+      excluded_template = factories.AssessmentTemplateFactory()
+
+      assessment = factories.AssessmentFactory()
+      assessment.audit = included_template_0.audit
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD 0",
+          definition_id=included_template_0.id,
+      )
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 0",
+      )
+
+      included_template_ids.append(included_template_0.id)
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD 1",
+          definition_id=included_template_1.id,
+      )
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 1",
+      )
+
+      included_template_ids.append(included_template_1.id)
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Excluded LCAD",
+          definition_id=excluded_template.id
+      )
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 2",
+      )
+
+    objects = [{
+        "object_name": "Assessment",
+        "template_ids": included_template_ids,
+    }]
+
+    response = self.export_csv_template(objects)
+
+    self.assertIn('Included LCAD 0', response.data)
+    self.assertIn('Included LCAD 1', response.data)
+    self.assertNotIn("Excluded LCAD", response.data)
+
+  def test_generation_without_template_ids_given(self):
+    """
+      Test generation of csv file without extra filtering by
+      ids of related assessment templates.
+    """
+
+    with factories.single_commit():
+      included_template_0 = factories.AssessmentTemplateFactory()
+      included_template_1 = factories.AssessmentTemplateFactory()
+
+      assessment = factories.AssessmentFactory()
+      assessment.audit = included_template_0.audit
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD 0",
+          definition_id=included_template_0.id,
+      )
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 0",
+      )
+
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment_template",
+          title="Included LCAD 1",
+          definition_id=included_template_1.id
+      )
+
+      factories.CustomAttributeValueFactory(
+          custom_attribute=cad,
+          attributable=assessment,
+          attribute_value="Test CAD 1",
+      )
+
+    objects = [{"object_name": "Assessment"}]
+
+    response = self.export_csv_template(objects)
+
+    self.assertIn('Included LCAD 0', response.data)
+    self.assertIn("Included LCAD 1", response.data)


### PR DESCRIPTION
To limit number of fields included in generated CSV file for Assessments extra filtering by template ids is implemented.

# Issue description

New user interface feature was implemented for downloading template CSV import file. Now user can select assessment templates which should be used for gathering custom attributes to include in CSV file thus limiting number of processed assessment templates thus speeding up CSV file generation. Previously if many assessment templates existed it took too long to process all of their custom attributes to generate template CSV import file.

# Steps to test the changes

1. Log in to GGRC-TEST
2. Open Import page
3. Click on 'Download Import Template' > Select 'Assessment' object type from the list
4. Select Assessment templates to use for custom attributes gathering <- new UI feature [GGRC-5880]
4. Click on 'Download CSV'

# Solution description

Added support for optional parameter for get_object_attr_definitions. If object_type is Assessment that attribute is processed to filter processed assessment templates by given ids.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
