### PR TITLE
GGRC-7290 Change "risk type" field from mandatory to optional

### DIFF
--- a/src/ggrc/migrations/versions/20190511_b194e332fa65_change_risk_type_to_optional.py
+++ b/src/ggrc/migrations/versions/20190511_b194e332fa65_change_risk_type_to_optional.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Change 'risk_type' to optional
+
+Create Date: 2019-05-11 11:25:04.552633
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'b194e332fa65'
+down_revision = '9d89d2061961'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  script = """ALTER TABLE risks MODIFY risk_type text"""
+  op.execute(script)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/models/risk.py
+++ b/src/ggrc/models/risk.py
@@ -77,19 +77,10 @@ class Risk(synchronizable.Synchronizable,
     return deferred(db.Column(db.Text, nullable=False, default=u""),
                     cls.__name__)
 
-  risk_type = db.Column(db.Text, nullable=False)
+  risk_type = db.Column(db.Text, nullable=True)
   threat_source = db.Column(db.Text, nullable=True)
   threat_event = db.Column(db.Text, nullable=True)
   vulnerability = db.Column(db.Text, nullable=True)
-
-  @validates("risk_type")
-  def validate_risk_type(self, key, value):
-    """Validate risk_type"""
-    #  pylint: disable=unused-argument,no-self-use
-    if value:
-      return value
-    else:
-      raise ValueError("Risk Type value shouldn't be empty")
 
   @validates('review_status')
   def validate_review_status(self, _, value):
@@ -153,7 +144,7 @@ class Risk(synchronizable.Synchronizable,
       },
       "risk_type": {
           "display_name": "Risk Type",
-          "mandatory": True
+          "mandatory": False
       },
       "threat_source": {
           "display_name": "Threat Source",

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -850,7 +850,6 @@ class TestGetObjectColumnDefinitions(TestCase):
             "Description",
             "Admin",
             "Title",
-            "Risk Type",
         },
         "unique": {
             "Code",

--- a/test/integration/ggrc/services/test_revision_history.py
+++ b/test/integration/ggrc/services/test_revision_history.py
@@ -242,7 +242,7 @@ class TestRevisionHistory(TestCase):
                   'description', 'title', 'slug', 'folder']},
       {"factory": factories.RiskFactory,
        "fields": ['test_plan', 'status', 'description', 'external_id',
-                  'notes', 'title', 'slug', 'folder', 'risk_type']},
+                  'notes', 'title', 'slug', 'folder']},
   )
   @ddt.unpack
   def test_get_mandatory_fields(self, factory, fields):


### PR DESCRIPTION
# Issue description
Column "risk_type" for "Risk" model should be changed from mandatory to optional

# Steps to test the changes
Check scheme before and after migration - "risk_type" should be optional after migration
Create risk object without risk type
Check create/update Risk on UI - "risk_type" should be optional


# Solution description
Update back-end implementation for "risk_type" column
Update initial scheme with "risk_type"
Add migration for make "risk_type" optional

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
