### PR TITLE
GGRC-7059 Removes ability to modify relationships via PUT method

### DIFF
--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -352,7 +352,6 @@ class AutoStatusChangeable(object):
       cls.handle_acl_edit(obj)
 
     @signals.Restful.model_posted.connect_via(relationship.Relationship)
-    @signals.Restful.model_put.connect_via(relationship.Relationship)
     @signals.Restful.model_deleted.connect_via(relationship.Relationship)
     def handle_relationship(sender, obj=None, src=None, service=None):
       """Handle creation of relationships that can change object status.

--- a/src/ggrc/models/mixins/rest_handable.py
+++ b/src/ggrc/models/mixins/rest_handable.py
@@ -71,10 +71,6 @@ class WithRelationshipsHandable(object):
     """relationship POST handler"""
     pass
 
-  def handle_relationship_put(self, counterparty):
-    """relationship PUT handler"""
-    pass
-
   def handle_relationship_delete(self, counterparty):
     """relationship DELETE handler"""
     pass
@@ -111,15 +107,6 @@ class WithRelationshipsHandable(object):
         return
       obj, counterparty = get_obj_counterparty(relationship)
       model.handle_relationship_post(obj, counterparty)
-
-    @signals.Restful.model_put.connect_via(all_models.Relationship)
-    def relationship_updated(*args, **kwargs):
-      """relationship PUT handler"""
-      relationship = kwargs["obj"]
-      if not is_in_relationship(relationship):
-        return
-      obj, counterparty = get_obj_counterparty(relationship)
-      model.handle_relationship_put(obj, counterparty)
 
     @signals.Restful.model_deleted.connect_via(all_models.Relationship)
     def relationship_delete(*args, **kwargs):

--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -448,7 +448,6 @@ def register_handlers():  # noqa: C901
       handle_comment_created(obj, src)
 
   @signals.Restful.model_posted.connect_via(models.Relationship)
-  @signals.Restful.model_put.connect_via(models.Relationship)
   @signals.Restful.model_deleted.connect_via(models.Relationship)
   def relationship_altered_listener(sender, obj=None, src=None, service=None):
     """Listener for modified relationships."""

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -14,7 +14,6 @@ import itertools
 import json
 import logging
 import time
-import re
 
 from wsgiref.handlers import format_date_time
 from urllib import urlencode
@@ -627,9 +626,6 @@ class Resource(ModelView):
   @utils.validate_mimetype("application/json")
   def put(self, id):  # pylint: disable=redefined-builtin
     """PUT operation handler."""
-
-    if re.findall('/api/relationships/[0-9]+$', self.request.url):
-      raise MethodNotAllowed()
     with benchmark("Query for object"):
       obj = self.get_object(id)
     if obj is None:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -14,6 +14,7 @@ import itertools
 import json
 import logging
 import time
+import re
 
 from wsgiref.handlers import format_date_time
 from urllib import urlencode
@@ -626,6 +627,9 @@ class Resource(ModelView):
   @utils.validate_mimetype("application/json")
   def put(self, id):  # pylint: disable=redefined-builtin
     """PUT operation handler."""
+
+    if re.findall('/api/relationships/[0-9]+$', self.request.url):
+      raise MethodNotAllowed()
     with benchmark("Query for object"):
       obj = self.get_object(id)
     if obj is None:

--- a/src/ggrc/services/resources/relationship.py
+++ b/src/ggrc/services/resources/relationship.py
@@ -112,3 +112,7 @@ class RelationshipResource(ggrc.services.common.Resource):
       return None
 
     return super(RelationshipResource, self).json_create(obj, src)
+
+  def put(self, id):  # pylint: disable=redefined-builtin
+    """Disable ability to make PUT operation handler."""
+    raise MethodNotAllowed()

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -23,7 +23,6 @@ from ggrc.models import CustomAttributeValue
 from ggrc.models import Notification
 from ggrc.models import NotificationType
 from ggrc.models import Revision
-from ggrc.models import Relationship
 from ggrc.models import all_models
 from ggrc.utils import errors
 from integration.ggrc import TestCase
@@ -1178,10 +1177,9 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
 
     # assign another Assignee, change notification should be created
     person2 = factories.PersonFactory()
-    response, relationship2 = self.objgen.generate_relationship(
+    response, _ = self.objgen.generate_relationship(
         person2, asmt, attrs={"AssigneeType": "Assignees"})
     self.assertEqual(response.status_code, 201)
-    rel2_id = relationship2.id
 
     change_notifs = self._get_notifications(notif_type="assessment_updated")
     self.assertEqual(change_notifs.count(), 1)
@@ -1191,13 +1189,6 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
     self.client.get("/_notifications/send_daily_digest")
     self.assertEqual(change_notifs.count(), 0)
     asmt = Assessment.query.get(asmts["A 5"].id)
-    relationship2 = Relationship.query.get(rel2_id)
-
-    self.api_helper.modify_object(
-        relationship2, {"AssigneeType": "Assignees,Verifiers"})
-
-    change_notifs = self._get_notifications(notif_type="assessment_updated")
-    self.assertEqual(change_notifs.count(), 0)
 
     # clear notifications, delete an Assignee, test for change notification
     self.client.get("/_notifications/send_daily_digest")
@@ -1212,14 +1203,6 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
     # clear notifications, delete one of the person's roles, test for
     # change notification
     self.client.get("/_notifications/send_daily_digest")
-    self.assertEqual(change_notifs.count(), 0)
-    asmt = Assessment.query.get(asmts["A 5"].id)
-    relationship2 = Relationship.query.get(rel2_id)
-
-    self.api_helper.modify_object(
-        relationship2, {"AssigneeType": "Assignees"})  # not Verifier anymore
-
-    change_notifs = self._get_notifications(notif_type="assessment_updated")
     self.assertEqual(change_notifs.count(), 0)
 
     # changing people if completed should result in "reopened" notification

--- a/test/integration/ggrc/notifications/test_assignable_notifications.py
+++ b/test/integration/ggrc/notifications/test_assignable_notifications.py
@@ -1197,7 +1197,7 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
         relationship2, {"AssigneeType": "Assignees,Verifiers"})
 
     change_notifs = self._get_notifications(notif_type="assessment_updated")
-    self.assertEqual(change_notifs.count(), 1)
+    self.assertEqual(change_notifs.count(), 0)
 
     # clear notifications, delete an Assignee, test for change notification
     self.client.get("/_notifications/send_daily_digest")
@@ -1220,7 +1220,7 @@ class TestAssignableNotificationUsingAPI(TestAssignableNotification):
         relationship2, {"AssigneeType": "Assignees"})  # not Verifier anymore
 
     change_notifs = self._get_notifications(notif_type="assessment_updated")
-    self.assertEqual(change_notifs.count(), 1)
+    self.assertEqual(change_notifs.count(), 0)
 
     # changing people if completed should result in "reopened" notification
 

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -287,20 +287,22 @@ class TestServices(TestCase):
     check_response_409(response_date_invalid)
 
   def test_put_relationship_405(self):
-    """
-    This test ensures that put method to the
-    /api/relationships/<id>/ PUT method not allowed
-    """
-    assessment = factories.AssessmentFactory()
-    assessment_2 = factories.AssessmentFactory()
-    evidence = factories.EvidenceUrlFactory()
-    rel_id = factories.RelationshipFactory(source=assessment,
-                                           destination=evidence).id
+    """Ensures that ability to modify relationships via PUT was removed"""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      assessment_id = assessment.id
+      assessment_2 = factories.AssessmentFactory()
+      evidence = factories.EvidenceUrlFactory()
+      rel_id = factories.RelationshipFactory(source=assessment,
+                                             destination=evidence).id
+
     relationship = all_models.Relationship.query.get(rel_id)
     response = self.api.put(relationship, {"relationship": {
-        "id": assessment_2.id, "type": assessment_2.type
+        "source": {"id": assessment_2.id, "type": assessment_2.type},
+        "destination": {"id": evidence.id, "type": evidence.type},
     }})
     self.assert405(response)
+    self.assertEqual(relationship.source_id, assessment_id)
 
   def test_options(self):
     mock_obj = self.mock_model()

--- a/test/integration/ggrc/services/test_common.py
+++ b/test/integration/ggrc/services/test_common.py
@@ -27,6 +27,10 @@ RESOURCE_ALLOWED = ["HEAD", "GET", "PUT", "DELETE", "OPTIONS"]
 class TestServices(TestCase):
   """Integration tests suite for /api/<model> endpoints common logic."""
 
+  def setUp(self):
+    super(TestServices, self).setUp()
+    self.api = api_helper.Api()
+
   @staticmethod
   def get_location(response):
     """Ignore the `http://localhost` prefix of the Location"""
@@ -281,6 +285,22 @@ class TestServices(TestCase):
         ("If-Match", response.headers["Etag"]),
     )
     check_response_409(response_date_invalid)
+
+  def test_put_relationship_405(self):
+    """
+    This test ensures that put method to the
+    /api/relationships/<id>/ PUT method not allowed
+    """
+    assessment = factories.AssessmentFactory()
+    assessment_2 = factories.AssessmentFactory()
+    evidence = factories.EvidenceUrlFactory()
+    rel_id = factories.RelationshipFactory(source=assessment,
+                                           destination=evidence).id
+    relationship = all_models.Relationship.query.get(rel_id)
+    response = self.api.put(relationship, {"relationship": {
+        "id": assessment_2.id, "type": assessment_2.type
+    }})
+    self.assert405(response)
 
   def test_options(self):
     mock_obj = self.mock_model()


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description


There is not such user case where source/destination objects can be   changed for relationship object. However, it's possible make PUT request to /api/relationships/<id> which   potentially can modify source/destination.  

 The goal of this ticket is to ensure that FE doesn't use PUT requests to /api/relationships/<id>, and   disallow PUT (modifying) requests to this endpoint.

# Steps to test the changes

Run in the container command run_integration to verify the added test 'test_put_relationship_405' is working properly

# Solution description

raise MethodNotAllowed error in def put() method for the urls that are matches **/api/relationships/[0-9]+$** expression

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
