### PR TITLE
QUICK-FIX Fix deferred exceptions in tests

### DIFF
--- a/src/ggrc-client/js/components/bulk-update-button/tests/bulk-update-button_spec.js
+++ b/src/ggrc-client/js/components/bulk-update-button/tests/bulk-update-button_spec.js
@@ -61,6 +61,7 @@ describe('bulk-update-button component', function () {
 
       viewModel.attr('model', {
         name_singular: 'Some Model',
+        name_plural: 'Some Models',
       });
       resMessage = 'items updated';
       updateDfd = $.Deferred();

--- a/src/ggrc-client/js/components/object-review/tests/request-review-modal_spec.js
+++ b/src/ggrc-client/js/components/object-review/tests/request-review-modal_spec.js
@@ -79,6 +79,7 @@ describe('request-review-modal component', () => {
 
       viewModel.attr('review', review);
       viewModel.attr('modalState.open', true);
+      viewModel.attr('parentInstance', {dispatch: () => {}});
     });
 
     it('should not save review in case of empty ACL', () => {

--- a/src/ggrc-client/js/components/snapshotter/tests/snapshot-scope-update_spec.js
+++ b/src/ggrc-client/js/components/snapshotter/tests/snapshot-scope-update_spec.js
@@ -109,9 +109,9 @@ describe('snapshot-scope-update component', function () {
     });
 
     it('does not set refresh flag for each tree-widget-container that does ' +
-    'not contain snapshots', function () {
+    'not contain snapshots', async function () {
       _.assign(containerVM.model, {model_singular: 'Something'});
-      method();
+      await method();
       $('tree-widget-container').each(function () {
         let viewModel = $(this).viewModel();
         expect(viewModel.setRefreshFlag).not.toHaveBeenCalled();

--- a/src/ggrc-client/js_specs/models/mappers_spec.js
+++ b/src/ggrc-client/js_specs/models/mappers_spec.js
@@ -104,21 +104,21 @@ describe('mappers', function () {
         spyOn(binding, 'refresh_instances').and.returnValue($.when());
       });
 
-      it('attaches its instance to a new ReifyingListLoader', function () {
-        binding.refresh_list();
+      it('attaches its instance to a new ReifyingListLoader', async () => {
+        await binding.refresh_list();
         expect(LL.ReifyingListLoader.newInstance).toHaveBeenCalledWith(binding);
         expect(loader.attach).toHaveBeenCalledWith(binding.instance);
       });
 
       it('sets the name of the ReifyingListLoader\'s ListBinding to ' +
-         'its own name plus "_instances"', function () {
+         'its own name plus "_instances"', async function () {
         binding.name = 'foo';
-        binding.refresh_list();
+        await binding.refresh_list();
         expect(otherBinding.name).toBe('foo_instances');
       });
 
-      it('refreshes instances on the new binding', function () {
-        binding.refresh_list();
+      it('refreshes instances on the new binding', async function () {
+        await binding.refresh_list();
         expect(otherBinding.refresh_instances).toHaveBeenCalledWith(binding);
       });
 


### PR DESCRIPTION
# Issue description

4 Deferred exceptions appear in the console as warnings just if you run `run_karma`. Such warnings are completely useless, so should be removed:

1st
```
WARN: 'jQuery.Deferred exception: Cannot read property 'toLowerCase' of undefined', 'TypeError: Cannot read property 'toLowerCase' of undefined
    at Map.getResultNotification (webpack-internal:///./js/components/bulk-update-button/bulk-update-button.js:65:44)
    at Map.eval (webpack-internal:///./js/components/bulk-update-button/bulk-update-button.js:53:28)
    at mightThrow (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3557:29)
    at process (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3625:12)', undefined
```
2nd
```
WARN: 'jQuery.Deferred exception: Cannot read property 'model_singular' of undefined', 'TypeError: Cannot read property 'model_singular' of undefined
    at HTMLElement.eval (webpack-internal:///./js/components/snapshotter/scope-update.js:40:36)
    at Function.each (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:367:19)
    at jQuery.fn.init.each (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:202:17)
    at eval (webpack-internal:///./js/components/snapshotter/scope-update.js:38:36)
    at mightThrow (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3557:29)
    at process (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3625:12)', undefined
```
3rd exception, which is shown 3 times:
```
WARN: 'jQuery.Deferred exception: this.loader.refresh_instances is not a function', 'TypeError: this.loader.refresh_instances is not a function
    at Constructor.refresh_instances (webpack-internal:///./js/models/mappers/list-binding.js:25:26)
    at eval (webpack-internal:///./js/models/mappers/list-binding.js:54:21)
    at mightThrow (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3557:29)
    at process (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3625:12)', undefined
```

4th one:
```
WARN: 'jQuery.Deferred exception: Cannot read property 'dispatch' of null', 'TypeError: Cannot read property 'dispatch'
 of null
    at eval (webpack-internal:///./js/components/object-review/request-review-modal.js:78:37)
    at mightThrow (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3557:29)
    at process (webpack-internal:///../../../vagrant-dev/node_modules/jquery/dist/jquery.js?369c:3625:12)', undefined
```

# Steps to test the changes

Run `run_karma`

# Solution description

Fixes all 4 out of 4 exceptions.

The 1st exception is fixed by adding plural_name to bulk-update-button. Required, cause we need plural_name in [bulk-update-button.getResultNotification](https://github.com/google/ggrc-core/blob/b09eccffb7820dda778411e623f8b34289d05dde/src/ggrc-client/js/components/bulk-update-button/bulk-update-button.js#L51), another way it throws `can't get function toLowerCase of undefined` 

The 3rd exceptions are fixed by waiting in tests for the resolution of Deferred, returned by `refresh_list`. Cause error is thrown in the `refresh_instances` method. Which is mocked, so should not even be called. But mock is cleared after test finishes. And `refresh_list` is the async method, `refresh_instances` is called asynchronously, but tests are synchronous, so I made tests asynchronous, so they wait till deferred resolves and clear mocks only after deferred resolution. 

The second exception is fixed the same way. We already mock `$.prototype.ViewModel`, mocking doesn't work because the test is asynchronous but wrote in a synchronous manner. So we need to tell Jasmine to wait before all our Deferreds completes.

The fourth exception occurs because we don't set `parentInstance` in tests but after some asynchronous stuff call `dispatch` on it. So I just set `parentInstance` object with a dummy `dispatch` function in the `beforeEach` block

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".