### PR TITLE
GGRC-6650 Fix title for 'Authorization' attribute on 'Person' tab

### DIFF
--- a/src/ggrc-client/js/components/people/people-list-info.stache
+++ b/src/ggrc-client/js/components/people/people-list-info.stache
@@ -19,7 +19,7 @@
               <user-roles-selector-button personId:from="id">
                 <a href="javascript://" on:el:click="openModal(scope.event)">
                   <i class="fa fa-address-card"></i>
-                  Edit Authorizations
+                  Edit System Authorizations
                 </a>
               </user-roles-selector-button>
             </li>
@@ -74,7 +74,7 @@
 
         <div class="row-fluid wrap-row">
           <div class="span12">
-            <h6>Authorizations</h6>
+            <h6>System Authorizations</h6>
             <p>
               {{^if isNoRole}}
                 <span class="role">

--- a/src/ggrc-client/js/components/tree/templates/tree-header.stache
+++ b/src/ggrc-client/js/components/tree/templates/tree-header.stache
@@ -17,7 +17,7 @@
       <ul class="attr-list">
         {{#columns}}
           <li class="{{#if mandatory}}disabled{{/if}}">
-            <tree-visible-column-checkbox column:from="{.}">
+            <tree-visible-column-checkbox column:from="{.}" viewType:from="'tree-view'">
             </tree-visible-column-checkbox>
           </li>
         {{/columns}}

--- a/src/ggrc-client/js/components/tree/templates/tree-visible-column-checkbox.stache
+++ b/src/ggrc-client/js/components/tree/templates/tree-visible-column-checkbox.stache
@@ -4,7 +4,7 @@
 }}
 
 {{#column}}
-  <label class="checkbox-inline" title="{{title}}">
+  <label class="checkbox-inline" title="{{title viewType}}">
     {{#if selected}}
       <input type="checkbox"
         checked="checked"
@@ -19,7 +19,6 @@
         value="{{name}}"
         class="attr-checkbox {{#mandatory}}mandatory{{/mandatory}}">
     {{/if}}
-
-    {{title}}
+    {{title viewType}}
   </label>
 {{/column}}

--- a/src/ggrc-client/js/components/tree/tree-visible-column-checkbox.js
+++ b/src/ggrc-client/js/components/tree/tree-visible-column-checkbox.js
@@ -11,6 +11,7 @@ export default can.Component.extend({
   leakScope: true,
   viewModel: can.Map.extend({
     column: {},
+    viewType: null,
     onChange(attr) {
       attr.attr('selected', !attr.attr('selected'));
     },

--- a/src/ggrc-client/js/components/unified-mapper/templates/mapper-results-columns-configuration.stache
+++ b/src/ggrc-client/js/components/unified-mapper/templates/mapper-results-columns-configuration.stache
@@ -16,13 +16,13 @@
     <ul class="attr-list">
       {{#columns}}
         <li class="{{#mandatory}}disabled{{/mandatory}}">
-          <tree-visible-column-checkbox column:from="{.}">
+          <tree-visible-column-checkbox column:from="{.}" viewType:from="'unified-mapper'">
           </tree-visible-column-checkbox>
         </li>
       {{/columns}}
       {{#serviceColumns}}
         <li class="{{#mandatory}}disabled{{/mandatory}}">
-          <tree-visible-column-checkbox column:from="{.}">
+          <tree-visible-column-checkbox column:from="{.}" viewType:from="'unified-mapper'">
           </tree-visible-column-checkbox>
         </li>
       {{/serviceColumns}}

--- a/src/ggrc-client/js/components/unified-mapper/templates/mapper-results-items-header.stache
+++ b/src/ggrc-client/js/components/unified-mapper/templates/mapper-results-items-header.stache
@@ -7,11 +7,11 @@
   {{#each aggregatedColumns}}
     {{#if disable_sorting}}
       <div class="title">
-        {{attr_title}}
+        {{attr_title 'unified-mapper'}}
       </div>
     {{else}}
       <div class="title title_sortable" on:el:click="applySort">
-        {{attr_title}}
+        {{attr_title 'unified-mapper'}}
         {{#if isSorted}}
           <i class="fa
             {{#if isSortedAsc}}

--- a/src/ggrc-client/js/models/business-models/person.js
+++ b/src/ggrc-client/js/models/business-models/person.js
@@ -58,7 +58,14 @@ export default Cacheable.extend({
       attr_title: 'Email',
       attr_name: 'email',
     }, {
-      attr_title: 'Authorizations',
+      attr_title(viewType) {
+        viewType = _.isFunction(viewType) ? viewType() : viewType;
+        if (viewType === 'unified-mapper') {
+          return 'System Authorizations';
+        }
+
+        return 'Object Authorizations';
+      },
       attr_name: 'authorizations',
     }, {
       attr_title: 'Last Updated Date',

--- a/src/ggrc-client/js/templates/people/filters.stache
+++ b/src/ggrc-client/js/templates/people/filters.stache
@@ -53,7 +53,7 @@
     </div>
     <div class="span2">
       <div class="oneline">
-        Authorizations
+        System Authorizations
       </div>
     </div>
     <div class="span2">

--- a/src/ggrc-client/js/templates/people/info.stache
+++ b/src/ggrc-client/js/templates/people/info.stache
@@ -68,7 +68,7 @@
             </div>
             <div class="row-fluid wrap-row">
               <div class="span12">
-                <h6>Authorizations</h6>
+                <h6>System Authorizations</h6>
                 <span>
                   {{#is(instance.system_wide_role, "No Access")}}
                     No Role


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Authorization field for person on 'People' tab contains list of all roles in scope of current object. On the other hand 'Authorization' section on Person Info pane contains 'Global Role' for specified person. Different content for the same field may lead to confusion.

# Steps to test the changes

Part 1. System Authorizations
1. The 'AUTHORIZATIONS' column on the People tab of the Administration page should be re-named to 'SYSTEM AUTHORIZATIONS' 
2. The 'AUTHORIZATIONS' attribute of the Person Info page should be re-named to ' SYSTEM AUTHORIZATIONS'
3. The 'AUTHORIZATIONS' attribute of the Person for Global Search should be re-named to ' SYSTEM AUTHORIZATIONS' (includes: 'Set visible fields for Person' menu, Attribute dropdown, AUTHORIZATIONS column)
4. Check places the field is also displayed and re-name it there as well.
Part 2. Object Authorizations
1. The 'AUTHORIZATIONS' column on the 'People' tab of an Object (Program, Issue, etc,) should be re-named to ' OBJECT AUTHORIZATIONS' 

# Solution description

Modified following files to modify AUTHORIZATIONS column.
src/ggrc-client/js/components/people/people-list-info.stache
src/ggrc-client/js/components/tree/templates/tree-header.stache
src/ggrc-client/js/components/tree/templates/tree-visible-column-checkbox.stache
src/ggrc-client/js/models/business-models/person.js
src/ggrc-client/js/templates/people/filters.stache
src/ggrc-client/js/templates/people/info.stache
test/integration/ggrc/services/test_authorizations.py

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
