### PR TITLE
GGRC-7305 Remove "recipients" sorting from "content"

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -638,18 +638,6 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
       automapping_json = flask.g.automappings_cache[automapping_id]
     return {"automapping": automapping_json}
 
-  @staticmethod
-  def _populate_recipients(populated_content):
-    """Normalize recipients if present in content."""
-    if "recipients" in populated_content:
-      # There are revisions with same recipients put in different order and
-      # since this field is of string type, order matters which leads to wrong
-      # result during diff calculation. To prevent it, recipients should be
-      # sorted in same order when populating content.
-      populated_content["recipients"] = ",".join(
-          sorted(populated_content["recipients"].split(",")),
-      )
-
   @builder.simple_property
   def content(self):
     """Property. Contains the revision content dict.
@@ -674,7 +662,6 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
     self.populate_requirements(populated_content)
     self.populate_options(populated_content)
     self.populate_review_status_display_name(populated_content)
-    self._populate_recipients(populated_content)
     # remove custom_attributes,
     # it's old style interface and now it's not needed
     populated_content.pop("custom_attributes", None)


### PR DESCRIPTION
# Issue description

List of recipients can be empty for objects that were moved to GGRCQ (Control, Risk and etc.)
In that case validation on string should be added for correct implementation

# Steps to test the changes
Run integration tests
Generate request for objects that were moved to GGRCQ (control for example) without recipients

# Solution description
Recipients population were updated with additional string validation

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


