### PR TITLE
GGRC-7271 Evidence attached to assessment object duplicates in audit folder

### DIFF
--- a/src/ggrc/models/evidence.py
+++ b/src/ggrc/models/evidence.py
@@ -249,6 +249,7 @@ class Evidence(Roleable, Relatable, mixins.Titled,
       response = process_gdrive_file(file_id, folder_id,
                                      is_uploaded=self.is_uploaded)
       self._update_fields(response, parent)
+      self._parent_obj = None  # pylint: disable=attribute-defined-outside-init
 
   def is_with_parent_obj(self):
     return bool(hasattr(self, '_parent_obj') and self._parent_obj)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Evidence file copied few times during every `flush()`.

# Steps to test the changes

Steps to reproduce:
1. Log in ggrc app and open any audit
2. Attach folder to audit
3. Create assessment and attach evidence file to this assessment from GDrive
4. Open Gdrive and open the folder
Actual Result: Evidence attached to assessment object duplicates in audit folder
Expected Result: Evidence attached to assessment object should not be duplicated in audit folder

# Solution description

Evidence.`_parent_obj` can only be set using API and should be handled only once in `ggrc.models.evidence.Evidence#exec_gdrive_file_copy_flow` during before_flush hook, but it was handled few times because of bug.
Also I removed function `_build_relationship()` since it is unused after #9199

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
