### PR TITLE
GGRC-7309 Remove "Risk" type from import template

### DIFF
--- a/src/ggrc/converters/__init__.py
+++ b/src/ggrc/converters/__init__.py
@@ -65,7 +65,6 @@ GGRC_IMPORTABLE = {
     "regulation": all_models.Regulation,
     "requirement": all_models.Requirement,
     "risk assessment": all_models.RiskAssessment,
-    "risk": all_models.Risk,
     "risk_assessment": all_models.RiskAssessment,
     "riskassessment": all_models.RiskAssessment,
     "standard": all_models.Standard,
@@ -80,6 +79,7 @@ GGRC_IMPORTABLE = {
 GGRC_EXPORTABLE = {
     "snapshot": all_models.Snapshot,
     "control": all_models.Control,
+    "risk": all_models.Risk,
 }
 
 


### PR DESCRIPTION
# Issue description
Risk type should be only exportable from GGRC side, not importable

# Steps to test the changes
Try to import Risk from UI - it's should not be possible
Try to export Risk from UI - it's should be possible
Run integration/unit tests

# Solution description
Update constants from import/export tamplates

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).



# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

