### PR TITLE
GGRC-6977/GGRC-7216/GGRC-7217 Add revisions for program

### DIFF
--- a/src/ggrc-client/js/templates/programs/info.stache
+++ b/src/ggrc-client/js/templates/programs/info.stache
@@ -1,10 +1,10 @@
 {{!
-    Copyright (C) 2019 Google Inc.
-    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
 {{#instance}}
-  <section class="info{{#if is_info_pin}} sticky-info-panel{{/if}}">
+  <section class="info {{#if is_info_pin}}sticky-info-panel{{/if}}">
     <div class="tier-content">
       <general-page-header instance:from="instance"></general-page-header>
 
@@ -103,6 +103,9 @@
             <related-proposals baseInstance:from="instance"
                                on:updateProposalsWarning="updateWarningState(scope.event)">
             </related-proposals>
+          </tab-panel>
+          <tab-panel panels:bind="panels" titleText:from="'Version History'">
+            <related-revisions instance:from="instance"></related-revisions>
           </tab-panel>
           <tab-panel tabId:from="'change-log'" panels:bind="panels" titleText:from="'Change Log'">
             <revision-log instance:from="instance" options:from="tabOptions"></revision-log>

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -718,7 +718,9 @@ class Folderable(WithProtectedAttributes):
         orm.Load(cls).load_only("folder"),
     )
 
-  _api_attrs = reflection.ApiAttributes('folder')
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute('folder', update=False),
+  )
   _fulltext_attrs = ['folder']
   _aliases = {"folder": "Folder"}
 

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -468,7 +468,9 @@ class Slugged(Base):
     return ()
 
   # REST properties
-  _api_attrs = reflection.ApiAttributes('slug')
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute('slug', update=False)
+  )
   _fulltext_attrs = ['slug']
   _sanitize_html = ['slug']
   _aliases = {

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -71,7 +71,6 @@ class Program(mega.Mega,
       'kind',
       reflection.Attribute('audits', create=False, update=False),
       reflection.Attribute('risk_assessments', create=False, update=False),
-      reflection.Attribute('folder', create=False, update=False),
   )
   _include_links = []
   _aliases = {

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -71,6 +71,7 @@ class Program(mega.Mega,
       'kind',
       reflection.Attribute('audits', create=False, update=False),
       reflection.Attribute('risk_assessments', create=False, update=False),
+      reflection.Attribute('folder', create=False, update=False),
   )
   _include_links = []
   _aliases = {

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -257,8 +257,33 @@ def generate_fields(fields, proposed_content, current_data):
     proposed_val = proposed_content[field_name]
     current_val = current_data.get(field_name)
     if proposed_val != current_val:
+      if field_name == u'recipients' and not _recipients_changed(proposed_val,
+                                                                 current_val):
+        continue
       diff[field_name] = proposed_val
   return diff
+
+
+def _recipients_changed(proposed_val, current_val):
+  """Check if the recipients attribute has been semantically modified.
+
+  The recipients attribute is a comma-separated string, and the exact order of
+  the items in it does not matter, i.e. it is not considered a change.
+
+  Args:
+    proposed_val (str): recipients' proposed value
+    current_val (str): recipients' current value
+
+  Returns:
+    True if there was a (semantic) change, False otherwise
+  """
+  if current_val is None:
+    current_val = ""
+
+  if proposed_val is None:
+    proposed_val = ""
+
+  return sorted(current_val.split(",")) != sorted(proposed_val.split(","))
 
 
 def _construct_diff(meta, current_content, new_content):

--- a/test/integration/ggrc/api/test_folder_field.py
+++ b/test/integration/ggrc/api/test_folder_field.py
@@ -35,7 +35,6 @@ class TestFolderField(TestCase):
       factories.ProcessFactory,
       factories.ProductFactory,
       factories.ProductGroupFactory,
-      factories.ProgramFactory,
       factories.ProjectFactory,
       factories.RegulationFactory,
       factories.RequirementFactory,

--- a/test/integration/ggrc/api/test_folder_field.py
+++ b/test/integration/ggrc/api/test_folder_field.py
@@ -35,6 +35,7 @@ class TestFolderField(TestCase):
       factories.ProcessFactory,
       factories.ProductFactory,
       factories.ProductGroupFactory,
+      factories.ProgramFactory,
       factories.ProjectFactory,
       factories.RegulationFactory,
       factories.RequirementFactory,
@@ -77,7 +78,8 @@ class TestFolderField(TestCase):
 
   @ddt.data(*FOLDERABLE_FACTORIES)
   def test_put_object(self, factory):
-    """Test put folder field for {0._meta.model.__name__}."""
+    """Test folder field can't be updated
+    with put for {0._meta.model.__name__}."""
     test_folder_name = "tmp_folder_put_name"
     obj = factory(folder=test_folder_name)
     update_test_folder_name = "upd_tmp_folder_put_name"
@@ -93,7 +95,7 @@ class TestFolderField(TestCase):
 
       self.api.put(obj, {"folder": update_test_folder_name})
       self.assertEqual(
-          update_test_folder_name,
+          test_folder_name,
           obj.__class__.query.get(obj_id).folder
       )
 

--- a/test/integration/ggrc/models/mixins/test_autostatuschangable.py
+++ b/test/integration/ggrc/models/mixins/test_autostatuschangable.py
@@ -192,8 +192,6 @@ class TestFirstClassAttributes(TestMixinAutoStatusChangeableBase):
       ('notes', 'new note', models.Assessment.FINAL_STATE),
       ('description', 'some description', models.Assessment.DONE_STATE),
       ('description', 'some description', models.Assessment.FINAL_STATE),
-      ('slug', 'some code', models.Assessment.DONE_STATE),
-      ('slug', 'some code', models.Assessment.FINAL_STATE),
       ('start_date', '2020-01-01', models.Assessment.DONE_STATE),
       ('start_date', '2020-01-01', models.Assessment.FINAL_STATE),
       ('design', 'Effective', models.Assessment.DONE_STATE),

--- a/test/integration/ggrc/models/test_audit.py
+++ b/test/integration/ggrc/models/test_audit.py
@@ -203,6 +203,19 @@ class TestAudit(TestCase):
     expected_slug = "SLUG"
     self.assertEqual(current_slug, expected_slug)
 
+  def test_slug_no_update(self):
+    """Test put slug has no effect since slug became
+    not updatable API attribute"""
+    with factories.single_commit():
+      audit = factories.AuditFactory(slug="SLUG-01")
+
+    response = self.api.put(audit, {"slug": "NEW SLUG"})
+    self.assert200(response)
+    audit = db.session.query(all_models.Audit).get(audit.id)
+    current_slug = audit.slug
+    expected_slug = "SLUG-01"
+    self.assertEqual(current_slug, expected_slug)
+
 
 class TestManualAudit(TestCase):
   """ Test Audit with manual snapshot mapping"""

--- a/test/integration/ggrc/models/test_audit.py
+++ b/test/integration/ggrc/models/test_audit.py
@@ -203,18 +203,6 @@ class TestAudit(TestCase):
     expected_slug = "SLUG"
     self.assertEqual(current_slug, expected_slug)
 
-  def test_slug_validation_update(self):
-    """Test put slug with trailing space"""
-    with factories.single_commit():
-      audit = factories.AuditFactory(slug="SLUG-01")
-
-    response = self.api.put(audit, {"slug": "SLUG "})
-    self.assert200(response)
-    audit = db.session.query(all_models.Audit).get(audit.id)
-    current_slug = audit.slug
-    expected_slug = "SLUG"
-    self.assertEqual(current_slug, expected_slug)
-
 
 class TestManualAudit(TestCase):
   """ Test Audit with manual snapshot mapping"""

--- a/test/integration/ggrc/services/test_revision_history.py
+++ b/test/integration/ggrc/services/test_revision_history.py
@@ -239,10 +239,10 @@ class TestRevisionHistory(TestCase):
   @ddt.data(
       {"factory": factories.ControlFactory,
        "fields": ['test_plan', 'status', 'notes',
-                  'description', 'title', 'slug', 'folder']},
+                  'description', 'title', 'folder']},
       {"factory": factories.RiskFactory,
        "fields": ['test_plan', 'status', 'description', 'external_id',
-                  'notes', 'title', 'slug', 'folder']},
+                  'notes', 'title', 'folder']},
   )
   @ddt.unpack
   def test_get_mandatory_fields(self, factory, fields):

--- a/test/integration/ggrc/services/test_revision_history.py
+++ b/test/integration/ggrc/services/test_revision_history.py
@@ -239,10 +239,10 @@ class TestRevisionHistory(TestCase):
   @ddt.data(
       {"factory": factories.ControlFactory,
        "fields": ['test_plan', 'status', 'notes',
-                  'description', 'title', 'folder']},
+                  'description', 'title']},
       {"factory": factories.RiskFactory,
        "fields": ['test_plan', 'status', 'description', 'external_id',
-                  'notes', 'title', 'folder']},
+                  'notes', 'title']},
   )
   @ddt.unpack
   def test_get_mandatory_fields(self, factory, fields):


### PR DESCRIPTION
Make 'slug' and 'folder' fields not updatable to remove them from diff builder.
Fix recipients handling in diff builder - do not show diff if recipients reordered but not changed.

# Dependencies

This PR is `on hold` until the FE PR merged:

- [x] GGRC-7217

# Issue description

Revisions functionality is currently available for Risks.
We need to replicate the flow for Programs.

Two places of the app should be updated:
1. The 'Review & Apply' button should be added to the Change Proposals tab of the Program
2. The 'Review: Compare to Current' modal window
This PR provides minor BE fixes for Programs 'Version History'

# Steps to test the changes

1. Open Program with id=131 (qa dump)
2. Open 'Version History' tab

Before changes:

- Code(slug) and folder can be restored from version history
- Some revisions have reordered 'Recipients' that are shown as diff

After changes:
- Code(slug) and folder can not be restored from version history
- Reordered 'Recipients' are not displayed in diff

# Solution description

1. Make slug and folder fields not updatable API Attributes
2. Fix diff builder for 'recipients' field

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
