### PR TITLE
QUICK-FIX Fix Change Log for Risks&Controls

### DIFF
--- a/src/ggrc-client/js/models/service-models/external-comment.js
+++ b/src/ggrc-client/js/models/service-models/external-comment.js
@@ -1,0 +1,23 @@
+/*
+ Copyright (C) 2019 Google Inc.
+ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import Cacheable from '../cacheable';
+
+export default Cacheable.extend({
+  root_object: 'external_comment',
+  root_collection: 'external_comments',
+  findOne: 'GET /api/external_comments/{id}',
+  findAll: 'GET /api/external_comments',
+  update: 'PUT /api/external_comments/{id}',
+  destroy: 'DELETE /api/external_comments/{id}',
+  create: 'POST /api/external_comments',
+}, {
+  display_type() {
+    return 'Comment';
+  },
+  display_name() {
+    return this.description || '';
+  },
+});

--- a/src/ggrc-client/js/models/service-models/index.js
+++ b/src/ggrc-client/js/models/service-models/index.js
@@ -19,3 +19,4 @@ export {default as Role} from './role';
 export {default as Search} from './search';
 export {default as Snapshot} from './snapshot';
 export {default as PersonProfile} from './person-profile';
+export {default as ExternalComment} from './external-comment';


### PR DESCRIPTION
# Issue description

*Show ExternalComment on Change log.*

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
