### PR TITLE
GGRC-7310 Snakecase in mega objects names in filter sub tree 

### DIFF
--- a/src/ggrc-client/js/components/tree/sub-tree-models.js
+++ b/src/ggrc-client/js/components/tree/sub-tree-models.js
@@ -21,8 +21,10 @@ let viewModel = can.Map.extend({
     displayModelsList: {
       get: function () {
         return this.attr('modelsList').map((model) => {
-          const displayName =
-            model.attr('name').split(/(?=[A-Z])/).join(' ');
+          const displayName = model.attr('widgetName')
+            .replace(' ', '')
+            .split(/(?=[A-Z])/)
+            .join(' ');
           model.attr('displayName', displayName);
           return model;
         }).sort((a, b) => {

--- a/src/ggrc-client/js/components/tree/templates/sub-tree-models.stache
+++ b/src/ggrc-client/js/components/tree/templates/sub-tree-models.stache
@@ -17,13 +17,10 @@
   <div class="sub-tree-models__options">
     {{#displayModelsList}}
       <div class="sub-models_item">
-          <label for="{{firstnonempty inputId ''}}" class="single-line" title="{{displayName}}">
-            <input type="checkbox"
-              id="{{firstnonempty inputId ''}}"
-              el:checked:bind="display"
-              value="{{name}}">
-            {{displayName}}
-          </label>
+        <label class="single-line" title="{{displayName}}">
+          <input type="checkbox" el:checked:bind="display" value="{{name}}">
+          {{displayName}}
+        </label>
       </div>
     {{/displayModelsList}}
   </div>

--- a/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
@@ -74,11 +74,11 @@ describe('sub-tree-models component', function () {
   });
 
   describe('get() of displayModelsList', function () {
-    it('splits model names', function () {
+    it('splits widgetNames', function () {
       let result;
       vm.attr('modelsList', new can.List([
-        {name: 'MockName'},
-        {name: 'Singlelinename'},
+        {widgetName: 'MockName'},
+        {widgetName: 'Singlelinename'},
       ]));
 
       result = vm.attr('displayModelsList');
@@ -90,10 +90,10 @@ describe('sub-tree-models component', function () {
     it('sorts model names', function () {
       let result;
       vm.attr('modelsList', new can.List([
-        {name: 'Metrics'},
-        {name: 'Control'},
-        {name: 'Risk'},
-        {name: 'Audit'},
+        {widgetName: 'Metrics'},
+        {widgetName: 'Control'},
+        {widgetName: 'Risk'},
+        {widgetName: 'Audit'},
       ]));
 
       result = vm.attr('displayModelsList');

--- a/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
@@ -77,14 +77,16 @@ describe('sub-tree-models component', function () {
     it('splits widgetNames', function () {
       let result;
       vm.attr('modelsList', new can.List([
+        {widgetName: 'Child Programs'},
         {widgetName: 'MockName'},
         {widgetName: 'Singlelinename'},
       ]));
 
       result = vm.attr('displayModelsList');
 
-      expect(result[0].displayName).toEqual('Mock Name');
-      expect(result[1].displayName).toEqual('Singlelinename');
+      expect(result[0].displayName).toEqual('Child Programs');
+      expect(result[1].displayName).toEqual('Mock Name');
+      expect(result[2].displayName).toEqual('Singlelinename');
     });
 
     it('sorts model names', function () {
@@ -94,14 +96,16 @@ describe('sub-tree-models component', function () {
         {widgetName: 'Control'},
         {widgetName: 'Risk'},
         {widgetName: 'Audit'},
+        {widgetName: 'Child Programs'},
       ]));
 
       result = vm.attr('displayModelsList');
 
       expect(result[0].displayName).toEqual('Audit');
-      expect(result[1].displayName).toEqual('Control');
-      expect(result[2].displayName).toEqual('Metrics');
-      expect(result[3].displayName).toEqual('Risk');
+      expect(result[1].displayName).toEqual('Child Programs');
+      expect(result[2].displayName).toEqual('Control');
+      expect(result[3].displayName).toEqual('Metrics');
+      expect(result[4].displayName).toEqual('Risk');
     });
   });
 

--- a/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
@@ -132,7 +132,7 @@ describe('sub-tree-models component', function () {
       spyOn(childModelsMap, 'setModels');
     });
 
-    it('sets selectedModels ti childModelsMap', function () {
+    it('sets selectedModels to childModelsMap', function () {
       vm.setVisibility(event);
 
       expect(childModelsMap.setModels)

--- a/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/sub-tree-models_spec.js
@@ -191,11 +191,8 @@ describe('sub-tree-models component', function () {
   });
 
   describe('getSelectedModels() method', function () {
-    let modelsList;
-    let expectedResult;
-
     beforeEach(function () {
-      modelsList = new can.List([
+      const modelsList = new can.List([
         {name: 'Audit', display: true},
         {name: 'Control', display: true},
         {name: 'Objective', display: false},
@@ -204,9 +201,8 @@ describe('sub-tree-models component', function () {
       vm.attr('modelsList', modelsList);
     });
 
-    it('returns models names which are selected', function () {
-      expectedResult = vm.attr('modelsList').filter((model) => model.display)
-        .map((model) => model.name).serialize();
+    it('returns selected models widgetIds', function () {
+      const expectedResult = ['Audit', 'Control', 'Market'];
       expect(vm.getSelectedModels().serialize()).toEqual(expectedResult);
     });
   });


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

"Program_child" and "Program_parent" naming in Filter sub tree 

# Steps to test the changes

1. Open programs list. 
2. Open "Filter sub tree" for some program. 
Expected result: "Child Programs" and "Parent Programs" among other options.
Actual result: "Program_child" and "Program_parent"

# Solution description

Use `widgetName` instead of `name` in `displayModelsList` getter in `sub-tree-models`, cause it's almost the same for mega and simple objects. Now, this getter also removes spaces in `widgetName`. Cause mega object's widgetName is space-delimited and simple objects don't contain spaces. So in order to avoid having 2 spaces in mega objects `displayName` we need to remove all spaces in `widgetName`

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".