### PR TITLE
GGRC-5088 Fix validation in Relationship model.

### DIFF
--- a/src/ggrc/services/resources/relationship.py
+++ b/src/ggrc/services/resources/relationship.py
@@ -109,6 +109,7 @@ class RelationshipResource(ggrc.services.common.Resource):
       relationship_obj = relationship.Relationship()
       relationship_obj.source = obj.parent
       relationship_obj.destination = obj
+      db.session.add(relationship_obj)
       return None
 
     return super(RelationshipResource, self).json_create(obj, src)

--- a/src/ggrc/services/resources/relationship.py
+++ b/src/ggrc/services/resources/relationship.py
@@ -106,10 +106,9 @@ class RelationshipResource(ggrc.services.common.Resource):
       json_builder.create(obj, snapshot_data)
       obj.modified_by = get_current_user()
       obj.context = obj.parent.context
-      relationship.Relationship(
-          source=obj.parent,
-          destination=obj,
-      )
+      relationship_obj = relationship.Relationship()
+      relationship_obj.source = obj.parent
+      relationship_obj.destination = obj
       return None
 
     return super(RelationshipResource, self).json_create(obj, src)

--- a/test/integration/ggrc/services/resources/test_relationship.py
+++ b/test/integration/ggrc/services/resources/test_relationship.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for /api/relationship endpoints."""
+
+import json
+
+from integration.ggrc import api_helper
+from integration.ggrc.models import factories
+from integration.ggrc.services import TestCase
+
+
+class TestRelationshipResource(TestCase):
+  """Tests for special api endpoints."""
+
+  def setUp(self):
+    super(TestRelationshipResource, self).setUp()
+    self.api = api_helper.Api()
+
+  def test_map_object(self):
+    """It should be possible to map an object to an audit."""
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      audit = factories.AuditFactory(program=program)
+      factories.RelationshipFactory(
+          source=audit,
+          destination=program
+      )
+      product = factories.ProductFactory()
+      factories.RelationshipFactory(
+          source=program,
+          destination=product
+      )
+
+    data = [{
+        "relationship": {
+            "context": None,
+            "destination": {
+                "id": product.id,
+                "type": "Product",
+                "href": "/api/products/{}".format(product.id)
+            },
+            "source": {
+                "id": audit.id,
+                "type": "Audit",
+                "href": "/api/audits/{}".format(audit.id)
+            }
+        }
+    }]
+
+    response = self.api.client.post(
+        "/api/relationships",
+        data=json.dumps(data),
+        headers=self.headers
+    )
+    self.assert200(response)


### PR DESCRIPTION
Make validation of "source" and "destination" be independent from the
order in which those fields are set.

# Issue description
It is impossible to map a control onto a program.

# Steps to test the changes

(locally, empty DB, Version 1.11.0-Strawberry (dd9207d)) :

1. Create a program
2. Create several audits in the program
3. Open one of the audits created and try to map control to the audit.

**Expected result:** a control snapshot is created
**Actual result:** control snapshot is failing to create with the following error:

```
WARNING  2018-05-15 14:03:41,813 common.py:1106] Collection POST commit failed
Traceback (most recent call last):
  File "/vagrant/src/ggrc/services/common.py", line 1096, in collection_post
    self.collection_post_loop(body, res, no_result)
  File "/vagrant/src/ggrc/services/common.py", line 973, in collection_post_loop
    self.json_create(obj, src)
  File "/vagrant/src/ggrc/services/resources/relationship.py", line 74, in json_create
    destination=obj,
  File "<string>", line 4, in __init__
  File "/vagrant/src/packages/sqlalchemy/orm/state.py", line 260, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
  File "/vagrant/src/packages/sqlalchemy/ext/declarative/base.py", line 526, in _declarative_constructor
    setattr(self, k, kwargs[k])
  File "/vagrant/src/ggrc/models/relationship.py", line 61, in source
    self.validate_relatable_type("source", value)
  File "/vagrant/src/ggrc/models/relationship.py", line 144, in validate_relatable_type
    snapshot = db.session.query(Snapshot).get(tgt_id)
  File "/vagrant/src/packages/sqlalchemy/orm/query.py", line 818, in get
    if len(ident) != len(mapper.primary_key):
TypeError: object of type 'NoneType' has no len()
```
# Solution description
The core problem is that validation of fields [`Relationship.source`](https://github.com/google/ggrc-core/blob/60f0e328165664ac7e8be5f07e00c9e709b502dc/src/ggrc/models/relationship.py#L58) and [`Relationship.destination`](https://github.com/google/ggrc-core/blob/60f0e328165664ac7e8be5f07e00c9e709b502dc/src/ggrc/models/relationship.py#L81) is [dependent](https://github.com/google/ggrc-core/blob/60f0e328165664ac7e8be5f07e00c9e709b502dc/src/ggrc/models/relationship.py#L152) on both fields but is done independently ([1](https://github.com/google/ggrc-core/blob/60f0e328165664ac7e8be5f07e00c9e709b502dc/src/ggrc/models/relationship.py#L73), [2](https://github.com/google/ggrc-core/blob/60f0e328165664ac7e8be5f07e00c9e709b502dc/src/ggrc/models/relationship.py#L96)) for each field when it's being set. It works only when `destination` is set first and `source` afterwards and breaks when it's done in the other way around. 

The solution is more a workaround than a proper solution - it forces the order in which the fields are being set. The real solution would be to implement instance-wise validation that would happen simultaneously for both fields, but currently other code is dependent on validation being done during assignment and changing it would possible require architectural changes.

Because of the intermittent nature of the bug, the test would not fail in every run on unfixed code, however the test reproduces the failure situation and serves to validate that the changes do not break the expected behavior of the code that is changed in this PR.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation


# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
