### PR TITLE
GGRC-6794 Add tests for Mega Program FE

### DIFF
--- a/src/ggrc-client/js/components/mega-relation-selection-item/tests/mega-relation-selection-item_spec.js
+++ b/src/ggrc-client/js/components/mega-relation-selection-item/tests/mega-relation-selection-item_spec.js
@@ -1,0 +1,76 @@
+/*
+    Copyright (C) 2019 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import Component from '../mega-relation-selection-item';
+import pubSub from '../../../pub-sub';
+
+describe('mega-relation-selection-item component', () => {
+  let viewModel;
+  let fakeEvent;
+
+  beforeEach(() => {
+    viewModel = getComponentVM(Component);
+  });
+
+  describe('switchRelation() method', () => {
+    beforeEach(() => {
+      fakeEvent = new Event('click');
+    });
+
+    it('dispatches mapAsChild event', () => {
+      spyOn(pubSub, 'dispatch');
+      viewModel.attr('id', 123);
+      viewModel.switchRelation(fakeEvent, true);
+
+      expect(pubSub.dispatch).toHaveBeenCalledWith({
+        type: 'mapAsChild',
+        id: 123,
+        val: 'child',
+      });
+    });
+
+    it('calls stopPropagation for passed event', () => {
+      spyOn(fakeEvent, 'stopPropagation');
+      viewModel.switchRelation(fakeEvent, true);
+
+      expect(fakeEvent.stopPropagation).toHaveBeenCalled();
+    });
+  });
+
+  describe('childRelation getter', () => {
+    it('should return false if mapAsChild is equal null', () => {
+      viewModel.attr('mapAsChild', null);
+      expect(viewModel.attr('childRelation')).toBe(false);
+    });
+
+    it('should return true if mapAsChild is equal true', () => {
+      viewModel.attr('mapAsChild', true);
+      expect(viewModel.attr('childRelation')).toBe(true);
+    });
+
+    it('should return false if mapAsChild is not equal true', () => {
+      viewModel.attr('mapAsChild', false);
+      expect(viewModel.attr('childRelation')).toBe(false);
+    });
+  });
+
+  describe('parentRelation getter', () => {
+    it('should return false if mapAsChild is equal null', () => {
+      viewModel.attr('mapAsChild', null);
+      expect(viewModel.attr('parentRelation')).toBe(false);
+    });
+
+    it('should return true if mapAsChild is equal false', () => {
+      viewModel.attr('mapAsChild', false);
+      expect(viewModel.attr('parentRelation')).toBe(true);
+    });
+
+    it('should return false if mapAsChild is not equal false', () => {
+      viewModel.attr('mapAsChild', true);
+      expect(viewModel.attr('parentRelation')).toBe(false);
+    });
+  });
+});

--- a/src/ggrc-client/js/components/object-mapper/tests/create-and-map_spec.js
+++ b/src/ggrc-client/js/components/object-mapper/tests/create-and-map_spec.js
@@ -163,4 +163,16 @@ describe('create-and-map component', () => {
       expect(viewModel.cancel).toHaveBeenCalled();
     });
   });
+
+  describe('megaRelation getter', () => {
+    it('should return the last set value', () => {
+      const lastValue = 'parent';
+      viewModel.attr('megaRelation', lastValue);
+      expect(viewModel.attr('megaRelation')).toBe(lastValue);
+    });
+
+    it('should return "child" if the value was not set before', () => {
+      expect(viewModel.attr('megaRelation')).toBe('child');
+    });
+  });
 });

--- a/src/ggrc-client/js/components/object-mapper/tests/object-mapper_spec.js
+++ b/src/ggrc-client/js/components/object-mapper/tests/object-mapper_spec.js
@@ -181,6 +181,21 @@ describe('object-mapper component', function () {
       }, []);
       expect(spyObj).toHaveBeenCalledWith([]);
     });
+
+    it('calls performMegaMap to map results for mega-objects ' +
+    'if "options" and "options.megaMapping" are truthy values', function () {
+      const objects = jasmine.any(Object);
+      const options = {
+        megaMapping: true,
+        megaRelation: 'child',
+      };
+      viewModel.attr('deferred', false);
+      handler.call({
+        viewModel: viewModel,
+        performMegaMap: spyObj,
+      }, objects, options);
+      expect(spyObj).toHaveBeenCalledWith(objects, options.megaRelation);
+    });
   });
 
   describe('"create-and-map click" event', function () {
@@ -214,6 +229,29 @@ describe('object-mapper component', function () {
     });
   });
 
+  describe('"{pubSub} mapAsChild" event', function () {
+    let element = {};
+    let event;
+    let that;
+
+    beforeEach(function () {
+      event = {
+        id: 22,
+        val: 'child',
+      };
+      that = {
+        viewModel: viewModel,
+      };
+      handler = events['{pubSub} mapAsChild'];
+    });
+
+    it('assigns "event.val" to "megaRelationObj" attr by "event.id"',
+      function () {
+        handler.call(that, element, event);
+        expect(viewModel.attr('megaRelationObj')[event.id]).toBe(event.val);
+      });
+  });
+
   describe('"inserted" event', function () {
     let that;
 
@@ -238,6 +276,32 @@ describe('object-mapper component', function () {
       handler.call(that);
       expect(viewModel.attr('entries').length)
         .toEqual(0);
+    });
+  });
+
+  describe('"performMegaMap" event', function () {
+    let spyObj;
+
+    beforeEach(function () {
+      handler = events['performMegaMap'];
+      spyObj = jasmine.createSpy();
+    });
+
+    it('calls mapObjects to map results for mega-objects', function () {
+      const objects = [
+        {id: 101},
+        {id: 102},
+      ];
+      const relation = 'child';
+      const relationsObj = {
+        '101': relation,
+        '102': relation,
+      };
+
+      handler.call({
+        mapObjects: spyObj,
+      }, objects, relation);
+      expect(spyObj).toHaveBeenCalledWith(objects, true, relationsObj);
     });
   });
 

--- a/src/ggrc-client/js/components/revision-log/tests/revision-page_spec.js
+++ b/src/ggrc-client/js/components/revision-log/tests/revision-page_spec.js
@@ -645,6 +645,51 @@ describe('revision-page component', function () {
       });
     }
     );
+
+    it('returns correct change information ' +
+    'when revisions contains automapping content', function () {
+      let revision = {
+        updated_at: new Date('2015-05-17T17:24:01'),
+        source: {
+          display_type: function () {
+            return 'Other';
+          },
+          display_name: function () {
+            return 'OtherObject';
+          },
+        },
+        destination_id: 123,
+        destination_type: 'ObjectFoo',
+        content: {
+          automapping: {
+            destination: {
+              type: 'DestinationType',
+              title: 'DestinationTitle',
+            },
+            source: {
+              type: 'SourceType',
+              title: 'SourceTitle',
+            },
+          },
+        },
+      };
+
+      let result = viewModel._mappingChange(revision, [revision]);
+
+      expect(result).toEqual({
+        automapping: {
+          title: '(automapping triggered after "unknown" user mapped ' +
+          'DestinationType "DestinationTitle" to SourceType "SourceTitle")',
+        },
+        updatedAt: new Date('2015-05-17T17:24:01'),
+        role: 'none',
+        changes: {
+          origVal: '—',
+          newVal: '',
+          fieldName: 'Mapping to Other: OtherObject',
+        },
+      });
+    });
   });
 
   describe('_computeRoleChanges method', function () {

--- a/src/ggrc-client/js/components/tree/tests/child-models-map_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/child-models-map_spec.js
@@ -4,6 +4,7 @@
 */
 
 import * as DisplayPrefs from '../../../plugins/utils/display-prefs-utils';
+import * as MegaObject from '../../../plugins/utils/mega-object-utils';
 import childModelsMap from '../child-models-map';
 
 describe('child-models-map object', () => {
@@ -11,7 +12,7 @@ describe('child-models-map object', () => {
     childModelsMap.attr('container', {});
   });
 
-  describe('getChildModels() method', () => {
+  describe('getModels() method', () => {
     let types = ['Program', 'System', 'Assessment'];
     let spy;
 
@@ -40,10 +41,13 @@ describe('child-models-map object', () => {
         expect(spy.calls.count()).toEqual(3);
       });
 
-      it('returns childModels for specified type', () => {
+      it('returns childModels for specified type and mega object', () => {
         let type = 'Program';
-        let expectedResult = ['Audit'];
+        let expectedResult = ['Audit', 'Program_child'];
+
         spy.and.returnValue(expectedResult);
+        spyOn(MegaObject, 'isMegaObjectRelated')
+          .and.returnValue(true);
 
         expect(childModelsMap.getModels(type).serialize())
           .toEqual(expectedResult);

--- a/src/ggrc-client/js/components/tree/tests/sub-tree-item_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/sub-tree-item_spec.js
@@ -1,0 +1,144 @@
+/*
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import Component from '../sub-tree-item';
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import CycleTaskGroupObjectTask from '../../../models/business-models/cycle-task-group-object-task';
+import {trigger} from 'can-event';
+
+describe('sub-tree-item component', () => {
+  let viewModel;
+
+  beforeEach(() => {
+    viewModel = getComponentVM(Component);
+  });
+
+  describe('get() of isMega', () => {
+    it('should return "instance.is_mega" attr', () => {
+      viewModel.attr('instance', {is_mega: true});
+      expect(viewModel.attr('isMega')).toBe(true);
+    });
+  });
+
+  describe('get() of dueDate', () => {
+    it('should return "instance.next_due_date" attr', () => {
+      viewModel.attr('instance', {next_due_date: '2019-05-15'});
+      expect(viewModel.attr('dueDate')).toBe('2019-05-15');
+    });
+
+    it('should return "instance.end_date" attr ' +
+    'if "instance.next_due_date" attr is falsy value', () => {
+      viewModel.attr('instance', {end_date: '2019-07-15'});
+      expect(viewModel.attr('dueDate')).toBe('2019-07-15');
+    });
+  });
+
+  describe('get() of dueDateCssClass', () => {
+    it('should return "state-overdue" ' +
+    'if "instance.isOverdue" attr is truthy value', () => {
+      viewModel.attr('instance', {isOverdue: true});
+      expect(viewModel.attr('dueDateCssClass')).toBe('state-overdue');
+    });
+
+    it('should return "" if "instance.isOverdue" attr is falsy value', () => {
+      viewModel.attr('instance', {isOverdue: false});
+      expect(viewModel.attr('dueDateCssClass')).toBe('');
+    });
+  });
+
+  describe('get() of isCycleTaskGroupObjectTask', () => {
+    it('should return true if "instance" attr ' +
+    'is instanceof CycleTaskGroupObjectTask', () => {
+      viewModel.attr('instance', new CycleTaskGroupObjectTask);
+      expect(viewModel.attr('isCycleTaskGroupObjectTask')).toBe(true);
+    });
+
+    it('should return false if "instance" attr ' +
+    'is not instanceof CycleTaskGroupObjectTask', () => {
+      viewModel.attr('instance', {});
+      expect(viewModel.attr('isCycleTaskGroupObjectTask')).toBe(false);
+    });
+  });
+
+  describe('get() of cssClasses', () => {
+    it('should return css classes if "instance.snapshot" attr ' +
+    'is truthy value', () => {
+      viewModel.attr('instance', {snapshot: true});
+      expect(viewModel.attr('cssClasses')).toBe('snapshot');
+    });
+
+    it('should return css classes with joined "extraCss" attr', () => {
+      viewModel.attr('instance', {});
+      viewModel.attr('extraCss', 'class1 class2');
+      expect(viewModel.attr('cssClasses')).toBe('class1 class2');
+    });
+
+    it('should return css classes if "instance.snapshot" and "extraCss" attr ' +
+    'are truthy values', () => {
+      viewModel.attr('instance', {snapshot: true});
+      viewModel.attr('extraCss', 'class1 class2');
+      expect(viewModel.attr('cssClasses')).toBe('snapshot class1 class2');
+    });
+  });
+
+  describe('get() of title', () => {
+    it('should return "instance.title" attr ' +
+    'if it is truthy value', () => {
+      viewModel.attr('instance', {title: 'title'});
+      expect(viewModel.attr('title')).toBe('title');
+    });
+
+    it('should return "instance.description_inline" attr ' +
+    'if "instance.title" attr is falsy value', () => {
+      viewModel.attr('instance', {description_inline: 'description_inline'});
+      expect(viewModel.attr('title')).toBe('description_inline');
+    });
+
+    it('should return "instance.name" attr ' +
+    'if "instance.title" and "instance.description_inline" attr ' +
+    'are falsy values', () => {
+      viewModel.attr('instance', {name: 'name'});
+      expect(viewModel.attr('title')).toBe('name');
+    });
+
+    it('should return "instance.email" attr ' +
+    'if "instance.title", "instance.description_inline" and ' +
+    '"instance.name" attr are falsy values', () => {
+      viewModel.attr('instance', {email: 'email'});
+      expect(viewModel.attr('title')).toBe('email');
+    });
+
+    it('should return "" if "instance.title", "instance.description_inline", ' +
+    '"instance.name" and "instance.email" attr are falsy values', () => {
+      viewModel.attr('instance', {});
+      expect(viewModel.attr('title')).toBe('');
+    });
+  });
+
+  describe('inserted event', () => {
+    it('should set "$el" attribute', () => {
+      let handler = Component.prototype.events['inserted'];
+      handler.call({
+        viewModel,
+        element: '<div></div>',
+      });
+      expect(viewModel.attr('$el')).toBe('<div></div>');
+    });
+  });
+
+  describe('"{viewModel.instance} destroyed" event', () => {
+    it('triggers "refreshTree" event', () => {
+      spyOn($.prototype, 'closest').and.returnValue(['closest']);
+      spyOn(trigger, 'call');
+      let handler =
+        Component.prototype.events['{viewModel.instance} destroyed'];
+      handler.call({
+        viewModel,
+        element: '<div></div>',
+      });
+      expect(trigger.call).toHaveBeenCalledWith('closest', 'refreshTree');
+    });
+  });
+});

--- a/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-columns-configuration_spec.js
+++ b/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-columns-configuration_spec.js
@@ -50,6 +50,20 @@ describe('mapper-results-columns-configuration component', function () {
       });
   });
 
+  describe('set() of viewModel.serviceColumns', function () {
+    beforeEach(function () {
+      spyOn(TreeViewUtils, 'getVisibleColumnsConfig').and.returnValue(456);
+    });
+
+    it('updates value of viewModel.serviceColumns with the result of ' +
+    'TreeViewUtils.getVisibleColumnsConfig function', function () {
+      viewModel.attr('serviceColumns', 123);
+      expect(TreeViewUtils.getVisibleColumnsConfig)
+        .toHaveBeenCalledWith(123, 123);
+      expect(viewModel.serviceColumns).toEqual(456);
+    });
+  });
+
   describe('init() method', function () {
     beforeEach(function () {
       spyOn(viewModel, 'initializeColumns');

--- a/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-item-attrs_spec.js
+++ b/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-item-attrs_spec.js
@@ -1,0 +1,42 @@
+/*
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import Component from '../mapper-results-item-attrs';
+
+
+describe('mapper-results-item-attrs component', () => {
+  let viewModel;
+
+  beforeEach(() => {
+    viewModel = getComponentVM(Component);
+  });
+
+  describe('aggregatedColumns()', () => {
+    it('should concat columns and serviceColumns attributes', () => {
+      viewModel.attr('columns', [0, 1]);
+      viewModel.attr('serviceColumns', [5]);
+      const result = viewModel.aggregatedColumns();
+      expect(can.makeArray(result)).toEqual([0, 1, 5]);
+    });
+  });
+
+  describe('click() handler', () => {
+    let handler;
+    let event;
+    beforeEach(() => {
+      handler = Component.prototype.events.click.bind({viewModel});
+      event = {
+        target: $('<a class="link"></a>'),
+        stopPropagation: jasmine.createSpy(),
+      };
+    });
+
+    it('calls stopPropagation() if event.target is .link', () => {
+      handler(null, event);
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-items-header_spec.js
+++ b/src/ggrc-client/js/components/unified-mapper/tests/mapper-results-items-header_spec.js
@@ -15,6 +15,15 @@ describe('mapper-results-items-header component', function () {
     viewModel = getComponentVM(Component);
   });
 
+  describe('aggregatedColumns()', () => {
+    it('should concat columns and serviceColumns attributes', () => {
+      viewModel.attr('columns', [0, 1]);
+      viewModel.attr('serviceColumns', [2]);
+      const result = viewModel.aggregatedColumns();
+      expect(can.makeArray(result)).toEqual([0, 1, 2]);
+    });
+  });
+
   describe('isSorted() method', function () {
     let attr = new can.Map({
       attr_sort_field: 'Title',

--- a/src/ggrc-client/js/controllers/tests/mapper_spec.js
+++ b/src/ggrc-client/js/controllers/tests/mapper_spec.js
@@ -157,5 +157,46 @@ describe('ObjectMapper', function () {
         );
       });
     });
+
+    describe('shows mapper for mega objects', function () {
+      let fakeDataForMega;
+
+      beforeEach(function () {
+        fakeDataForMega = _.assign({}, fakeData, {
+          mega_object: 'Program',
+          mega_object_widget: 'Program_parent',
+          toggle: 'unified unified-search',
+        });
+      });
+
+      it('extends generalConfig with "isMegaObject" and "megaRelation"',
+        function () {
+          let args;
+          let btn = {};
+          method(fakeDataForMega, false, btn);
+
+          args = fakeCtrlInst.launch.calls.argsFor(0);
+
+          expect(args[1]).toEqual(
+            jasmine.objectContaining({
+              general: jasmine.objectContaining({
+                isMegaObject: 'Program',
+                megaRelation: 'parent',
+              }),
+            })
+          );
+        });
+
+      it('calls launch for ObjectMapper with passed btn and config',
+        function () {
+          let btn = {};
+          method(fakeDataForMega, false, btn);
+
+          expect(fakeCtrlInst.launch).toHaveBeenCalledWith(
+            btn,
+            jasmine.any(Object)
+          );
+        });
+    });
   });
 });

--- a/src/ggrc-client/js/models/mixins/tests/mega-object_spec.js
+++ b/src/ggrc-client/js/models/mixins/tests/mega-object_spec.js
@@ -1,0 +1,34 @@
+/*
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import {makeFakeModel} from '../../../../js_specs/spec_helpers';
+import Program from '../../business-models/program';
+
+describe('mega-object mixin', () => {
+  let model;
+
+  beforeEach(function () {
+    model = makeFakeModel({model: Program});
+  });
+
+  describe('created model', () => {
+    it('should has "isMegaObject" equal to true', () => {
+      expect(model.isMegaObject).toBe(true);
+    });
+  });
+
+  describe('"after:init" event', () => {
+    it('should set mega_attr_list attributes', () => {
+      expect(model.tree_view_options.mega_attr_list).toEqual([{
+        attr_title: 'Map as',
+        attr_name: 'map_as',
+        attr_type: 'map_as',
+        order: 41,
+        disable_sorting: true,
+        mandatory: true,
+      }]);
+    });
+  });
+});

--- a/src/ggrc-client/js/plugins/tests/utils/mega-object-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/mega-object-utils_spec.js
@@ -1,0 +1,145 @@
+/*
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+import * as megaObjectUtils from '../../utils/mega-object-utils';
+import {businessObjects} from '../../../plugins/models-types-collections';
+
+describe('getRelatedWidgetNames method', () => {
+  it('should return composed mega object specific widget names', () => {
+    const result = megaObjectUtils.getRelatedWidgetNames('Program');
+    expect(result).toEqual(['Program_child', 'Program_parent']);
+  });
+});
+
+describe('isMegaObjectRelated method', () => {
+  it('should return true if widget name has relation to Mega object as parent',
+    () => {
+      const result = megaObjectUtils.isMegaObjectRelated('Program_parent');
+      expect(result).toBeTruthy();
+    });
+
+  it('should return true if widget name has relation to Mega object as child',
+    () => {
+      const result = megaObjectUtils.isMegaObjectRelated('Program_child');
+      expect(result).toBeTruthy();
+    });
+
+  it('should return false if widget name has not relation to Mega object',
+    () => {
+      const result = megaObjectUtils.isMegaObjectRelated('Program');
+      expect(result).toBeFalsy();
+    });
+});
+
+describe('isMegaMapping method', () => {
+  it('should return true if models are equal and they are a megaObject',
+    () => {
+      const megaObjects = ['Program'];
+      businessObjects.forEach((obj1) => {
+        businessObjects.forEach((obj2) => {
+          const result = megaObjectUtils.isMegaMapping(obj1, obj2);
+          if (obj1 === obj2 && megaObjects.includes(obj1)) {
+            expect(result).toBe(true);
+          } else {
+            expect(result).toBe(false);
+          }
+        });
+      });
+    });
+});
+
+describe('getMegaObjectConfig method', () => {
+  it('should return config for mega object', () => {
+    const result = megaObjectUtils.getMegaObjectConfig('Program_parent');
+    expect(result).toEqual({
+      name: 'Program',
+      originalModelName: 'Program',
+      widgetId: 'Program_parent',
+      widgetName: 'Parent Programs',
+      relation: 'parent',
+      isMegaObject: true,
+    });
+  });
+});
+
+describe('getMegaObjectRelation method', () => {
+  it('should return object with original model name as source ' +
+  'and relation parsed from modelName', () => {
+    const result = megaObjectUtils.getMegaObjectRelation('Program_parent');
+    expect(result).toEqual({
+      source: 'Program',
+      relation: 'parent',
+    });
+  });
+});
+
+describe('transformQueryForMega method', () => {
+  it('should return transformed query if query.filters.expression and ' +
+  'query.fields are not defined', () => {
+    const result = megaObjectUtils.transformQueryForMega({
+      object_name: 'Program_parent',
+      filters: {},
+    });
+    expect(result).toEqual({
+      object_name: 'Program',
+      filters: {},
+    });
+  });
+
+  it('should return transformed query if query.filters.expression is defined',
+    () => {
+      const result = megaObjectUtils.transformQueryForMega({
+        object_name: 'Program_parent',
+        filters: {
+          expression: {},
+        },
+      });
+      expect(result).toEqual({
+        object_name: 'Program',
+        filters: {
+          expression: {
+            op: {
+              name: 'parent',
+            },
+          },
+        },
+      });
+    });
+
+  it('should return transformed query if query.fields is defined ' +
+  'and does not contain "is_mega"', () => {
+    const result = megaObjectUtils.transformQueryForMega({
+      object_name: 'Program_parent',
+      filters: {},
+      fields: 'field',
+    });
+    expect(result).toEqual({
+      object_name: 'Program',
+      filters: {},
+      fields: 'fieldis_mega',
+    });
+  });
+
+  it('should return transformed query if query.filters.expression, ' +
+  'query.fields are defined and does not contain "is_mega"', () => {
+    const result = megaObjectUtils.transformQueryForMega({
+      object_name: 'Program_parent',
+      filters: {
+        expression: {},
+      },
+      fields: 'field',
+    });
+    expect(result).toEqual({
+      object_name: 'Program',
+      filters: {
+        expression: {
+          op: {
+            name: 'parent',
+          },
+        },
+      },
+      fields: 'fieldis_mega',
+    });
+  });
+});

--- a/src/ggrc-client/js/plugins/tests/utils/object-versions-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/object-versions-utils_spec.js
@@ -1,0 +1,61 @@
+/*
+  Copyright (C) 2019 Google Inc.
+  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import * as objectVersionsUtils from '../../utils/object-versions-utils';
+import {businessObjects} from '../../../plugins/models-types-collections';
+
+describe('isObjectVersion method', () => {
+  it('should return true if model name contains "_version"', () => {
+    const result = objectVersionsUtils.isObjectVersion('Program_version');
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false if model name does not contain "_version"', () => {
+    const result = objectVersionsUtils.isObjectVersion('Program');
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if called without param', () => {
+    const result = objectVersionsUtils.isObjectVersion();
+    expect(result).toBeFalsy();
+  });
+
+  it('should return false if param type is not "string"', () => {
+    const result = objectVersionsUtils.isObjectVersion([]);
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('parentHasObjectVersions method', () => {
+  it('should return true if parent model has object versions tabs', () => {
+    businessObjects.forEach((obj) => {
+      const result = objectVersionsUtils.parentHasObjectVersions(obj);
+      if (obj === 'Issue') {
+        expect(result).toBeTruthy();
+      } else {
+        expect(result).toBeFalsy();
+      }
+    });
+  });
+});
+
+describe('getObjectVersionConfig method', () => {
+  it('should return {} if model name does not contain "_version"', () => {
+    const result = objectVersionsUtils.getObjectVersionConfig('Program');
+    expect(result).toEqual({});
+  });
+
+  it('should return object version config if model name contains "_version"',
+    () => {
+      const result = objectVersionsUtils
+        .getObjectVersionConfig('Program_version');
+      expect(result).toEqual({
+        originalModelName: 'Program',
+        isObjectVersion: true,
+        widgetId: 'Program_version',
+        widgetName: 'Programs Versions',
+      });
+    });
+});

--- a/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
@@ -434,4 +434,73 @@ describe('GGRC Utils Widgets', function () {
         });
     });
   });
+
+  describe('getWidgetConfigs() method', function () {
+    it('should return object configs', function () {
+      const result = WidgetsUtils.getWidgetConfigs(
+        [{name: 'Program'}, {name: 'Assesment'}]);
+      expect(result).toEqual([{
+        name: 'Program',
+        widgetName: 'Program',
+        widgetId: 'Program',
+      }, {
+        name: 'Assesment',
+        widgetName: 'Assesment',
+        widgetId: 'Assesment',
+      }]);
+    });
+  });
+
+  describe('getWidgetConfig() method', function () {
+    it('should return object config if model name is Object', function () {
+      const result = WidgetsUtils.getWidgetConfig({name: 'Program'});
+      expect(result).toEqual({
+        name: 'Program',
+        widgetName: 'Program',
+        widgetId: 'Program',
+      });
+    });
+
+    it('should return object config if model name is cashed', function () {
+      WidgetsUtils.getWidgetConfig('Program_version');
+      const result = WidgetsUtils.getWidgetConfig('Program_version');
+      expect(result).toEqual({
+        name: 'Program',
+        widgetId: 'Program_version',
+        widgetName: 'Programs Versions',
+        countsName: 'Program_version',
+        isObjectVersion: true,
+        relation: undefined,
+        isMegaObject: undefined,
+      });
+    });
+
+    it('should return object config if model name contains "_version"',
+      function () {
+        const result = WidgetsUtils.getWidgetConfig('Program_version');
+        expect(result).toEqual({
+          name: 'Program',
+          widgetId: 'Program_version',
+          widgetName: 'Programs Versions',
+          countsName: 'Program_version',
+          isObjectVersion: true,
+          relation: undefined,
+          isMegaObject: undefined,
+        });
+      }
+    );
+
+    it('should return object config if model name is mega object', function () {
+      const result = WidgetsUtils.getWidgetConfig('Program_parent');
+      expect(result).toEqual({
+        name: 'Program',
+        widgetId: 'Program_parent',
+        widgetName: 'Parent Programs',
+        countsName: 'Program_parent',
+        isObjectVersion: undefined,
+        relation: 'parent',
+        isMegaObject: true,
+      });
+    });
+  });
 });

--- a/src/ggrc-client/js/plugins/utils/mega-object-utils.js
+++ b/src/ggrc-client/js/plugins/utils/mega-object-utils.js
@@ -36,7 +36,7 @@ function isMegaObjectRelated(widgetName) {
  * @return {Boolean} True or False
  */
 function isMegaMapping(model1, model2) {
-  return model1 === model2 && businessModels[model1].isMegaObject;
+  return model1 === model2 && !!businessModels[model1].isMegaObject;
 }
 
 /**


### PR DESCRIPTION
# Solution description

Add missing tests for Mega Program FE.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
