### PR TITLE
Revert "GGRC-6812 Cannot turn ON issue tracker for completed assessment"

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -290,7 +290,6 @@ class AssessmentTrackerHandler(object):
       return
 
     if not self._is_issue_on_create_enabled(assessment, assessment_src):
-      self._create_disabled_record(assessment, assessment_src)
       return
 
     issue_id = assessment_src.get("issue_tracker", {}).get("issue_id")
@@ -315,15 +314,6 @@ class AssessmentTrackerHandler(object):
           assessment,
           issue_info
       )
-
-  @staticmethod
-  def _create_disabled_record(assessment, assessment_src):
-    """Create IssueTrackerIssue model for assessment with default values"""
-    integration_utils.set_values_for_missed_fields(assessment, assessment_src)
-    all_models.IssuetrackerIssue.create_or_update_from_dict(
-        assessment,
-        assessment_src,
-    )
 
   def handle_assessment_delete(self, assessment):
     """Handle assessment issue delete.

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -1272,34 +1272,6 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
       )
       self.assertEqual(issue_obj.enabled, issue_tracker_enabled)
 
-  def test_default_values_set_correctly(self):
-    """Check audit values were set to assessment with disabled integration"""
-    with factories.single_commit():
-      audit = factories.AuditFactory()
-      audit_id = audit.id
-      factories.IssueTrackerIssueFactory(
-          issue_tracked_obj=audit,
-          component_id=self.DEFAULT_ASSESSMENT_ATTRS["component_id"],
-          hotlist_id=self.DEFAULT_ASSESSMENT_ATTRS["hotlist_id"],
-          issue_priority=self.DEFAULT_ASSESSMENT_ATTRS["issue_priority"],
-          issue_severity=self.DEFAULT_ASSESSMENT_ATTRS["issue_severity"],
-          issue_type=self.DEFAULT_ASSESSMENT_ATTRS["issue_type"],
-      )
-
-    payload = self.request_payload_builder({"enabled": False}, audit)
-    response = self.api.post(all_models.Assessment, payload)
-
-    self.assertEqual(response.status_code, 201)
-    assmt_id = response.json.get("assessment").get("id")
-    assmt_iti = models.IssuetrackerIssue.get_issue("Assessment", assmt_id)
-    audit_iti = models.IssuetrackerIssue.get_issue("Audit", audit_id)
-
-    self.assertEqual(assmt_iti.component_id, audit_iti.component_id)
-    self.assertEqual(assmt_iti.hotlist_id, audit_iti.hotlist_id)
-    self.assertEqual(assmt_iti.issue_priority, audit_iti.issue_priority)
-    self.assertEqual(assmt_iti.issue_severity, audit_iti.issue_severity)
-    self.assertEqual(assmt_iti.issue_type, audit_iti.issue_type)
-
 
 @mock.patch('ggrc.models.hooks.issue_tracker.'
             'assessment_integration.AssessmentTrackerHandler.'


### PR DESCRIPTION
Reverts google/ggrc-core#9430
We have bug now. We can create audit with issue tracker off. than create assessments. 
If wi will turn on issue tracker on audit and change values for integration and then generate tickets it would create tickets with default values instead of audit ones.