### PR TITLE
QUICK-FIX Set attribute_object_id for global CAVs to NULL

### DIFF
--- a/src/ggrc/migrations/versions/20190524_b881918e8cdc_set_cav_attribute_object_id_to_null.py
+++ b/src/ggrc/migrations/versions/20190524_b881918e8cdc_set_cav_attribute_object_id_to_null.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+set_cav_attribute_object_id_to_null
+
+Create Date: 2019-05-24 16:05:16.169777
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b881918e8cdc'
+down_revision = '296bde07a661'
+
+
+def get_cav_with_attribute_object_id(conn):
+  """Get CAVs having attribute_object_id set."""
+  sql = """
+      SELECT
+          cav.id
+      FROM custom_attribute_values AS cav
+          JOIN custom_attribute_definitions AS cad
+          ON cav.custom_attribute_id = cad.id
+      WHERE
+          cad.definition_id IS NULL AND
+          cav.attribute_object_id IS NOT NULL
+      ;
+  """
+  return conn.execute(sa.text(sql)).fetchall()
+
+
+def set_attribute_object_id_null(conn, cavs):
+  """Set attribute_object_id for CAVs to NULL."""
+  if not cavs:
+    return
+  sql = """
+      UPDATE custom_attribute_values
+      SET attribute_object_id = NULL
+      WHERE id IN :ids;
+  """
+  conn.execute(sa.text(sql), ids=[cav.id for cav in cavs])
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  conn = op.get_bind()
+  cavs = get_cav_with_attribute_object_id(conn)
+  set_attribute_object_id_null(conn, cavs)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Mappable CAV holds mapped object ID in `attribute_object_id` field. In #9223 all CADs with type `Map:Person` where changed to type `Text` but values in `attribute_object_id` on CAV still remains the same. This causes problems during object serialization in query API.

JSON builder has the following code:
```py
if getattr(obj, '{0}_id'.format(attr_name)):
          result = LazyStubRepresentation(
              getattr(obj, '{0}_type'.format(attr_name)),
              getattr(obj, '{0}_id'.format(attr_name)))
```

So since `attribute_object_id` still holds person ID, for `obj` of `CustomAttributeValue` type and `attr_name = "attribute_object"` code above returns `LazyStubRepresentation` with `type` set to `None`. The reason for it is in the code bellow:
```py
  @property
  def attribute_object_type(self):
    """Fetch the mapped object pointed to by attribute_object_id.

    Returns:
       A model of type referenced in attribute_value
    """
    attr_type = self.custom_attribute.attribute_type
    if not attr_type.startswith("Map:"):
      return None
    return self.attribute_object.__class__.__name__
```

Here if CAD type does not start with `Map:`, `attribute_object_type` returns `None`. And this cases errors since JSON builder tries to get model by type from `LazyStubRepresentation`,  but receives `None`.

# Steps to test the changes

1. Try to map Control to Program;

Expected result: there should not be any errors during control search on map modal window.

# Solution description

Solution includes migration which sets `attribute_object_id` for global CAVs to `NULL`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
