### PR TITLE
GGRC-6358 Assessment File Upload - Frequent Auth Requested

### DIFF
--- a/src/ggrc/gdrive/__init__.py
+++ b/src/ggrc/gdrive/__init__.py
@@ -50,6 +50,7 @@ def get_http_auth():
     logger.exception(ex.message)
     del flask.session['credentials']
     raise GdriveUnauthorized(errors.GDRIVE_UNAUTHORIZED)
+  flask.session.permanent = True
   flask.session['credentials'] = credentials.to_json()
   return http_auth
 
@@ -80,6 +81,7 @@ def auth_gdrive():
   # to prevent Cross Site Request Forgery we need to send state to google auth
   state = str(uuid.uuid4())
   auth_uri = flow.step1_get_authorize_url(state=state)
+  flask.session.permanent = True
   flask.session['state'] = state
   return flask.redirect(auth_uri)
 
@@ -99,7 +101,7 @@ def authorize_app():
   except FlowExchangeError as ex:
     logger.exception(ex.message)
     raise Unauthorized(errors.UNABLE_GET_TOKEN.format(ex.message))
-
+  flask.session.permanent = True
   flask.session['credentials'] = credentials.to_json()
   return render_template('gdrive/auth_gdrive.haml')
 
@@ -112,6 +114,8 @@ def init_flow():
       redirect_uri=flask.url_for('authorize_app', _external=True),
       auth_uri=_GOOGLE_AUTH_URI,
       token_uri=_GOOGLE_TOKEN_URI,
+      access_type='offline',
+      prompt='consent',
   )
 
 

--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -3,9 +3,10 @@
 
 """Module defines application settings."""
 
-import os
-import jinja2
 import datetime
+import os
+
+import jinja2
 
 DEBUG = False
 TESTING = False

--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -5,6 +5,7 @@
 
 import os
 import jinja2
+import datetime
 
 DEBUG = False
 TESTING = False
@@ -89,6 +90,8 @@ else:
 # Initialize from environment if present
 SQLALCHEMY_DATABASE_URI = os.environ.get('GGRC_DATABASE_URI', '')
 SECRET_KEY = os.environ.get('GGRC_SECRET_KEY', 'Replace-with-something-secret')
+PERMANENT_SESSION_LIFETIME = os.environ.get('GGRC_PERMANENT_SESSION_LIFETIME',
+                                            datetime.timedelta(days=365))
 
 MEMCACHE_MECHANISM = True
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When uploading files to assessments, I get asked to auth for what seems like every assessment I complete. This can happen many times in the same day or even in the same session.

# Steps to test the changes

Try to attach evidence to assessment with few scenarios. 
1) during day with more than hour interval
2) deploy with reduced cookie lifetime, and check updating expired refresh token
3) Also check imports are working.

Also i think we should notify users that they would be asked to give permissions to our app and should not worry about it.

# Solution description

During authorization on google drive we get access token and refresh token. Access token get 1 hour life limit, but we can use refresh token to get new access token.
Refresh tokens are send only in case of consent prompt at google, that is why I changed it. Also I changed cookie storage lifetime to one year. 

http://flask.pocoo.org/docs/1.0/api/#flask.Flask.permanent_session_lifetime
http://flask.pocoo.org/docs/1.0/api/#sessions
http://usefulangle.com/post/51/google-refresh-token-common-questions

https://developers.google.com/identity/protocols/OAuth2WebServer

PS. FE also get access tokens from google using JS library and we can't improve it. Looks like it already working good.
`chrome://settings/siteData` you can use this link to delete cookies

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
