### PR TITLE
GGRC-7361 No possibility to Search by Created By/Due Date/Last Owner Reviewed Date/Last Owner Reviewed By/Last Compliance Reviewed Date/Last Compliance Reviewed By

### DIFF
--- a/src/ggrc-client/js/components/tree/tree-item-attr.js
+++ b/src/ggrc-client/js/components/tree/tree-item-attr.js
@@ -33,6 +33,14 @@ const RICH_TEXT_ATTRS = new Set([
   'vulnerability',
 ]);
 
+// attribute names considered "default" and representing fields which contain
+// at least "email" field
+const PERSON_ATTRS = new Set([
+  'created_by',
+  'last_submitted_by',
+  'last_verified_by',
+]);
+
 export default can.Component.extend({
   tag: 'tree-item-attr',
   view: can.stache(template),
@@ -85,9 +93,14 @@ export default can.Component.extend({
       const regexNewLines = /<\/p>?/g;
 
       if (result !== undefined && result !== null) {
+        if (PERSON_ATTRS.has(attrName)) {
+          return result.attr('email');
+        }
+
         if (DATE_ATTRS.has(attrName)) {
           return formatDate(result, true);
         }
+
         if (RICH_TEXT_ATTRS.has(attrName)) {
           if (this.isMarkdown()) {
             result = convertMarkdownToHtml(result);

--- a/src/ggrc-client/js/components/tree/tree-item-attr.js
+++ b/src/ggrc-client/js/components/tree/tree-item-attr.js
@@ -8,28 +8,30 @@ import template from './templates/tree-item-attr.stache';
 import {convertMarkdownToHtml} from '../../plugins/utils/markdown-utils';
 
 // attribute names considered "default" and representing a date
-const DATE_ATTRS = Object.freeze({
-  end_date: 1,
-  due_date: 1,
-  finished_date: 1,
-  start_date: 1,
-  created_at: 1,
-  updated_at: 1,
-  verified_date: 1,
-  last_deprecated_date: 1,
-  last_assessment_date: 1,
-});
+const DATE_ATTRS = new Set([
+  'end_date',
+  'due_date',
+  'finished_date',
+  'start_date',
+  'created_at',
+  'updated_at',
+  'verified_date',
+  'last_deprecated_date',
+  'last_assessment_date',
+  'last_submitted_at',
+  'last_verified_at',
+]);
 
 // attribute names considered "default" and representing rich text fields
-const RICH_TEXT_ATTRS = Object.freeze({
-  notes: 1,
-  description: 1,
-  test_plan: 1,
-  risk_type: 1,
-  threat_source: 1,
-  threat_event: 1,
-  vulnerability: 1,
-});
+const RICH_TEXT_ATTRS = new Set([
+  'notes',
+  'description',
+  'test_plan',
+  'risk_type',
+  'threat_source',
+  'threat_event',
+  'vulnerability',
+]);
 
 export default can.Component.extend({
   tag: 'tree-item-attr',
@@ -83,10 +85,10 @@ export default can.Component.extend({
       const regexNewLines = /<\/p>?/g;
 
       if (result !== undefined && result !== null) {
-        if (attrName in DATE_ATTRS) {
+        if (DATE_ATTRS.has(attrName)) {
           return formatDate(result, true);
         }
-        if (attrName in RICH_TEXT_ATTRS) {
+        if (RICH_TEXT_ATTRS.has(attrName)) {
           if (this.isMarkdown()) {
             result = convertMarkdownToHtml(result);
           }

--- a/src/ggrc-client/js/models/business-models/risk.js
+++ b/src/ggrc-client/js/models/business-models/risk.js
@@ -76,6 +76,30 @@ export default Cacheable.extend({
         attr_name: 'external_review_status',
         attr_sort_field: 'review_status_display_name',
         order: 80,
+      }, {
+        attr_title: 'Created By',
+        attr_name: 'created_by',
+        attr_sort_field: 'created_by',
+      }, {
+        attr_title: 'Due Date',
+        attr_name: 'due_date',
+        attr_sort_field: 'due_date',
+      }, {
+        attr_title: 'Last Owner Reviewed Date',
+        attr_name: 'last_submitted_at',
+        attr_sort_field: 'last_submitted_at',
+      }, {
+        attr_title: 'Last Owner Reviewed By',
+        attr_name: 'last_submitted_by',
+        attr_sort_field: 'last_submitted_by',
+      }, {
+        attr_title: 'Last Compliance Reviewed Date',
+        attr_name: 'last_verified_at',
+        attr_sort_field: 'last_verified_at',
+      }, {
+        attr_title: 'Last Compliance Reviewed By',
+        attr_name: 'last_verified_by',
+        attr_sort_field: 'last_verified_by',
       }]),
   },
   sub_tree_view_options: {

--- a/src/ggrc/models/risk.py
+++ b/src/ggrc/models/risk.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import validates
 
 from ggrc import db
 from ggrc import utils as ggrc_utils
+from ggrc.fulltext import attributes
 from ggrc.fulltext.mixin import Indexed
 from ggrc.models import comment
 from ggrc.models import exceptions
@@ -112,7 +113,27 @@ class Risk(synchronizable.Synchronizable,
       'threat_source',
       'threat_event',
       'vulnerability',
-      'review_status_display_name'
+      'review_status_display_name',
+      attributes.DateFullTextAttr('due_date', 'due_date'),
+      attributes.DatetimeFullTextAttr('last_submitted_at',
+                                      'last_submitted_at'),
+      attributes.DatetimeFullTextAttr('last_verified_at',
+                                      'last_verified_at'),
+      attributes.FullTextAttr(
+          "created_by",
+          "created_by",
+          ["email", "name"]
+      ),
+      attributes.FullTextAttr(
+          "last_submitted_by",
+          "last_submitted_by",
+          ["email", "name"]
+      ),
+      attributes.FullTextAttr(
+          "last_verified_by",
+          "last_verified_by",
+          ["email", "name"]
+      )
   ]
 
   _custom_publish = {
@@ -176,6 +197,30 @@ class Risk(synchronizable.Synchronizable,
       },
       "review_status_display_name": {
           "display_name": "Review Status",
+          "mandatory": False,
+      },
+      "due_date": {
+          "display_name": "Due Date",
+          "mandatory": False,
+      },
+      "created_by": {
+          "display_name": "Created By",
+          "mandatory": False,
+      },
+      "last_submitted_at": {
+          "display_name": "Last Owner Reviewed Date",
+          "mandatory": False,
+      },
+      "last_submitted_by": {
+          "display_name": "Last Owner Reviewed By",
+          "mandatory": False,
+      },
+      "last_verified_at": {
+          "display_name": "Last Compliance Reviewed Date",
+          "mandatory": False,
+      },
+      "last_verified_by": {
+          "display_name": "Last Compliance Reviewed By",
           "mandatory": False,
       },
   }

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -844,6 +844,12 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Threat Event",
         "Risk Type",
         "Review Status",
+        "Due Date",
+        "Created By",
+        "Last Owner Reviewed Date",
+        "Last Owner Reviewed By",
+        "Last Compliance Reviewed Date",
+        "Last Compliance Reviewed By",
     }
     expected_fields = {
         "mandatory": {


### PR DESCRIPTION
# Issue description
Steps to reproduce:
1. Login ggrc app and open Global Search
2. Search Risks by Created By/Due Date/Last Owner Reviewed Date/Last Owner Reviewed By/Last Compliance Reviewed Date/Last Compliance Reviewed By
Actual Result: "Created By/Due Date/Last Owner Reviewed Date/Last Owner Reviewed By/Last Compliance Reviewed Date/Last Compliance Reviewed By" are not displayed in attributes dropdown in Global Search, Unified Mapper, Advanced Search
Expected Result: "Created By/Due Date/Last Owner Reviewed Date/Last Owner Reviewed By/Last Compliance Reviewed Date/Last Compliance Reviewed By" should be displayed in attributes dropdown in Global Search, Unified Mapper, Advanced Search. User should be able to Search by such attributes.

# Steps to test the changes
Run reindex task
Try to search by steps above

# Solution description
Add attributes for fulltext search in Risk class
Run reindex

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


