### PR TITLE
GGRC-7301 Border is not red for mandatory CA

### DIFF
--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -933,7 +933,8 @@ export default can.Control.extend({
       $.when(this.options.attr('instance', newInstance))
         .then(() => this.apply_object_params())
         .then(() => this.serialize_form())
-        .then((el) => this.autocomplete(el));
+        .then((el) => this.autocomplete(el))
+        .then(() => this.options.attr('instance').backup());
     });
 
     this.restore_ui_status();


### PR DESCRIPTION
# Issue description

Mandatory fields in popup are not highlighted in red when we create an object by clicking on 'Save & Add Another' button

# Steps to test the changes

1. Open New Assessment popup with mandatory GCA
2. Fill out required fields and click 'Save & Add Another' button
3. In New Assessment popup fill in a title and click out of title field

**Actual Result**: No red color for mandatory CA
**Expected result**: Border for mandatory CA should be displayed

# Solution description

In change event handler for popup the result of checking for isDirty returns false for instance created by clicking on 'Save & Add Another' button because they do not have backup.
Add call backup for instance created by clicking on 'Save & Add Another' button.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
