### PR TITLE
QUICK-FIX Fix wrong test params

### DIFF
--- a/test/integration/ggrc/services/test_query/test_snapshots.py
+++ b/test/integration/ggrc/services/test_query/test_snapshots.py
@@ -596,7 +596,7 @@ class TestSnapshotIndexing(TestCase, WithQueryApi):
 
   @data(
       ("updated_at", ("updated_at", "Last Updated Date", "last updated date")),
-      ("created_at", ("updated_at", "Created Date", "Created Date")),
+      ("created_at", ("created_at", "Created Date", "created date")),
   )
   @unpack
   def test_filter_by_dt_field(self, field, aliases):


### PR DESCRIPTION

# Issue description

We have a test with wrong params thats need to be fixed.

# Steps to test the changes

Tests should pass same as before.

# Solution description

Fix parameters list.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
