### PR TITLE
GGRC-7022 Snapshotable object has last deleted GCA after deleting all GCAs and before getting the latest version

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -479,17 +479,9 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
 
   def _get_cads(self):
     """Return cads definitions from content and new CADs from db."""
-    from ggrc.models import custom_attribute_definition
-
-    all_cads = []
-    if "custom_attribute_definitions" in self._content and \
-       self._content["custom_attribute_definitions"]:
-      all_cads.extend(self._content["custom_attribute_definitions"])
-
-    db_cads = custom_attribute_definition.get_custom_attributes_for(
-        self.resource_type, self.resource_id)
-    all_cads_ids = [cad['id'] for cad in all_cads]
-    return all_cads + [cad for cad in db_cads if cad['id'] not in all_cads_ids]
+    if "custom_attribute_definitions" in self._content:
+      return self._content["custom_attribute_definitions"]
+    return []
 
   def populate_cavs(self):
     """Setup cads in cav list if they are not presented in content

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -298,6 +298,9 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
     cad = all_models.CustomAttributeDefinition.query.get(cad_id)
     self.assertEqual(cad.id,
                      revision.content["custom_attribute_definitions"][0]["id"])
+    old_revision = revisions[1]
+    self.assertEqual([], old_revision.content["custom_attribute_values"])
+    self.assertEqual([], old_revision.content["custom_attribute_definitions"])
 
   @ddt.data(
       ("Text", ""),

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -269,27 +269,39 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
     self.assertEqual([], revision._content["custom_attribute_values"])
     self.assertEqual([], revision._content["custom_attribute_definitions"])
     self.assertIn("custom_attribute_values", revision.content)
-    self.assertEqual(
-        [{
-            'attributable_id': asmnt_id,
-            'attributable_type': 'Assessment',
-            'attribute_object': None,
-            'attribute_value': attribute_value,
-            'context_id': None,
-            'custom_attribute_id': cad_id,
-            'display_name': '',
-            'type': 'CustomAttributeValue',
-        }],
-        revision.content["custom_attribute_values"])
+    self.assertEqual([], revision.content["custom_attribute_values"])
     self.assertIn("custom_attribute_definitions", revision.content)
+    self.assertEqual([], revision.content["custom_attribute_definitions"])
+
+    self.gen.api.modify_object(
+        asmnt, {
+            "custom_attribute_values": [{
+                "attributable_id": asmnt.id,
+                "attributable_type": "assessment",
+                "attribute_value": attribute_value,
+                "custom_attribute_id": cad.id,
+            }, ],
+        },
+    )
+    revisions = ggrc.models.Revision.query.filter(
+        ggrc.models.Revision.resource_id == asmnt_id,
+        ggrc.models.Revision.resource_type == "Assessment",
+    ).order_by(ggrc.models.Revision.id.desc()).all()
+    self.assertEqual(2, len(revisions))
+    revision = revisions[0]
+    self.assertEqual(1, len(revision.content["custom_attribute_values"]))
+    cav = revision.content["custom_attribute_values"][0]
+    self.assertEqual(asmnt_id, cav["attributable_id"])
+    self.assertEqual(cad_id, cav["custom_attribute_id"])
+    self.assertIn("custom_attribute_definitions", revision.content)
+    self.assertEqual(1, len(revision.content["custom_attribute_definitions"]))
     cad = all_models.CustomAttributeDefinition.query.get(cad_id)
-    self.assertEqual([cad.log_json()],
-                     revision.content["custom_attribute_definitions"])
+    self.assertEqual(cad.id,
+                     revision.content["custom_attribute_definitions"][0]["id"])
 
   @ddt.data(
       ("Text", ""),
       ("Rich Text", ""),
-      ("Dropdown", ""),
       ("Checkbox", "0"),
       ("Date", ""),
   )
@@ -301,7 +313,6 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
   @ddt.data(
       ("Text", ""),
       ("Rich Text", ""),
-      ("Dropdown", ""),
       ("Checkbox", "0"),
       ("Date", ""),
   )


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

After previous PR https://github.com/google/ggrc-core/pull/9258 objects return extra CADs.

# Steps to test the changes

1. Open audit with mapped objective snapshot
2. Open Admin page and add any few GCAs for Objective
3. Refresh audit page and open objective snapshot: new GCAs are displayed (incorrect)
4. Remove GCAs for Objective on Admin page
5. Refresh audit page and open objective snapshot: the least removed GCA is displayed (incorrect)

# Solution description

We should return only CADs that is saved in revision and do not fetch CADs from custom_attributes_description DB table.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
