### PR TITLE
GGRC-3837 Make name field mandatory for User model

### DIFF
--- a/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
+++ b/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
@@ -24,7 +24,6 @@ def upgrade():
   """)
 
 
-
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
   raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
+++ b/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '437d91566937'
-down_revision = '6d7a0c2baba1'
+down_revision = '0cc3ce187621'
 
 
 def upgrade():

--- a/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
+++ b/src/ggrc/migrations/versions/20190514_437d91566937_make_user_mandatory_for_person.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+make user mandatory for Person
+
+Create Date: 2019-05-14 08:32:27.609326
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '437d91566937'
+down_revision = '6d7a0c2baba1'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      ALTER TABLE people
+      MODIFY COLUMN name VARCHAR (250) NOT NULL
+  """)
+
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
+++ b/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
@@ -24,6 +24,7 @@ def upgrade():
       SET name=SUBSTRING_INDEX(email, '@', 1) WHERE name=''
   """)
 
+
 def downgrade():
   """Downgrade database schema and/or data back to the previous revision."""
   raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
+++ b/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
@@ -10,19 +10,38 @@ Create Date: 2019-06-04 11:35:57.993731
 # pylint: disable=invalid-name
 
 from alembic import op
+from ggrc.migrations import utils
 
 
 # revision identifiers, used by Alembic.
 revision = '1f6da86c4564'
-down_revision = 'b6e89c388581'
+down_revision = '437d91566937'
+
+
+def get_users_without_name(conn):
+  """Get users with empty name column"""
+  res = conn.execute("""
+      SELECT id FROM people
+      WHERE name=''
+  """)
+  ids = [person[0] for person in res.fetchall()]
+  return ids
 
 
 def upgrade():
   """Upgrade database schema and/or data, creating a new revision."""
+  conn = op.get_bind()
+  ids = get_users_without_name(conn)
+  utils.add_to_objects_without_revisions_bulk(
+      conn, ids, obj_type="Person", action="modified"
+  )
+
+  migrator_id = utils.migrator.get_migration_user_id(conn)
   op.execute("""
       UPDATE people
-      SET name=SUBSTRING_INDEX(email, '@', 1) WHERE name=''
-  """)
+      SET name=SUBSTRING_INDEX(email, '@', 1), modified_by_id={migrator_id}
+      WHERE name=''
+  """.format(migrator_id=migrator_id))
 
 
 def downgrade():

--- a/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
+++ b/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+update empty name from email
+
+Create Date: 2019-06-04 11:35:57.993731
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1f6da86c4564'
+down_revision = '437d91566937'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      UPDATE people
+      SET name=SUBSTRING_INDEX(email, '@', 1) WHERE name=''
+  """)
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
+++ b/src/ggrc/migrations/versions/20190604_1f6da86c4564_update_empty_name_from_email.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '1f6da86c4564'
-down_revision = '437d91566937'
+down_revision = 'b6e89c388581'
 
 
 def upgrade():

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -42,7 +42,7 @@ class Person(CustomAttributable, CustomAttributeMapable, HasOwnContext,
   __tablename__ = 'people'
 
   email = deferred(db.Column(db.String, nullable=False), 'Person')
-  name = deferred(db.Column(db.String), 'Person')
+  name = deferred(db.Column(db.String, nullable=False), 'Person')
   language_id = deferred(db.Column(db.Integer), 'Person')
   company = deferred(db.Column(db.String), 'Person')
 
@@ -162,6 +162,13 @@ class Person(CustomAttributable, CustomAttributeMapable, HasOwnContext,
       message = "Email address '{}' is invalid. Valid email must be provided"
       raise ValidationError(message.format(email))
     return email
+
+  @validates('name')
+  def validate_name(self, _, name):
+    """Name property validator."""
+    if not name:
+      raise ValidationError("Name is empty")
+    return name
 
   @staticmethod
   def is_valid_email(val):

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1214,6 +1214,10 @@ class Resource(ModelView):
 
       # auto generation of user with Creator role if external flag is set
       if body and 'person' in body[0]:
+
+        if not body[0]["person"].get("name") and body[0]["person"].get("email"):
+          body[0]["person"]["name"] = body[0]["person"]["email"].split("@")[0]
+
         ext_flags_passed = {p.get("person", {}).get("external", False)
                             for p in body}
         if ext_flags_passed == {True, False}:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1215,7 +1215,8 @@ class Resource(ModelView):
       # auto generation of user with Creator role if external flag is set
       if body and 'person' in body[0]:
 
-        if not body[0]["person"].get("name") and body[0]["person"].get("email"):
+        if not body[0]["person"].get("name") and \
+           body[0]["person"].get("email"):
           body[0]["person"]["name"] = body[0]["person"]["email"].split("@")[0]
 
         ext_flags_passed = {p.get("person", {}).get("external", False)

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -346,6 +346,7 @@ class TestBasicCsvImport(TestCase):
 
     expected_errors = {
         errors.MISSING_VALUE_ERROR.format(line=8, column_name="Email"),
+        errors.MISSING_VALUE_ERROR.format(line=9, column_name="Name"),
         errors.WRONG_VALUE_ERROR.format(line=10, column_name="Email"),
         errors.WRONG_VALUE_ERROR.format(line=11, column_name="Email"),
     }

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -714,6 +714,7 @@ class TestGetObjectColumnDefinitions(TestCase):
     expected_fields = {
         "mandatory": {
             "Email",
+            "Name",
         },
         "unique": {
             "Email",

--- a/test/integration/ggrc/fulltext/test_mysql.py
+++ b/test/integration/ggrc/fulltext/test_mysql.py
@@ -172,5 +172,6 @@ class TestMysql(TestCase):
         sorted([
             (searchable_person.email, "{}-email".format(searchable_person.id)),
             (searchable_person.email, "__sort__"),
+            (searchable_person.name, "{}-name".format(searchable_person.id)),
         ]),
         sorted(searchable_contents))

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -268,6 +268,9 @@ class PersonFactory(ModelFactory):
   email = factory.LazyAttribute(
       lambda _: random_str(chars=string.ascii_letters) + "@example.com"
   )
+  name = factory.LazyAttribute(
+      lambda _: random_str(prefix="Person")
+  )
 
 
 class CommentFactory(ModelFactory):

--- a/test/integration/ggrc/test_csvs/people_order.csv
+++ b/test/integration/ggrc/test_csvs/people_order.csv
@@ -1,7 +1,7 @@
 Object type,,,,,,,,,,,,
 Person,Name,Email*,Company,Role,,,,,,,,
 ,Alan Turing,turing@example.com,,Administrator,,,,,,,,
-,,test@example.com,,Administrator,,,,,,,,
+,test,test@example.com,,Administrator,,,,,,,,
 ,Terminator,terminator@example.com,,Administrator,,,,,,,,
 ,Smurfette,blue@example.com,,Administrator,,,,,,,,
 ,user1,user@2.com,,Administrator,,,,,,,,

--- a/test/integration/ggrc/utils/test_user_generator.py
+++ b/test/integration/ggrc/utils/test_user_generator.py
@@ -176,6 +176,30 @@ class TestUserGenerator(TestCase):
 
   @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
   @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
+  @freeze_time("2019-05-17 17:52:44")
+  def test_creation_with_empty_name(self):
+    """Test user creation with empty name."""
+    with mock.patch.multiple(
+        PersonClient,
+        _post=self._mock_post
+    ):
+      data = json.dumps([{'person': {
+          'name': '',
+          'email': 'aturing@example.com',
+          'context': None,
+          'external': True
+      }}])
+      response = self._post(data)
+      self.assertStatus(response, 200)
+
+      user = Person.query.filter_by(email='aturing@example.com').first()
+      self.assertEquals(user.name, 'aturing')
+
+    # checks person profile restrictions
+    self.assert_profiles_restrictions()
+
+  @mock.patch('ggrc.settings.INTEGRATION_SERVICE_URL', new='endpoint')
+  @mock.patch('ggrc.settings.AUTHORIZED_DOMAIN', new='example.com')
   @freeze_time("2018-05-20 10:22:22")
   def test_person_import(self):
     """Test for mapped person"""

--- a/test/integration/ggrc_workflows/helpers/person_setup.py
+++ b/test/integration/ggrc_workflows/helpers/person_setup.py
@@ -42,7 +42,8 @@ class PersonSetup(object):
         Generated person.
     """
     email = self._gen_email(g_rname, m_rname)
-    person = factories.PersonFactory(email=email)
+    name = email.split("@")[0]
+    person = factories.PersonFactory(email=email, name=name)
     bp_factories.UserRoleFactory(person=person,
                                  role=rbac_helper.G_ROLES[g_rname])
     return person


### PR DESCRIPTION
# Issue description
Make name field mandatory for User model
For users with empty name, name should be populated from email (parsed by @ and get ldap)

# Steps to test the changes
Create user without name from API
Create user without name from import
Create user without name from UI

# Solution description
Add migration to populate users without name with ldap
Add migration to make name column mandatory
Add back-end logic for get ldap from email for user without name

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


