### PR TITLE
GGRC-7206 Adds error content in blank 400 program response

### DIFF
--- a/src/ggrc/models/exceptions.py
+++ b/src/ggrc/models/exceptions.py
@@ -8,6 +8,8 @@ from logging import getLogger
 
 from sqlalchemy.exc import IntegrityError
 
+from ggrc.utils.errors import INTERNAL_SERVER_ERROR
+
 logger = getLogger(__name__)
 
 
@@ -27,7 +29,12 @@ def translate_message(exception):
   """
   Translates db exceptions to something a user can understand.
   """
-  message = exception.message
+  if exception.message:
+    message = exception.message
+  elif len(exception.args) > 1:
+    message = exception.args[1]
+  else:
+    message = INTERNAL_SERVER_ERROR.format(job_type='Request')
 
   if isinstance(exception, IntegrityError):
     # TODO: Handle not null, foreign key, uniqueness errors with compound keys

--- a/test/integration/ggrc/models/test_program.py
+++ b/test/integration/ggrc/models/test_program.py
@@ -49,6 +49,30 @@ class TestProgram(TestCase):
     response = self.api.delete(self.program)
     self.assert200(response)
 
+  def test_create_wrong_recipients(self):
+    """Test creation of a program with a wrong recipients"""
+    data = [{
+        'program': {
+            'status': 'Draft',
+            'kind': 'Directive',
+            'send_by_default': True,
+            'managers': ['user@example.com'],
+            'recipients': 'Admin,Primary Contacts,Secondary Contacts',
+            'title': 'Program_Test',
+            'review': {
+                'status': 'Unreviewed',
+            },
+            'access_control_list': [],
+            'slug': 'program_test'
+        }
+    }]
+    response = self.api.post(all_models.Program, data=data)
+    self.assert400(response)
+    self.assertIn(
+        u"Value should be either empty or comma separated list of",
+        response.json[0][1]
+    )
+
 
 class TestMegaProgram(TestCase):
   """Mega Program test cases"""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*Create Program via rest with following body:*
 
*[{"program": {"status": "Draft", "kind": "Directive", "send_by_default": true, "managers": ["user@example.com"], "description": "", "recipients": "Admin,Primary Contacts,Secondary Contacts", "title": "Program_1ea9d2a8-c93b_06E~(}Hh(fgwb", "notes": "", "custom_attributes": {}, "custom_attribute_definitions": [], "context": null, "review": {"status": "Unreviewed", "reviewers": null, "last_reviewed_by": null}, "access_control_list": [{"person": {"type": "Person", "id": 2}, "ac_role_id": 1333}], "slug": "e72669b9-0587"}}]
Actual result: empty response text
Expected result: response text with error message*

# Steps to test the changes

*Run command: nosetests -s test/integration/ggrc/models/test_program.py:TestProgram.test_create_program_with_wrong_recipients
or send a POST request on /api/programs/ with the same data as in the descripion*

# Solution description

*Generated ValueError exception didn't have any data in .message attribute but it has the expecting content in .args. If the .message is blank then it will use data from .args*

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
