### PR TITLE
GGRC-5793 Improve performance for single assessment export

### DIFF
--- a/src/ggrc/converters/handlers/custom_attribute.py
+++ b/src/ggrc/converters/handlers/custom_attribute.py
@@ -225,7 +225,7 @@ class CustomAttributeColumnHandler(handlers.TextColumnHandler):
 
   def get_ca_definition(self):
     """Get custom attribute definition."""
-    cache = self.row_converter.block_converter.get_ca_definitions_cache()
+    cache = self.row_converter.block_converter.ca_definitions_cache
     return cache.get((None, self.display_name))
 
 
@@ -249,5 +249,5 @@ class ObjectCaColumnHandler(CustomAttributeColumnHandler):
     """Get custom attribute definition for a specific object."""
     if self.row_converter.obj.id is None:
       return None
-    cache = self.row_converter.block_converter.get_ca_definitions_cache()
+    cache = self.row_converter.block_converter.ca_definitions_cache
     return cache.get((self.row_converter.obj.id, self.display_name))

--- a/src/ggrc/converters/import_helper.py
+++ b/src/ggrc/converters/import_helper.py
@@ -17,33 +17,41 @@ from ggrc.converters import get_exportables
 from ggrc.converters.column_handlers import model_column_handlers
 from ggrc.converters.handlers import handlers
 
+
 # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)
 
 
-def get_object_column_definitions(object_class, fields=None,
+def get_object_column_definitions(object_class, fields=None, ca_cache=None,
                                   include_hidden=False):
   """Attach additional info to attribute definitions.
 
   Fetches the attribute info (_aliases) for the given object class and adds
-  additional data (handler class, validator function, default value) )needed
-  for imports.
+  additional data (handler class, validator function, default value) needed
+  for imports. For better performance consider to provide `ca_cache` argument.
 
   Args:
-    object_class (db.Model): Model for which we want to get column definitions
-      for imports.
+    object_class (db.Model): Model whose column definitions to get for import.
+    fields (iterable): Iterable of field names of the given object class to
+      include in returned attribute definitions list. If None, all fields will
+      be included. Defaults to None.
+    ca_cache (dict): Dictionary containing custom attribute definitions grouped
+      by their definitions_type. If None, definitions will be queried from the
+      DB. Defaults to None.
     include_hidden (bool): Flag which specifies if we should include column
       handlers for hidden attributes (they marked as 'hidden'
       in _aliases dict).
 
   Returns:
-    dict: Updated attribute definitions dict with additional data.
+    A dict of attribute definitions.
   """
   attributes = AttributeInfo.get_object_attr_definitions(
       object_class,
-      fields=fields,
-      include_hidden=include_hidden
+      ca_fields=fields,
+      include_hidden=include_hidden,
+      ca_cache=ca_cache,
   )
+
   column_handlers = model_column_handlers(object_class)
   for key, attr in attributes.iteritems():
     handler_key = attr.get("handler_key", key)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Currently export of a single assessment with small number of CADs and assignees takes an unreasonable amount of time - about 10 s. It should be faster.

# Steps to test the changes

1. Create assessment with:
    * 1 creator;
    * 2 assignees;
    * 2 verifiers;
    * 1 mapped control snapshot;
    * 2 gca.
2. Export created assessment like this (no LCA and 2 GCA selected):

![image](https://user-images.githubusercontent.com/22235241/59110856-9c090c00-8948-11e9-9309-65d4d3c02920.png)

# Solution description

Solution includes following changes:

1. Cache of snapshots mapped to object being passed to the row converter is created. It allows to rewrite snapshot column handler to use this cache of snapshots to simplify query needed to get an object for which snapshot was created. It leads to performance improvement since SELECT by ID is faster than query in `snapshoted_instances_query` method that was in use before this change.

2. Custom attribute definitions cache on `BlockConverter` is rewritten to provide additional filters (i.e. object IDs, definition titles) when querying definitions if possible. Also this cache is now being populated during `ExportBlock` initialization which allows to pass it into `AttributeInfo.get_object_attr_definitions` as `ca_cache` argument. Because of that there will be only 1 DB query for CADs in export (previously 1 query happened during block initialization and 1 during `get_value` call in  `CustomAttributeColumnHandler`).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
