### PR TITLE
GGRC-7265 'There was an error' for conflict resolution message

### DIFF
--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -273,7 +273,7 @@ export default can.Model.extend({
               resolveConflict(xhr, this.findInCacheById(id))
                 .then(
                   (obj) => dfd.resolve(obj),
-                  (obj, xhr) => dfd.reject(xhr)
+                  (xhr) => dfd.reject(xhr)
                 );
               return dfd;
             }

--- a/src/ggrc-client/js/models/conflict-resolution/conflict-resolution.js
+++ b/src/ggrc-client/js/models/conflict-resolution/conflict-resolution.js
@@ -7,7 +7,6 @@ import {
   simpleFieldResolver,
   customAttributeResolver,
 } from './conflict-resolvers';
-import {notifierXHR} from '../../plugins/utils/notifiers-utils';
 
 export function tryResolveConflictValues(baseAttrs, attrs, remoteAttrs, obj) {
   let hasConflict = false;
@@ -61,9 +60,8 @@ export default function resolveConflict(xhr, obj) {
     stillHasConflict =
       tryResolveConflictValues(baseAttrs, attrs, remoteAttrs, obj);
     if (stillHasConflict) {
-      notifierXHR('warning', {status: 409});
       xhr.remoteObject = remoteAttrs;
-      return new $.Deferred().reject(xhr, 409, 'CONFLICT');
+      return new $.Deferred().reject(xhr);
     }
 
     return obj.save();

--- a/src/ggrc-client/js_specs/models/cacheable_conflict_resolution_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_conflict_resolution_spec.js
@@ -24,6 +24,8 @@ describe('Cacheable conflict resolution', function () {
     });
   });
 
+  // do not remove because this function is needed in PR #9607
+  // eslint-disable-next-line
   function _resovleDfd(obj, reject) {
     return new $.Deferred(function (dfd) {
       setTimeout(function () {
@@ -35,38 +37,6 @@ describe('Cacheable conflict resolution', function () {
       }, 10);
     });
   }
-
-  it('triggers error flash when one property has an update conflict',
-    function (done) {
-      let obj = new DummyModel({id: 1});
-      obj.attr('foo', 'bar');
-      obj.backup();
-
-      expect(obj._backupStore()).toEqual(
-        jasmine.objectContaining({id: obj.id, foo: 'bar'}));
-      obj.attr('foo', 'plonk');
-      spyOn($.fn, 'trigger').and.callThrough();
-      spyOn(obj, 'save').and.callFake(function () {
-        return _resovleDfd(obj);
-      });
-      spyOn(obj, 'refresh').and.callFake(function () {
-        obj.attr('foo', 'thud'); // uh-oh!  The same attr has been changed locally and remotely!
-        return _resovleDfd(obj);
-      });
-      ajaxSpy.and.callFake(function () {
-        return _resovleDfd({status: 409}, true);
-      });
-      DummyModel.update(obj.id.toString(), obj.serialize()).then(
-        function () {
-          fail("The update handler isn't supposed to resolve here.");
-          done();
-        }, function () {
-          expect($.fn.trigger).toHaveBeenCalledWith('ajax:flash', [{
-            warning: [jasmine.any(String)],
-          }, null]);
-          done();
-        });
-    });
 
   it('does not refresh model', function (done) {
     let obj = new DummyModel({id: 1});


### PR DESCRIPTION
# Issue description

Conflict resolution message is wrong

# Steps to test the changes

1. Open the same assessment in two tabs
2. Open edit modals for them
3. Edit title field in the first tab and save
4. In the second tab enter another value for title field and save

**Actual Result**: 'There was an error!' appears
**Expected result**: 'Please refresh the page and try saving again' should appear

# Solution description

Remove unnecessary notifierXHR call and arguments

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".