### PR TITLE
GGRC-7375 No email notification for mentioning person in assessment

### DIFF
--- a/src/ggrc/models/hooks/__init__.py
+++ b/src/ggrc/models/hooks/__init__.py
@@ -13,6 +13,7 @@ from ggrc.models.hooks import issue_tracker
 from ggrc.models.hooks import relationship
 from ggrc.models.hooks import acl
 from ggrc.models.hooks import access_control_role
+from ggrc.models.hooks import with_action
 
 
 ALL_HOOKS = [
@@ -22,6 +23,7 @@ ALL_HOOKS = [
     comment,
     issue,
     relationship,
+    with_action,
     custom_attribute_definition,
     acl,
     common,

--- a/src/ggrc/models/hooks/with_action.py
+++ b/src/ggrc/models/hooks/with_action.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Object with actions hooks."""
+
+from ggrc.models import all_models, comment
+from ggrc.models.mixins.base import ChangeTracked
+from ggrc.models.mixins.with_action import WithAction
+from ggrc.services import signals
+
+
+def init_hook():  # noqa
+  # pylint: disable=unused-variable
+
+  """Initialize all hooks."""
+
+  @signals.Restful.model_put_after_commit.connect_via(all_models.Assessment)
+  def handle_assessment_put(_, obj, **kwargs):
+    # pylint: disable=unused-argument
+    """Handle Assessments with Comment mapping action"""
+    from ggrc.notifications import people_mentions
+
+    if not isinstance(obj, WithAction) or not isinstance(
+        obj, (comment.Commentable, ChangeTracked)
+    ):
+      return
+
+    actions = getattr(obj, '_actions')
+    if not actions or 'add_related' not in actions:
+      return
+
+    saved_comments = list()
+    for action in actions.get('add_related'):
+      obj_type = action.get("type")
+      obj_id = action.get("id")
+
+      if obj_type != "Comment" or not obj_id:
+        continue
+
+      saved_comments.append(all_models.Comment.query.get(obj_id))
+
+    people_mentions.handle_comment_mapped(obj=obj, comments=saved_comments)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

No email notification for mentioning person in assessment

# Steps to test the changes

1. Open any audit page
2. Create assessment
3. Add a comment to assessment with mentioning person
Actual Result: Email notification that user is mentioned in assessment is not sent
Expected Result: Email notification that user is mentioned in assessment should be sent to a user that was mentioned in comment

# Solution description

FE was updated to not send POST relatiships request after creating a comment, but add action section to PUT object request. Action handler on BE should be updated.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
