### PR TITLE
GGRC-7025 FE: prevent "*" character to be used in local custom attribute names

### DIFF
--- a/src/ggrc-client/js/components/assessment-templates/add-template-field/add-template-field.js
+++ b/src/ggrc-client/js/components/assessment-templates/add-template-field/add-template-field.js
@@ -85,6 +85,7 @@ export default can.Component.extend({
     getValidators(title, fields) {
       return [
         isEmptyTitle.bind(null, title),
+        isInvalidTitle.bind(null, title),
         isDublicateTitle.bind(null, fields, title),
         isReservedByCustomAttr.bind(null, title),
         isReservedByModelAttr.bind(null, title),
@@ -136,8 +137,15 @@ const isDublicateTitle = (fields, selectedTitle) => {
 
 const isEmptyTitle = (selectedTitle) => {
   return !selectedTitle ?
-    'A custom attribute title can not be blank' :
+    'A custom attribute title cannot be blank' :
     '';
+};
+
+const isInvalidTitle = (title) => {
+  if (_.indexOf(title, '*') !== -1) {
+    return 'A custom attribute title cannot contain *';
+  }
+  return '';
 };
 
 const isReservedByCustomAttr = (title) => {

--- a/src/ggrc-client/js/components/assessment-templates/add-template-field/add-template-field.js
+++ b/src/ggrc-client/js/components/assessment-templates/add-template-field/add-template-field.js
@@ -174,6 +174,7 @@ const isReservedByModelAttr = (title) => {
 export {
   isDublicateTitle,
   isEmptyTitle,
+  isInvalidTitle,
   isReservedByCustomAttr,
   isReservedByModelAttr,
 };


### PR DESCRIPTION
# Issue description

The character "*" should not be allowed in any local custom attribute title

# Steps to test the changes

1. Try to create a local custom attribute with "*" in the title

**Actual Result**: Attributes with invalid titles are created
**Expected result**: User should not be able to do that

# Solution description

Add isInvalidTitle validator for checking "*" in custom attribute title.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
