### PR TITLE
GGRC-7228 Spinner rounds endlessly (instead of 'Activate Workflow' button) if press esc on keyboard 

### DIFF
--- a/src/ggrc-client/js/components/object-mapper/create-and-map.js
+++ b/src/ggrc-client/js/components/object-mapper/create-and-map.js
@@ -157,13 +157,7 @@ export default can.Component.extend({
       }, () => {
         // close object mapper
         this.attr('element').trigger('mapExternally');
-      }, () => this.cancel())
-        .on('keyup', (ev) => {
-          // handle esc key
-          if (ev.which === 27 && $(ev.target).closest('.modal').length) {
-            this.cancel();
-          }
-        });
+      }, () => this.cancel());
     },
     cancel() {
       this.attr('element').trigger('canceled');

--- a/src/ggrc-client/js/plugins/utils/modals.js
+++ b/src/ggrc-client/js/plugins/utils/modals.js
@@ -91,6 +91,13 @@ function warning(options, success, fail, extra) {
   return confirmResult;
 }
 
+function _onDismissHandler($target, dismiss) {
+  $target.modal('hide').remove();
+  if (dismiss) {
+    dismiss();
+  }
+}
+
 function confirm(options, success, dismiss) {
   let $target = $('<div class="modal hide ' +
     options.extraCssClass +
@@ -119,9 +126,14 @@ function confirm(options, success, dismiss) {
         }
       })
         .on('click.modal-form.close', '[data-dismiss="modal"]', function () {
-          $target.modal('hide').remove();
-          if (dismiss) {
-            dismiss();
+          _onDismissHandler($target, dismiss);
+        })
+        .on('keyup', function (e) {
+          const ESCAPE_KEY_CODE = 27;
+          const escapeKeyWasPressed = e.keyCode === ESCAPE_KEY_CODE;
+
+          if (escapeKeyWasPressed) {
+            _onDismissHandler($target, dismiss);
           }
         });
     });


### PR DESCRIPTION
# Issue description

Spinner rounds endlessly (instead of 'Activate Workflow' button) if press esc on keyboard

# Steps to test the changes

1. Create any workflow
2. Add task to Task group
3. Click on 'Activate Workflow' button
4. Click on ESC on keyboard

**Actual Result**: Spinner rounds endlessly (instead of 'Activate Workflow' button)
**Expected result**: 'Activate Workflow' button should be displayed and enabled

# Solution description

Add esc handler for popup

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".