### PR TITLE
GGRC-7120 Assessment template is not displayed in tree view after cloning for Global Creator user

### DIFF
--- a/src/ggrc/models/mixins/clonable.py
+++ b/src/ggrc/models/mixins/clonable.py
@@ -14,6 +14,7 @@ import sqlalchemy as sa
 from werkzeug import exceptions
 
 from ggrc import db
+from ggrc.cache import utils as cache_utils
 from ggrc.models import relationship, inflector
 from ggrc.rbac import permissions
 from ggrc.services import signals
@@ -187,6 +188,7 @@ class MultiClonable(object):
         collections.append(
             views.build_collection_representation(cls, obj.log_json())
         )
+    cache_utils.clear_permission_cache()
     return views.json_success_response(collections, datetime.datetime.utcnow())
 
   def _clone(self, target=None):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Clone of assessment template is not displayed in tree view

# Steps to test the changes

Steps to reproduce:
1. Log in ggrc app as Global Creator user
2. Open audit page (Global Creator user should be Audit Captain in the audit)
3. Go to Assessment template tab and click on Create button
4. Select any Assessment template to clone screenshot-1.png
5. Click Clone button and look at the tree view
Actual Result: Clone of assessment template is not displayed in tree view
Expected Result: Clone of assessment template should be displayed in tree view

# Solution description

This happened because cached permissions dict was not updated after creation of new assessment template

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
