### PR TITLE
GGRC-5052 _notifications/show_daily_digest page is loading all the time

### DIFF
--- a/src/ggrc/contributions.py
+++ b/src/ggrc/contributions.py
@@ -41,5 +41,5 @@ def contributed_notifications():
   return {
       "Assessment": data_handlers.get_assignable_data,
       "Comment": data_handlers.get_comment_data,
-      "Review": lambda x: {}
+      "Review": lambda x, _: {}
   }

--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -31,6 +31,7 @@ from ggrc.gcalendar import calendar_event_sync
 from ggrc.models import Person
 from ggrc.models import Notification, NotificationHistory
 from ggrc.models import background_task
+from ggrc.notifications.data_handlers import custom_attributes_cache
 from ggrc.notifications.unsubscribe import unsubscribe_url
 from ggrc.rbac import permissions
 from ggrc.utils import DATE_FORMAT_US, merge_dict, benchmark
@@ -42,8 +43,7 @@ from ggrc_workflows.notification.notification_handler \
     import done_tasks_notify, not_done_tasks_notify
 
 from ggrc_workflows.notification.data_handler import (
-    cycle_tasks_cache, deleted_task_rels_cache, get_cycle_task_data,
-    custom_attributes_cache)
+    cycle_tasks_cache, deleted_task_rels_cache, get_cycle_task_data)
 
 
 # pylint: disable=invalid-name
@@ -162,7 +162,7 @@ def get_notification_data(notifications):
 
   tasks_cache = cycle_tasks_cache(notifications)
   deleted_rels_cache = deleted_task_rels_cache(tasks_cache.keys())
-  ca_cache = custom_attributes_cache()
+  ca_cache = custom_attributes_cache(notifications)
 
   for notification in notifications:
     filtered_data = get_filter_data(

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -522,3 +522,25 @@ def get_comment_data(notif, **_):
       data[person.email] = generate_comment_notification(
           comment_obj, comment, person)
   return data
+
+
+def custom_attributes_cache(notifications):
+  """Compile and return Custom Attributes
+
+  Args:
+    notifications: a list of Notification instances for which to fetch the
+      corresponding CAds instances
+  Returns:
+    Dictionary containing all custom attributes with a definition type as a key
+  """
+  objects_ids = [notification.object_id for notification in notifications]
+  ca_cache = defaultdict(list)
+  definitions = models.CustomAttributeDefinition.eager_query().filter(
+      models.CustomAttributeDefinition.definition_id.in_(objects_ids)
+  ).group_by(
+      models.CustomAttributeDefinition.title,
+      models.CustomAttributeDefinition.definition_type)
+  for attr in definitions:
+    ca_cache[attr.definition_type].append(attr)
+
+  return ca_cache

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -173,13 +173,15 @@ def _get_assignable_roles(obj):
   return {role_id: name for role_id, name in query}
 
 
-def _get_assignable_dict(people, notif):
+def _get_assignable_dict(people, notif, ca_cache=None):
   """Get dict data for assignable object in notification.
 
   Args:
     people (List[Person]): List o people objects who should receive the
       notification.
     notif (Notification): Notification that should be sent.
+    ca_cache (dict): prefetched CustomAttributeDefinition instances accessible
+      by definition_type as a key
   Returns:
     dict: dictionary containing notification data for all people in the given
       list.
@@ -187,7 +189,8 @@ def _get_assignable_dict(people, notif):
   obj = get_notification_object(notif)
   data = {}
 
-  definitions = AttributeInfo.get_object_attr_definitions(obj.__class__)
+  definitions = AttributeInfo.get_object_attr_definitions(obj.__class__,
+                                                          ca_cache=ca_cache)
   roles = _get_assignable_roles(obj)
 
   for person in people:
@@ -217,10 +220,12 @@ def _get_assignable_dict(people, notif):
   return data
 
 
-def assignable_open_data(notif):
+def assignable_open_data(notif, ca_cache=None):
   """Get data for open assignable object.
 
   Args:
+    ca_cache (dict): prefetched CustomAttributeDefinition instances accessible
+      by definition_type as a key
     notif (Notification): Notification entry for an open assignable object.
 
   Returns:
@@ -235,13 +240,15 @@ def assignable_open_data(notif):
     return {}
   people = [person for person in obj.assignees]
 
-  return _get_assignable_dict(people, notif)
+  return _get_assignable_dict(people, notif, ca_cache=ca_cache)
 
 
-def assignable_updated_data(notif):
+def assignable_updated_data(notif, ca_cache=None):
   """Get data for updated assignable object.
 
   Args:
+    ca_cache (dict): prefetched CustomAttributeDefinition instances accessible
+      by definition_type as a key
     notif (Notification): Notification entry for an open assignable object.
 
   Returns:
@@ -256,7 +263,7 @@ def assignable_updated_data(notif):
     return {}
   people = [person for person in obj.assignees]
 
-  return _get_assignable_dict(people, notif)
+  return _get_assignable_dict(people, notif, ca_cache=ca_cache)
 
 
 def _get_declined_people(obj):
@@ -274,10 +281,12 @@ def _get_declined_people(obj):
   return []
 
 
-def assignable_declined_data(notif):
+def assignable_declined_data(notif, ca_cache=None):
   """Get data for declined assignable object.
 
   Args:
+    ca_cache (dict): prefetched CustomAttributeDefinition instances accessible
+      by definition_type as a key
     notif (Notification): Notification entry for a declined assignable object.
 
   Returns:
@@ -285,7 +294,7 @@ def assignable_declined_data(notif):
   """
   obj = get_notification_object(notif)
   people = _get_declined_people(obj)
-  return _get_assignable_dict(people, notif)
+  return _get_assignable_dict(people, notif, ca_cache=ca_cache)
 
 
 def get_assessment_url(assessment):
@@ -294,7 +303,7 @@ def get_assessment_url(assessment):
       "assessments/{}".format(assessment.id))
 
 
-def assignable_reminder(notif):
+def assignable_reminder(notif, **_):
   """Get data for assignable object for reminders"""
   obj = get_notification_object(notif)
   reminder = next((attrs for attrs in obj.REMINDERABLE_HANDLERS.values()
@@ -361,7 +370,7 @@ def get_notification_object(notif):
   return None
 
 
-def get_assignable_data(notif):
+def get_assignable_data(notif, **kwargs):
   """Return data for assignable object notifications.
 
   Args:
@@ -392,7 +401,7 @@ def get_assignable_data(notif):
 
   for suffix, data_handler in data_handlers.iteritems():
     if notif_type.endswith(suffix):
-      return data_handler(notif)
+      return data_handler(notif, ca_cache=kwargs.get('ca_cache'))
 
   return {}
 
@@ -470,7 +479,7 @@ def _get_people_with_roles(comment_obj):
   return assignees
 
 
-def get_comment_data(notif):
+def get_comment_data(notif, **_):
   """Return data for comment notifications.
 
   This functions checks who should receive the notification and who not, with

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -293,7 +293,7 @@ def get_cycle_created_data(notification, cycle):
   return result
 
 
-def get_cycle_data(notification):
+def get_cycle_data(notification, **_):
   """Get created and completed cycles data."""
   cycle = get_object(Cycle, notification.object_id)
   if not cycle:
@@ -363,6 +363,21 @@ def cycle_tasks_cache(notifications):
   return {task.id: task for task in results}
 
 
+def custom_attributes_cache():
+  """Compile and return Custom Attributes
+
+  Returns:
+    Dictionary containing all custom attributes with a definition type as a key
+  """
+  ca_cache = defaultdict(list)
+  definitions = models.CustomAttributeDefinition.eager_query().group_by(
+      models.CustomAttributeDefinition.title,
+      models.CustomAttributeDefinition.definition_type)
+  for attr in definitions:
+    ca_cache[attr.definition_type].append(attr)
+  return ca_cache
+
+
 def deleted_task_rels_cache(task_ids):
   """Compile and return deleted Relationships information for given Tasks.
 
@@ -403,7 +418,8 @@ def deleted_task_rels_cache(task_ids):
   return rels_cache
 
 
-def get_cycle_task_data(notification, tasks_cache=None, del_rels_cache=None):
+def get_cycle_task_data(notification, tasks_cache=None, del_rels_cache=None,
+                        **_):
   """Get all data of cycle task."""
   if tasks_cache is None:
     tasks_cache = {}
@@ -502,7 +518,7 @@ def get_cycle_start_failed_data(notification, workflow):
   return result
 
 
-def get_workflow_data(notification):
+def get_workflow_data(notification, **_):
   """Get workflow data."""
   workflow = get_object(Workflow, notification.object_id)
   if not workflow:
@@ -522,6 +538,7 @@ def get_workflow_data(notification):
 
 
 def get_object(obj_class, obj_id):
+  """Get object of type {obj_class} with id {obj_id}. None if unable to find"""
   result = db.session.query(obj_class).filter(obj_class.id == obj_id)
   if result.count() == 1:
     return result.one()

--- a/src/ggrc_workflows/notification/data_handler.py
+++ b/src/ggrc_workflows/notification/data_handler.py
@@ -363,21 +363,6 @@ def cycle_tasks_cache(notifications):
   return {task.id: task for task in results}
 
 
-def custom_attributes_cache():
-  """Compile and return Custom Attributes
-
-  Returns:
-    Dictionary containing all custom attributes with a definition type as a key
-  """
-  ca_cache = defaultdict(list)
-  definitions = models.CustomAttributeDefinition.eager_query().group_by(
-      models.CustomAttributeDefinition.title,
-      models.CustomAttributeDefinition.definition_type)
-  for attr in definitions:
-    ca_cache[attr.definition_type].append(attr)
-  return ca_cache
-
-
 def deleted_task_rels_cache(task_ids):
   """Compile and return deleted Relationships information for given Tasks.
 

--- a/test/unit/ggrc/notification/test_init.py
+++ b/test/unit/ggrc/notification/test_init.py
@@ -14,9 +14,12 @@ class TestNotificationsInit(unittest.TestCase):
 
   @patch("ggrc.notifications.common.deleted_task_rels_cache")
   @patch("ggrc.notifications.common.cycle_tasks_cache")
+  @patch("ggrc.notifications.common.custom_attributes_cache")
   @patch("ggrc.notifications.common.get_filter_data")
-  def test_get_notification_data(self, get_filter_data, *cache_mocks):
+  def test_get_notification_data(self, get_filter_data, ca_cache,
+                                 *cache_mocks):
     """ Test that data does not contain empty emails """
+    ca_cache.return_value = None
     for cache_func in cache_mocks:
       cache_func.return_value = {}
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

show_daily_digest take a huge amount of time to generate notifications

# Steps to test the changes

1. Open _notifications/show_daily_digest page for instance with huge amount of notifications (~30 000) and a lot of CADs (200 000).

# Solution description

Add ca_cache parameter to send daily notification functions,

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
