### PR TITLE
GGRC-3622 Disabled to map snapshot to issue via import

### DIFF
--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -163,7 +163,8 @@ ILLEGAL_APPEND_CONTROL_VALUE = (u"Line {line}: "
                                 u"is not mapped to the related audit.")
 
 ISSUE_SNAPSHOT_MAP_WARNING = (u"Line {line}: You cannot map {column_name} "
-                              u"snapshot to Issue directly")
+                              u"snapshot to Issue directly. Mapping will be "
+                              u"ignored.")
 
 UNMODIFIABLE_COLUMN = (u"Line {line}: Column '{column_name}' can not be "
                        u"modified. The value will be ignored.")

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -162,6 +162,9 @@ ILLEGAL_APPEND_CONTROL_VALUE = (u"Line {line}: "
                                 u"{object_type}, because this {mapped_type} "
                                 u"is not mapped to the related audit.")
 
+ISSUE_SNAPSHOT_MAP_WARNING = (u"Line {line}: You cannot map {column_name} "
+                              u"snapshot to Issue directly")
+
 UNMODIFIABLE_COLUMN = (u"Line {line}: Column '{column_name}' can not be "
                        u"modified. The value will be ignored.")
 

--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -29,6 +29,12 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
       return audit_items[0]
     return None
 
+  def disable_snapshot_map_to_issue(self, to_append_ids):
+    """Disable mapping of snapshot to Issue via import."""
+    if to_append_ids:
+      self.add_warning(errors.ISSUE_SNAPSHOT_MAP_WARNING,
+                       column_name=self.mapping_object.__name__)
+
   def get_audit_object_pool_query(self, child_ids=None):
     if isinstance(self.row_converter.obj, models.Audit):
       audit_id = self.row_converter.obj.id
@@ -187,5 +193,8 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
     }
     import_ids = {i.id for i in items or []}
     to_append_ids = import_ids - exists_ids
+    if isinstance(self.row_converter.obj, models.Issue):
+      self.disable_snapshot_map_to_issue(to_append_ids)
+      return None
     self.is_valid_creation(to_append_ids)
     return items


### PR DESCRIPTION
# Issue description

User can map snapshot to Issue via import

# Steps to test the changes

1. Have an audit with mapped snapshot
2. Create an Issue on the audit page
3. Export Issue 
4. Open csv file and map snapshot to Issue> Save changes
5. Import csv file with Issue
6. Expand subtree for Issue and look at the mapped objects: snapshot is shown
7. See warning message "You cannot map snapshots to Issue directly."

# Solution description

Disabled possibility to map snapshot to issue via import.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".