### PR TITLE
HOT FIX Updated Control.log_json method to contain person stub instead of model.

### DIFF
--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -189,9 +189,9 @@ class Control(synchronizable.Synchronizable,
 
   def log_json(self):
     out_json = super(Control, self).log_json()
-    out_json["created_by"] = self.created_by
-    out_json["last_submitted_by"] = self.last_submitted_by
-    out_json["last_verified_by"] = self.last_verified_by
+    out_json["created_by"] = ggrc_utils.created_by_stub(self)
+    out_json["last_submitted_by"] = ggrc_utils.last_submitted_by_stub(self)
+    out_json["last_verified_by"] = ggrc_utils.last_verified_by_stub(self)
     # so that event log can refer to deleted directive
     if self.directive:
       out_json["mapped_directive"] = self.directive.display_name

--- a/test/integration/ggrc/models/test_control.py
+++ b/test/integration/ggrc/models/test_control.py
@@ -1129,3 +1129,37 @@ class TestSyncServiceControl(TestCase):
         control,
         {"Admin": [{"name": "user1", "email": "user1@example.com"}]}
     )
+
+  def test_json_deserialization(self):
+    """Created_by attribute should contain person stub"""
+    with factories.single_commit():
+      creator_email = "creator@example.com"
+      creator = factories.PersonFactory(email=creator_email)
+      creator_id = creator.id
+      control = factories.ControlFactory(
+          title="Test control", created_by=creator,
+          last_submitted_by=creator,
+          last_verified_by=creator
+      )
+    json_representation = control.log_json()
+    self.assertTrue(isinstance(json_representation["created_by"], dict))
+    self.assertTrue(
+        isinstance(json_representation["last_submitted_by"], dict)
+    )
+    self.assertTrue(isinstance(json_representation["last_verified_by"], dict))
+    self.assertEquals(
+        json_representation["created_by"]["email"], creator_email
+    )
+    self.assertEquals(
+        json_representation["last_submitted_by"]["email"], creator_email
+    )
+    self.assertEquals(
+        json_representation["last_verified_by"]["email"], creator_email
+    )
+    self.assertEquals(json_representation["created_by"]["id"], creator_id)
+    self.assertEquals(
+        json_representation["last_submitted_by"]["id"], creator_id
+    )
+    self.assertEquals(
+        json_representation["last_verified_by"]["id"], creator_id
+    )


### PR DESCRIPTION
# Issue description

Error during updating of control by sync service.

# Steps to test the changes

Run sync from External App to GGRC.
Run test.

# Solution description

Control model has wrong deserialization logic for created_by attribute. It leads to error during revision comparison. I've fixed this method to use person stub instead of raw model.  

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
