### PR TITLE
GGRC-3652 Fix to unmap issue from assessment

### DIFF
--- a/src/ggrc/query/custom_operators.py
+++ b/src/ggrc/query/custom_operators.py
@@ -418,6 +418,7 @@ def cascade_unmappable(exp, object_class, target_class, query):
           all_models.Relationship.destination_id == issue_id,
           all_models.Relationship.destination_type == "Issue",
           all_models.Relationship.source_type == object_class.__name__,
+          ~all_models.Relationship.automapping_id.is_(None),
       ),
   ), name="mapped_to_issue")
 

--- a/test/integration/ggrc/query_helper.py
+++ b/test/integration/ggrc/query_helper.py
@@ -147,6 +147,13 @@ class WithQueryApi(object):
         model_name, field
     )
 
+  def raw_query(self, data):
+    """Do request with raw body"""
+    response = self._post(data)
+    self.assert200(response)
+    result = json.loads(response.data)
+    return result
+
 
 class TestQueryHelper(TestCase, WithQueryApi):
   """Test utils from ggrc.query_helper"""


### PR DESCRIPTION
# Issue description

'Related audit' section is shown up in unmapping popup if Issue is manually mapped to Audit

# Steps to test the changes

1. Have an audit with snapshot A
2. Create Assessment 1 and map snapshot A to assessment 1
3. On Audit page on Issues tab create an Issue and map it to the Audit.
4. Map the Issue to Assessment 1.
5. Open Issue page in a separate tab
7. On the Issue page in the Assessments tab click 'Unmap from Issue' from 3 bb's menu
8. See that 'Related audit' section was not shown up in unmapping popup.

# Solution description

'Related audit' section is not shown up in unmapping popup if Issue is manually mapped to Audit

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".