### PR TITLE
GGRC-7282 Replace can.Construct with class syntax

### DIFF
--- a/docs/source/frontend/frontend-dependencies.md
+++ b/docs/source/frontend/frontend-dependencies.md
@@ -5,7 +5,6 @@
 - can-stache: https://v3.canjs.com/doc/can-stache.html
 - can-stache-bindgins: https://v3.canjs.com/doc/can-stache-bindings.html
 - can-component: https://v3.canjs.com/doc/can-component.html
-- can-construct: https://v3.canjs.com/doc/can-construct.html
 - can-event: https://v3.canjs.com/doc/can-event.html
 - can-jquery: https://v3.canjs.com/doc/can-jquery.html
 

--- a/docs/source/frontend/modals.rst
+++ b/docs/source/frontend/modals.rst
@@ -48,7 +48,7 @@ the modals
 -  fetch_data a bit complex because we could be TBD
 -  ``_transient`` property - added to the object instance while the object
    is open, but removed from the modal once the modal closes
--  run form_preload on the modal (if it exists)
+-  run formPreload on the modal (if it exists)
 -  apply object params - uses the data-object-params from the link that
    gets set on the modal. Example: when you create a request for an
    audit, a hidden field is the audit id. That's how you communicate any

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "can-map-backup": "3.1.1",
     "can-validate-legacy": "2.0.0",
     "can-control": "3.2.0",
-    "can-construct": "3.5.4",
     "can-construct-super": "^3.2.0",
     "can-map-define": "3.1.2",
     "can-simple-observable": "2.4.1",

--- a/src/ggrc-client/js/apps/business_objects.js
+++ b/src/ggrc-client/js/apps/business_objects.js
@@ -62,20 +62,20 @@ Object.assign(CoreExtension, {
     // Info and summary widgets display the object information instead of listing
     // connected objects.
     if (summaryWidgetViews[objectTable]) {
-      widgetList.add_widget(object.constructor.model_singular, 'summary', {
+      widgetList.addWidget(object.constructor.model_singular, 'summary', {
         content_controller: SummaryWidgetController,
         instance: object,
         widget_view: summaryWidgetViews[objectTable],
       });
     }
     if (isDashboardEnabled(object)) {
-      widgetList.add_widget(object.constructor.model_singular, 'dashboard', {
+      widgetList.addWidget(object.constructor.model_singular, 'dashboard', {
         content_controller: DashboardWidget,
         instance: object,
         widget_view: path + '/base_objects/dashboard_widget.stache',
       });
     }
-    widgetList.add_widget(object.constructor.model_singular, 'info', {
+    widgetList.addWidget(object.constructor.model_singular, 'info', {
       content_controller: InfoWidget,
       instance: object,
       widget_view: infoWidgetViews[objectTable],
@@ -222,7 +222,7 @@ Object.assign(CoreExtension, {
       }
 
       descriptor.widgetType = 'treeview';
-      widgetList.add_widget(
+      widgetList.addWidget(
         object.constructor.model_singular, widgetId, descriptor);
     });
   },

--- a/src/ggrc-client/js/bootstrap/modal-ajax.js
+++ b/src/ggrc-client/js/bootstrap/modal-ajax.js
@@ -16,7 +16,7 @@ import {
   hasWarningType,
   shouldApplyPreconditions,
 } from '../plugins/utils/controllers';
-import Permission from '../permission';
+import {refreshPermissions} from '../permission';
 import {
   getPageInstance,
   navigate,
@@ -198,7 +198,7 @@ let handlers = {
           }
         }
 
-        Permission.refresh().then(function () {
+        refreshPermissions().then(function () {
           let hiddenElement;
           let tagName;
 

--- a/src/ggrc-client/js/components/access-control-list/tests/access-control-list-roles-helper_spec.js
+++ b/src/ggrc-client/js/components/access-control-list/tests/access-control-list-roles-helper_spec.js
@@ -10,7 +10,7 @@ import {
 import * as aclUtils from '../../../plugins/utils/acl-utils';
 import Component from '../access-control-list-roles-helper';
 import Cacheable from '../../../models/cacheable';
-import accessControlList from '../../../models/mixins/access-control-list';
+import AccessControlList from '../../../models/mixins/access-control-list';
 
 describe('access-control-list-roles-helper component', function () {
   'use strict';
@@ -24,7 +24,7 @@ describe('access-control-list-roles-helper component', function () {
       model: Cacheable,
       staticProps: {
         mixins: [
-          accessControlList,
+          AccessControlList,
         ],
       },
     });

--- a/src/ggrc-client/js/components/add-tab-button/add-tab-button.js
+++ b/src/ggrc-client/js/components/add-tab-button/add-tab-button.js
@@ -11,7 +11,7 @@ import {
   isMyWork,
   isAllObjects,
 } from '../../plugins/utils/current-page-utils';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {shouldBeMappedExternally} from '../../models/mappers/mappings';
 import '../questionnaire-mapping-link/questionnaire-mapping-link';
 
@@ -23,7 +23,7 @@ const viewModel = canMap.extend({
         let type = this.attr('instance.type');
         let result = (type === 'Assessment') &&
           !!audit &&
-          !Permission.is_allowed_for('read', audit);
+          !isAllowedFor('read', audit);
         return result;
       },
     },
@@ -32,7 +32,7 @@ const viewModel = canMap.extend({
         let instance = this.attr('instance');
 
         return !this.attr('isAuditInaccessibleAssessment')
-          && Permission.is_allowed_for('update', instance)
+          && isAllowedFor('update', instance)
           && !instance.attr('archived')
           && !isMyWork()
           && !isAllObjects()

--- a/src/ggrc-client/js/components/add-tab-button/tests/add-tab-button_spec.js
+++ b/src/ggrc-client/js/components/add-tab-button/tests/add-tab-button_spec.js
@@ -6,7 +6,7 @@
 import canMap from 'can-map';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../add-tab-button';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 
 describe('add-tab-button component', function () {
   'use strict';
@@ -45,7 +45,7 @@ describe('add-tab-button component', function () {
           type: 'Assessment',
           audit: {},
         });
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
         let result = viewModel.attr('isAuditInaccessibleAssessment');
 
@@ -56,7 +56,7 @@ describe('add-tab-button component', function () {
     describe('returns true', () => {
       it(`if instance type is Assessment, there is audit but
         it is not allowed to read instance.audit`, () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
         viewModel.attr('instance', {
           type: 'Assessment',
           audit: {},

--- a/src/ggrc-client/js/components/assessment/assessment-local-ca.js
+++ b/src/ggrc-client/js/components/assessment/assessment-local-ca.js
@@ -14,7 +14,7 @@ import {
 } from '../../plugins/utils/ca-utils';
 import {VALIDATION_ERROR, RELATED_ITEMS_LOADED} from '../../events/eventTypes';
 import tracker from '../../tracker';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import isFunction from 'can-util/js/is-function/is-function';
 import {getPageInstance} from '../../plugins/utils/current-page-utils';
 import {getPlainText} from '../../plugins/ggrc_utils';
@@ -45,7 +45,7 @@ export default canComponent.extend({
         value: false,
         get: function () {
           return this.attr('editMode') &&
-            Permission.is_allowed_for('update', this.attr('instance'));
+            isAllowedFor('update', this.attr('instance'));
         },
       },
       evidenceAmount: {

--- a/src/ggrc-client/js/components/assessment/attach-button.js
+++ b/src/ggrc-client/js/components/assessment/attach-button.js
@@ -6,7 +6,7 @@
 import canStache from 'can-stache';
 import canMap from 'can-map';
 import canComponent from 'can-component';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import template from './attach-button.stache';
 import {
   getGDriveItemId,
@@ -24,7 +24,7 @@ export default canComponent.extend({
       hasPermissions: {
         get: function (prevValue, setValue) {
           let instance = this.attr('instance');
-          if (Permission.is_allowed_for('update', instance) &&
+          if (isAllowedFor('update', instance) &&
             !instance.attr('archived')) {
             this.checkFolder().always(function () {
               setValue(true);

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
@@ -65,7 +65,7 @@ import {
   REFRESH_RELATED,
   REFRESHED,
 } from '../../../events/eventTypes';
-import Permission from '../../../permission';
+import {isAllowedFor} from '../../../permission';
 import {
   getPageInstance,
 } from '../../../plugins/utils/current-page-utils';
@@ -199,15 +199,14 @@ export default canComponent.extend({
       },
       isEditDenied: {
         get: function () {
-          return !Permission
-            .is_allowed_for('update', this.attr('instance')) ||
+          return !isAllowedFor('update', this.attr('instance')) ||
             this.attr('instance.archived');
         },
       },
       isAllowedToMap: {
         get: function () {
           let audit = this.attr('instance.audit');
-          return !!audit && Permission.is_allowed_for('read', audit);
+          return !!audit && isAllowedFor('read', audit);
         },
       },
       instance: {},

--- a/src/ggrc-client/js/components/assessment/info-pane/tests/assessment-info-pane_spec.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/tests/assessment-info-pane_spec.js
@@ -19,7 +19,7 @@ import * as commentsUtils from '../../../../plugins/utils/comments-utils';
 import * as aclUtils from '../../../../plugins/utils/acl-utils';
 import * as caUtils from '../../../../plugins/utils/ca-utils';
 import * as DeferredTransactionUtil from '../../../../plugins/utils/deferred-transaction-utils';
-import Permission from '../../../../permission';
+import * as Permission from '../../../../permission';
 import {CUSTOM_ATTRIBUTE_TYPE} from '../../../../plugins/utils/custom-attribute/custom-attribute-config';
 import * as NotifiersUtils from '../../../../plugins/utils/notifiers-utils';
 import * as businessModels from '../../../../models/business-models';
@@ -248,17 +248,17 @@ describe('assessment-info-pane component', () => {
 
   describe('isEditDenied get() method', () => {
     beforeEach(function () {
-      spyOn(Permission, 'is_allowed_for');
+      spyOn(Permission, 'isAllowedFor');
       vm.attr('instance', {});
     });
 
     it('returns true if there are no update permissions for the ' +
     'current instance', function () {
       let result;
-      Permission.is_allowed_for.and.returnValue(false);
+      Permission.isAllowedFor.and.returnValue(false);
       result = vm.attr('isEditDenied');
       expect(result).toBe(true);
-      expect(Permission.is_allowed_for).toHaveBeenCalledWith(
+      expect(Permission.isAllowedFor).toHaveBeenCalledWith(
         'update',
         vm.attr('instance')
       );
@@ -267,7 +267,7 @@ describe('assessment-info-pane component', () => {
     describe('when there are update permissions for the current instance',
       () => {
         beforeEach(function () {
-          Permission.is_allowed_for.and.returnValue(true);
+          Permission.isAllowedFor.and.returnValue(true);
         });
 
         it('returns true if the current instance is archived', function () {
@@ -654,7 +654,7 @@ describe('assessment-info-pane component', () => {
       it('returns true if there is audit and it is allowed to read ' +
       'instance.audit', () => {
         vm.attr('instance.audit', {});
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
         let result = vm.attr('isAllowedToMap');
 
@@ -671,7 +671,7 @@ describe('assessment-info-pane component', () => {
       it('returns false if there is audit but it is not allowed ' +
       'to read instance.audit', () => {
         vm.attr('instance.audit', {});
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
 
         let result = vm.attr('isAllowedToMap');
 

--- a/src/ggrc-client/js/components/assessment/tests/assessment-local-ca_spec.js
+++ b/src/ggrc-client/js/components/assessment/tests/assessment-local-ca_spec.js
@@ -7,7 +7,7 @@ import canMap from 'can-map';
 import {
   ddValidationMapToValue,
 } from '../../../plugins/utils/ca-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../assessment-local-ca';
 
@@ -22,7 +22,7 @@ describe('assessment-local-ca component', () => {
     let spy;
 
     beforeEach(() => {
-      spy = spyOn(Permission, 'is_allowed_for');
+      spy = spyOn(Permission, 'isAllowedFor');
       viewModel.attr('instance', {});
     });
 

--- a/src/ggrc-client/js/components/comment/comments-section.js
+++ b/src/ggrc-client/js/components/comment/comments-section.js
@@ -12,7 +12,7 @@ import './comment-data-provider';
 import './comment-add-form';
 import './mapped-comments';
 import './comments-paging';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 
 export default canComponent.extend({
   tag: 'comments-section',
@@ -27,7 +27,7 @@ export default canComponent.extend({
         get() {
           const instance = this.attr('instance');
 
-          return !Permission.is_allowed_for('update', instance)
+          return !isAllowedFor('update', instance)
             || instance.attr('archived')
             || isChangeableExternally(instance);
         },

--- a/src/ggrc-client/js/components/create-document-button/create-document-button.js
+++ b/src/ggrc-client/js/components/create-document-button/create-document-button.js
@@ -18,7 +18,7 @@ import {
   DOCUMENT_CREATE_FAILED,
   MAP_OBJECTS,
 } from '../../events/eventTypes';
-import Permission from '../../permission';
+import {refreshPermissions} from '../../permission';
 import template from './create-document-button.stache';
 import Document from '../../models/business-models/document';
 import Context from '../../models/service-models/context';
@@ -115,7 +115,7 @@ const viewModel = canMap.extend({
     let dfd = $.Deferred().resolve();
 
     if (documents.length) {
-      dfd = Permission.refresh();
+      dfd = refreshPermissions();
     }
 
     dfd.then(function () {

--- a/src/ggrc-client/js/components/cycle-task-actions/cycle-task-actions.js
+++ b/src/ggrc-client/js/components/cycle-task-actions/cycle-task-actions.js
@@ -13,7 +13,7 @@ import {
 } from '../../plugins/utils/current-page-utils';
 import template from './cycle-task-actions.stache';
 import {updateStatus} from '../../plugins/utils/workflow-utils';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {notifier} from '../../plugins/utils/notifiers-utils';
 import {reify} from '../../plugins/utils/reify-utils';
 
@@ -46,7 +46,7 @@ let viewModel = canMap.extend({
         const pageType = getPageType();
         const instance = this.attr('instance');
 
-        let showButtons = Permission.is_allowed_for('update', instance);
+        let showButtons = isAllowedFor('update', instance);
 
         if (pageType === 'Workflow') {
           return showButtons && reify(this.attr('cycle')).attr('is_current');
@@ -58,7 +58,7 @@ let viewModel = canMap.extend({
     isAllowedToUpdateWorkflow: {
       get: function () {
         const workflow = this.attr('instance.workflow');
-        return Permission.is_allowed_for('update', workflow);
+        return isAllowedFor('update', workflow);
       },
     },
   },

--- a/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.js
+++ b/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.js
@@ -13,7 +13,7 @@ import {
   BEFORE_DOCUMENT_CREATE,
   DOCUMENT_CREATE_FAILED,
 } from '../../events/eventTypes';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import template from './folder-attachments-list.stache';
 
 /**
@@ -44,7 +44,7 @@ export default canComponent.extend({
           }
 
           let isSnapshot = this.attr('isSnapshot');
-          return isSnapshot || !Permission.is_allowed_for('update', instance);
+          return isSnapshot || !isAllowedFor('update', instance);
         },
       },
       showMore: {

--- a/src/ggrc-client/js/components/global-custom-attributes/global-custom-attributes.js
+++ b/src/ggrc-client/js/components/global-custom-attributes/global-custom-attributes.js
@@ -8,7 +8,7 @@ import canComponent from 'can-component';
 import {
   CUSTOM_ATTRIBUTE_TYPE,
 } from '../../plugins/utils/custom-attribute/custom-attribute-config';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {notifierXHR} from '../../plugins/utils/notifiers-utils';
 import {isProposableExternally} from '../../plugins/utils/ggrcq-utils';
 
@@ -38,7 +38,7 @@ export default canComponent.extend({
             this.attr('instance.archived') ||
             this.attr('isAttributesDisabled') ||
             this.isReadOnlyForInstance(this.attr('instance')) ||
-            !Permission.is_allowed_for('update', this.attr('instance'));
+            !isAllowedFor('update', this.attr('instance'));
         },
       },
     },

--- a/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
+++ b/src/ggrc-client/js/components/issue-tracker/generate-issues-in-bulk-button.js
@@ -8,7 +8,7 @@ import canStache from 'can-stache';
 import canMap from 'can-map';
 import canComponent from 'can-component';
 import template from './templates/generate-issues-in-bulk-button.stache';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {notifier} from '../../plugins/utils/notifiers-utils';
 import Stub from '../../models/stub';
 import {handleAjaxError} from '../../plugins/utils/errors-utils';
@@ -25,7 +25,7 @@ export default canComponent.extend({
     define: {
       isAllowedToGenerate: {
         get() {
-          return Permission.is_allowed_for('update', this.attr('instance'));
+          return isAllowedFor('update', this.attr('instance'));
         },
       },
       disableButton: {

--- a/src/ggrc-client/js/components/issue-tracker/tests/generate-issues-in-bulk-button_spec.js
+++ b/src/ggrc-client/js/components/issue-tracker/tests/generate-issues-in-bulk-button_spec.js
@@ -7,7 +7,7 @@ import Component from '../generate-issues-in-bulk-button';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import * as notifierUtils from '../../../plugins/utils/notifiers-utils';
 import * as errorsUtils from '../../../plugins/utils/errors-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import pubSub from '../../../pub-sub';
 
 describe('generate-issues-in-bulk-button component', () => {
@@ -326,7 +326,7 @@ describe('generate-issues-in-bulk-button component', () => {
       });
 
       it('should check status if user has permissions', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
         event();
 
@@ -334,7 +334,7 @@ describe('generate-issues-in-bulk-button component', () => {
       });
 
       it('should not check status if user has not permissions', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
 
         event();
 

--- a/src/ggrc-client/js/components/nav-actions/nav-actions.js
+++ b/src/ggrc-client/js/components/nav-actions/nav-actions.js
@@ -5,14 +5,14 @@
 
 import canMap from 'can-map';
 import canComponent from 'can-component';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {peopleWithRoleName} from '../../plugins/utils/acl-utils';
 
 const viewModel = canMap.extend({
   define: {
     canEdit: {
       get() {
-        return Permission.is_allowed_for('update', this.attr('instance'));
+        return isAllowedFor('update', this.attr('instance'));
       },
     },
     showSetupRequirement: {

--- a/src/ggrc-client/js/components/object-mapper/create-and-map.js
+++ b/src/ggrc-client/js/components/object-mapper/create-and-map.js
@@ -15,7 +15,7 @@ import {
   isSnapshotModel,
   isSnapshotParent,
 } from '../../plugins/utils/snapshot-utils';
-import Permission from '../../permission';
+import {isAllowedAny} from '../../permission';
 import {shouldBeMappedExternally} from '../../models/mappers/mappings';
 import {
   confirm,
@@ -50,7 +50,7 @@ export default canComponent.extend({
           let isSnapshotModelDst = isSnapshotModel(destination);
 
           let result =
-            Permission.is_allowed_any('create', destination) &&
+            isAllowedAny('create', destination) &&
             // Don't allow if source is Audit scope model (Asmt) and destination is snapshotable
             !((isInAuditScopeSrc && isSnapshotModelDst) ||
               // Don't allow if source is snapshotParent (Audit) and destination is snapshotable.

--- a/src/ggrc-client/js/components/object-mapper/tests/create-and-map_spec.js
+++ b/src/ggrc-client/js/components/object-mapper/tests/create-and-map_spec.js
@@ -12,7 +12,7 @@ import SnapshotableModel from '../../../models/business-models/control';
 import NotSnapshotableModel from '../../../models/business-models/issue';
 import AuditScopeModel from '../../../models/business-models/assessment';
 import Audit from '../../../models/business-models/audit';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 
 describe('create-and-map component', () => {
   let viewModel;
@@ -24,7 +24,7 @@ describe('create-and-map component', () => {
   describe('allowedToCreate get prop', function () {
     it('returns false if user does not have permissions to create object',
       () => {
-        spyOn(Permission, 'is_allowed_any').and.returnValue(false);
+        spyOn(Permission, 'isAllowedAny').and.returnValue(false);
 
         viewModel.attr('source',
           makeFakeInstance({model: NotSnapshotableModel})());
@@ -36,7 +36,7 @@ describe('create-and-map component', () => {
 
     it('returns false if source is an audit-scope model and ' +
       'destination is snapshotable', () => {
-      spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+      spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
       viewModel.attr('sourceType', AuditScopeModel.model_singular);
       viewModel.attr('source', makeFakeInstance({model: AuditScopeModel})());
@@ -48,7 +48,7 @@ describe('create-and-map component', () => {
 
     it('returns true if source is an audit-scope model and ' +
       'destination is not snapshotable', () => {
-      spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+      spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
       viewModel.attr('source', makeFakeInstance({model: AuditScopeModel})());
       viewModel.attr('destinationModel', NotSnapshotableModel);
@@ -59,7 +59,7 @@ describe('create-and-map component', () => {
 
     it('returns false when source is Audit and destination is snapshotable',
       () => {
-        spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+        spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
         viewModel.attr('sourceType', 'Audit');
         viewModel.attr('source', makeFakeInstance({model: Audit})());
@@ -71,7 +71,7 @@ describe('create-and-map component', () => {
 
     it('returns true when source is Audit and destination is not snapshotable',
       () => {
-        spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+        spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
         viewModel.attr('source', makeFakeInstance({model: Audit})());
         viewModel.attr('destinationModel', NotSnapshotableModel);
@@ -82,7 +82,7 @@ describe('create-and-map component', () => {
 
     it('returns false when source is snapshotable and destination is Audit',
       () => {
-        spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+        spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
         viewModel.attr('sourceType', SnapshotableModel.model_singular);
         viewModel.attr('source',
@@ -95,7 +95,7 @@ describe('create-and-map component', () => {
 
     it('returns true when source is not snapshotable and destination is Audit',
       () => {
-        spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+        spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
         viewModel.attr('source',
           makeFakeInstance({model: NotSnapshotableModel})());
@@ -107,7 +107,7 @@ describe('create-and-map component', () => {
 
     it('returns true if source and destination are ' +
       'neither Audit nor audit-scope model', () => {
-      spyOn(Permission, 'is_allowed_any').and.returnValue(true);
+      spyOn(Permission, 'isAllowedAny').and.returnValue(true);
 
       viewModel.attr('source',
         makeFakeInstance({model: NotSnapshotableModel})());

--- a/src/ggrc-client/js/components/object-review/object-review.js
+++ b/src/ggrc-client/js/components/object-review/object-review.js
@@ -11,7 +11,7 @@ import './request-review-modal';
 import template from './templates/object-review.stache';
 import notificationTemplate from './templates/complete-review-notification.stache';
 import Review from '../../models/service-models/review';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {isSnapshot} from '../../plugins/utils/snapshot-utils';
 import {createReviewInstance, saveReview} from '../../plugins/utils/object-review-utils';
 import {
@@ -59,7 +59,7 @@ export default canComponent.extend({
         get() {
           const instance = this.attr('review') || this.attr('instance');
 
-          return Permission.is_allowed_for('update', instance);
+          return isAllowedFor('update', instance);
         },
       },
       hasReviewers: {

--- a/src/ggrc-client/js/components/object-review/tests/object-review_spec.js
+++ b/src/ggrc-client/js/components/object-review/tests/object-review_spec.js
@@ -8,7 +8,7 @@ import Component from '../object-review';
 import Review from '../../../models/service-models/review';
 import * as NotifiersUtils from '../../../plugins/utils/notifiers-utils';
 import * as ObjectReviewUtils from '../../../plugins/utils/object-review-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import * as AclUtils from '../../../plugins/utils/acl-utils';
 
 describe('object-review component', () => {
@@ -130,15 +130,15 @@ describe('object-review component', () => {
       });
 
       it(`should return true if user has
-      "is_allowed_for update review" permission`, () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      "isAllowedFor update review" permission`, () => {
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
         expect(viewModel.attr('showButtons')).toBeTruthy();
       });
 
       it(`should return false if user does not have
-      "is_allowed_for update review" permission`, () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+      "isAllowedFor update review" permission`, () => {
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
 
         expect(viewModel.attr('showButtons')).toBeFalsy();
       });
@@ -152,15 +152,15 @@ describe('object-review component', () => {
       });
 
       it(`should return true if user has
-      "is_allowed_for update instance" permission`, () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      "isAllowedFor update instance" permission`, () => {
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
         expect(viewModel.attr('showButtons')).toBeTruthy();
       });
 
       it(`should return false if user does not have
-      "is_allowed_for update instance" permission`, () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+      "isAllowedFor update instance" permission`, () => {
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
 
         expect(viewModel.attr('showButtons')).toBeFalsy();
       });

--- a/src/ggrc-client/js/components/person-modal/person-modal.js
+++ b/src/ggrc-client/js/components/person-modal/person-modal.js
@@ -29,7 +29,7 @@ const viewModel = canMap.extend({
   },
   loadPersonProfile() {
     // Profile is loaded in the moment of modal initialization via person's
-    // form_preload method
+    // formPreload method
     const profile = PersonProfile.findInCacheById(
       this.attr('instance.profile.id')
     );

--- a/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
+++ b/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
@@ -10,7 +10,7 @@ import canComponent from 'can-component';
 import {
   isSnapshot,
 } from '../../plugins/utils/snapshot-utils';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 
 export default canComponent.extend({
   tag: 'related-people-access-control-group',
@@ -27,7 +27,7 @@ export default canComponent.extend({
             !this.attr('updatableGroupId') &&
             (this.attr('isNewInstance') ||
               this.attr('isProposal') ||
-              Permission.is_allowed_for('update', instance));
+              isAllowedFor('update', instance));
 
           return canEdit;
         },

--- a/src/ggrc-client/js/components/related-objects/related-urls.js
+++ b/src/ggrc-client/js/components/related-objects/related-urls.js
@@ -8,7 +8,7 @@ import canStache from 'can-stache';
 import canMap from 'can-map';
 import canComponent from 'can-component';
 
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import template from './templates/related-urls.stache';
 import {notifier} from '../../plugins/utils/notifiers-utils';
 import {sanitizer} from '../../plugins/utils/url-utils';
@@ -22,7 +22,7 @@ export default canComponent.extend({
       canAddUrl: {
         get() {
           let canEditInstance = this.attr('instance').isNew() ||
-            Permission.is_allowed_for('update', this.attr('instance'));
+            isAllowedFor('update', this.attr('instance'));
           let isNotEditable = this.attr('isNotEditable');
 
           return canEditInstance && !isNotEditable;
@@ -31,7 +31,7 @@ export default canComponent.extend({
       canRemoveUrl: {
         get() {
           let canEditInstance = this.attr('instance').isNew() ||
-            Permission.is_allowed_for('update', this.attr('instance'));
+            isAllowedFor('update', this.attr('instance'));
           let isNotEditable = this.attr('isNotEditable');
           let allowToRemove = this.attr('allowToRemove');
 

--- a/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-people-access-control-group_spec.js
@@ -4,7 +4,7 @@
  */
 
 import * as SnapshotUtils from '../../../plugins/utils/snapshot-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../related-people-access-control-group';
 
@@ -18,7 +18,7 @@ describe('related-people-access-control-group component', () => {
 
   describe('canEdit prop', () => {
     it('returns "false" when instance is snapshot', () => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
       viewModel.instance.attr('archived', false);
       viewModel.attr('updatableGroupId', null);
       viewModel.attr('isNewInstance', false);
@@ -30,7 +30,7 @@ describe('related-people-access-control-group component', () => {
 
     it('returns "false" when instance is archived', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
       viewModel.attr('updatableGroupId', null);
       viewModel.attr('isNewInstance', false);
 
@@ -43,7 +43,7 @@ describe('related-people-access-control-group component', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
       viewModel.instance.attr('archived', false);
       viewModel.attr('isNewInstance', false);
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
       viewModel.attr('updatableGroupId', 'groupId');
 
@@ -56,14 +56,14 @@ describe('related-people-access-control-group component', () => {
       viewModel.attr('updatableGroupId', null);
       viewModel.attr('isNewInstance', false);
 
-      spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(false);
 
       expect(viewModel.attr('canEdit')).toEqual(false);
     });
 
     it('returns "false" when is readonly', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(false);
       viewModel.instance.attr('archived', false);
       viewModel.attr('updatableGroupId', null);
       viewModel.attr('isNewInstance', true);
@@ -74,7 +74,7 @@ describe('related-people-access-control-group component', () => {
 
     it('returns "true" when new instance', () => {
       spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
-      spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(false);
       viewModel.instance.attr('archived', false);
       viewModel.attr('updatableGroupId', null);
 
@@ -89,7 +89,7 @@ describe('related-people-access-control-group component', () => {
       viewModel.attr('updatableGroupId', null);
       viewModel.attr('isNewInstance', false);
 
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
 
       expect(viewModel.attr('canEdit')).toEqual(true);
     });

--- a/src/ggrc-client/js/components/related-objects/tests/related-urls_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-urls_spec.js
@@ -6,7 +6,7 @@
 import canMap from 'can-map';
 import Component from '../related-urls';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import * as NotifiersUtils from '../../../plugins/utils/notifiers-utils';
 import * as UrlUtils from '../../../plugins/utils/url-utils';
 
@@ -24,11 +24,11 @@ describe('related-urls component', () => {
 
   describe('canAddUrl get() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for');
+      spyOn(Permission, 'isAllowedFor');
     });
 
     it('returns false if user can not update instance', () => {
-      Permission.is_allowed_for.and.returnValue(false);
+      Permission.isAllowedFor.and.returnValue(false);
       viewModel.attr('instance').isNew.and.returnValue(false);
 
       let result = viewModel.attr('canAddUrl');
@@ -38,7 +38,7 @@ describe('related-urls component', () => {
 
     it(`returns false if user can update instance 
         but edit is disabled in the component`, () => {
-      Permission.is_allowed_for.and.returnValue(true);
+      Permission.isAllowedFor.and.returnValue(true);
       viewModel.attr('instance').isNew.and.returnValue(false);
       viewModel.attr('isNotEditable', true);
 
@@ -49,7 +49,7 @@ describe('related-urls component', () => {
 
     it('returns true if user can update instance and edit is not denied',
       () => {
-        Permission.is_allowed_for.and.returnValue(true);
+        Permission.isAllowedFor.and.returnValue(true);
         viewModel.attr('instance').isNew.and.returnValue(false);
         viewModel.attr('isNotEditable', false);
 
@@ -59,7 +59,7 @@ describe('related-urls component', () => {
       });
 
     it('returns true if user creates new instance', () => {
-      Permission.is_allowed_for.and.returnValue(false);
+      Permission.isAllowedFor.and.returnValue(false);
       viewModel.attr('instance').isNew.and.returnValue(true);
 
       let result = viewModel.attr('canAddUrl');
@@ -70,11 +70,11 @@ describe('related-urls component', () => {
 
   describe('canRemoveUrl get() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for');
+      spyOn(Permission, 'isAllowedFor');
     });
 
     it('returns false if user can not update instance', () => {
-      Permission.is_allowed_for.and.returnValue(false);
+      Permission.isAllowedFor.and.returnValue(false);
       viewModel.attr('instance').isNew.and.returnValue(false);
 
       let result = viewModel.attr('canRemoveUrl');
@@ -84,7 +84,7 @@ describe('related-urls component', () => {
 
     it(`returns false if user can update instance 
         but edit is disabled in the component`, () => {
-      Permission.is_allowed_for.and.returnValue(true);
+      Permission.isAllowedFor.and.returnValue(true);
       viewModel.attr('instance').isNew.and.returnValue(false);
       viewModel.attr('isNotEditable', true);
 
@@ -95,7 +95,7 @@ describe('related-urls component', () => {
 
     it(`returns false if user can update instance, edit is is not denied,
         but removal is disabled by flag`, () => {
-      Permission.is_allowed_for.and.returnValue(true);
+      Permission.isAllowedFor.and.returnValue(true);
       viewModel.attr('instance').isNew.and.returnValue(false);
       viewModel.attr('isNotEditable', false);
       viewModel.attr('allowToRemove', false);
@@ -107,7 +107,7 @@ describe('related-urls component', () => {
 
     it(`returns true if user can update instance, edit is not denied,
         and removal is not disabled`, () => {
-      Permission.is_allowed_for.and.returnValue(true);
+      Permission.isAllowedFor.and.returnValue(true);
       viewModel.attr('instance').isNew.and.returnValue(false);
       viewModel.attr('isNotEditable', false);
       viewModel.attr('allowToRemove', true);
@@ -118,7 +118,7 @@ describe('related-urls component', () => {
     });
 
     it('returns true if user creates instance', () => {
-      Permission.is_allowed_for.and.returnValue(false);
+      Permission.isAllowedFor.and.returnValue(false);
       viewModel.attr('instance').isNew.and.returnValue(true);
 
       let result = viewModel.attr('canRemoveUrl');

--- a/src/ggrc-client/js/components/tree/tests/tree-actions_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-actions_spec.js
@@ -8,7 +8,7 @@ import Component from '../tree-actions';
 import * as SnapshotUtils from '../../../plugins/utils/snapshot-utils';
 import * as AclUtils from '../../../plugins/utils/acl-utils';
 import * as CurrentPageUtils from '../../../plugins/utils/current-page-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 
 describe('tree-actions component', () => {
@@ -109,14 +109,14 @@ describe('tree-actions component', () => {
 
     it('returns true when objects are not snapshots and user has permissions',
       () => {
-        spyOn(Permission, 'is_allowed').and.returnValue(true);
+        spyOn(Permission, 'isAllowed').and.returnValue(true);
 
         expect(vm.attr('showImport')).toBeTruthy();
       });
 
     it('returns false for snapshots', () => {
       vm.attr('options', {objectVersion: {data: 'Data'}});
-      spyOn(Permission, 'is_allowed').and.returnValue(true);
+      spyOn(Permission, 'isAllowed').and.returnValue(true);
 
       expect(vm.attr('showImport')).toBeFalsy();
     });
@@ -126,14 +126,14 @@ describe('tree-actions component', () => {
         model_singular: 'Control',
         isChangeableExternally: true,
       });
-      spyOn(Permission, 'is_allowed').and.returnValue(true);
+      spyOn(Permission, 'isAllowed').and.returnValue(true);
 
       expect(vm.attr('showImport')).toBeFalsy();
     });
 
     it(`returns false when user does not have update permissions
       and is not auditor`, () => {
-      spyOn(Permission, 'is_allowed').and.returnValue(false);
+      spyOn(Permission, 'isAllowed').and.returnValue(false);
       spyOn(AclUtils, 'isAuditor').and.returnValue(false);
 
       expect(vm.attr('showImport')).toBeFalsy();
@@ -141,7 +141,7 @@ describe('tree-actions component', () => {
 
     it('returns true when user has update permissions but is not auditor',
       () => {
-        spyOn(Permission, 'is_allowed').and.returnValue(true);
+        spyOn(Permission, 'isAllowed').and.returnValue(true);
         spyOn(AclUtils, 'isAuditor').and.returnValue(false);
 
         expect(vm.attr('showImport')).toBeTruthy();
@@ -149,7 +149,7 @@ describe('tree-actions component', () => {
 
     it(`returns true when user has auditor rights
       but does not have update permissions`, () => {
-      spyOn(Permission, 'is_allowed').and.returnValue(false);
+      spyOn(Permission, 'isAllowed').and.returnValue(false);
       spyOn(AclUtils, 'isAuditor').and.returnValue(true);
 
       expect(vm.attr('showImport')).toBeTruthy();

--- a/src/ggrc-client/js/components/tree/tests/tree-item-actions_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-item-actions_spec.js
@@ -9,7 +9,7 @@ import {
   getComponentVM,
   makeFakeInstance,
 } from '../../../../js_specs/spec_helpers';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import * as SnapshotUtils from '../../../plugins/utils/snapshot-utils';
 import * as Mapper from '../../../models/mappers/mappings';
 import Cacheable from '../../../models/cacheable';
@@ -28,7 +28,7 @@ describe('tree-item-actions component', function () {
     });
     describe('returns false', () => {
       it('if there is no objects to map to instance type', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(Mapper, 'getMappingList').and.returnValue([]);
         viewModel.attr('instance.type', 'Workflow');
 
@@ -38,7 +38,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if user has no rights to update instance', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
         let result = viewModel.attr('isAllowedToMap');
 
         expect(result).toBe(false);
@@ -48,7 +48,7 @@ describe('tree-item-actions component', function () {
     describe('returns true', () => {
       it('if there are objects to map to instance type and ' +
         'user has permissions to update instance', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(Mapper, 'getMappingList').and.returnValue(['Object1']);
         viewModel.attr('instance.type', 'Type');
 
@@ -62,7 +62,7 @@ describe('tree-item-actions component', function () {
   describe('isAllowedToEdit get() method', () => {
     describe('returns false', () => {
       it('if instance is archived', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
         viewModel.attr('instance.type', 'Type');
         viewModel.attr('instance.archived', true);
@@ -72,7 +72,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if instance is snapshot', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(true);
         viewModel.attr('instance.type', 'Type');
         viewModel.attr('instance.archived', false);
@@ -82,7 +82,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if instance type is in forbiddenEditList', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
         viewModel.attr('instance.type', 'Cycle');
         viewModel.attr('instance.archived', false);
@@ -92,7 +92,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if user has not permissions to update instance', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(false);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
         viewModel.attr('instance.type', 'Type');
         viewModel.attr('instance.archived', false);
@@ -102,7 +102,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if object is changeable externally', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
 
         let instance = makeFakeInstance({
@@ -121,7 +121,7 @@ describe('tree-item-actions component', function () {
       });
 
       it('if instance is readonly', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
         viewModel.attr('instance.type', 'Type');
         viewModel.attr('instance.archived', false);
@@ -134,7 +134,7 @@ describe('tree-item-actions component', function () {
 
     describe('returns true', () => {
       it('if allowed to edit instance', () => {
-        spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+        spyOn(Permission, 'isAllowedFor').and.returnValue(true);
         spyOn(SnapshotUtils, 'isSnapshot').and.returnValue(false);
         viewModel.attr('instance.type', 'Type');
         viewModel.attr('instance.archived', false);

--- a/src/ggrc-client/js/components/tree/tree-actions.js
+++ b/src/ggrc-client/js/components/tree/tree-actions.js
@@ -19,7 +19,7 @@ import {
 import {
   isSnapshotRelated,
 } from '../../plugins/utils/snapshot-utils';
-import Permission from '../../permission';
+import {isAllowed} from '../../permission';
 import template from './templates/tree-actions.stache';
 
 export default canComponent.extend({
@@ -93,7 +93,7 @@ export default canComponent.extend({
           let model = this.attr('model');
           return !this.attr('isSnapshots') &&
             !model.isChangeableExternally &&
-            (Permission.is_allowed(
+            (isAllowed(
               'update', model.model_singular, instance.context)
               || isAuditor(instance, GGRC.current_user));
         },

--- a/src/ggrc-client/js/components/tree/tree-item-actions.js
+++ b/src/ggrc-client/js/components/tree/tree-item-actions.js
@@ -15,7 +15,7 @@ import {
 import {
   getPageType,
 } from '../../plugins/utils/current-page-utils';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {getMappingList} from '../../models/mappers/mappings';
 
 const forbiddenEditList = ['Cycle', 'CycleTaskGroup'];
@@ -56,7 +56,7 @@ const viewModel = canMap.extend({
         let isSnapshot = this.attr('isSnapshot');
         let isArchived = instance.attr('archived');
         let isInForbiddenList = forbiddenEditList.indexOf(type) > -1;
-        return !Permission.is_allowed_for('update', instance) ||
+        return !isAllowedFor('update', instance) ||
           (isSnapshot || isInForbiddenList || isArchived);
       },
     },
@@ -76,7 +76,7 @@ const viewModel = canMap.extend({
         if (type === 'Assessment') {
           let audit = this.attr('instance.audit');
 
-          if (!Permission.is_allowed_for('read', audit)) {
+          if (!isAllowedFor('read', audit)) {
             return false;
           }
         }

--- a/src/ggrc-client/js/components/workflow/create-task-group-button/create-task-group-button.js
+++ b/src/ggrc-client/js/components/workflow/create-task-group-button/create-task-group-button.js
@@ -6,7 +6,7 @@
 import canMap from 'can-map';
 import canComponent from 'can-component';
 import {refreshTGRelatedItems} from '../../../plugins/utils/workflow-utils';
-import Permission from '../../../permission';
+import {isAllowedFor} from '../../../permission';
 
 const viewModel = canMap.extend({
   define: {
@@ -14,7 +14,7 @@ const viewModel = canMap.extend({
       get() {
         const workflow = this.attr('workflow');
         return (
-          Permission.is_allowed_for('update', workflow) &&
+          isAllowedFor('update', workflow) &&
           workflow.attr('status') !== 'Inactive'
         );
       },

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/cycle-task-group-object-task.js
@@ -30,7 +30,7 @@ import {
 import {
   getPageType,
 } from '../../../plugins/utils/current-page-utils';
-import Permission from '../../../permission';
+import {isAllowedFor} from '../../../permission';
 
 let viewModel = canMap.extend({
   partials: {
@@ -41,7 +41,7 @@ let viewModel = canMap.extend({
   define: {
     isAllowedToUpdate: {
       get() {
-        return Permission.is_allowed_for('update', this.attr('instance'));
+        return isAllowedFor('update', this.attr('instance'));
       },
     },
     isEditDenied: {

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/tests/cycle-task-group-object-task_spec.js
@@ -10,7 +10,7 @@ import {
   getComponentVM,
   spyProp,
 } from '../../../../../js_specs/spec_helpers';
-import Permission from '../../../../permission';
+import * as Permission from '../../../../permission';
 
 describe('cycle-task-group-object-task component', () => {
   let viewModel;
@@ -22,18 +22,18 @@ describe('cycle-task-group-object-task component', () => {
   describe('isAllowedToUpdate get() method', () => {
     beforeEach(() => {
       viewModel.attr('instance', {});
-      spyOn(Permission, 'is_allowed_for');
+      spyOn(Permission, 'isAllowedFor');
     });
 
     it('returns true if it is allowed to update instance', () => {
-      Permission.is_allowed_for.
+      Permission.isAllowedFor.
         withArgs('update', viewModel.attr('instance')).and.returnValue(true);
 
       expect(viewModel.attr('isAllowedToUpdate')).toBe(true);
     });
 
     it('returns false if it is not allowed to update instance', () => {
-      Permission.is_allowed_for
+      Permission.isAllowedFor
         .withArgs('update', viewModel.attr('instance')).and.returnValue(false);
 
       expect(viewModel.attr('isAllowedToUpdate')).toBe(false);

--- a/src/ggrc-client/js/components/workflow/task-group/task-group.js
+++ b/src/ggrc-client/js/components/workflow/task-group/task-group.js
@@ -11,14 +11,14 @@ import '../task-group-clone';
 import '../task-list/task-list';
 import '../task-group-objects/task-group-objects';
 import template from './templates/task-group.stache';
-import Permission from '../../../permission';
+import {isAllowedFor} from '../../../permission';
 
 const viewModel = canMap.extend({
   define: {
     canEdit: {
       get() {
         return (
-          Permission.is_allowed_for('update', this.attr('instance')) &&
+          isAllowedFor('update', this.attr('instance')) &&
           this.attr('workflow.status') !== 'Inactive'
         );
       },

--- a/src/ggrc-client/js/components/workflow/task-list/task-list.js
+++ b/src/ggrc-client/js/components/workflow/task-list/task-list.js
@@ -8,7 +8,7 @@ import canMap from 'can-map';
 import canComponent from 'can-component';
 import template from './templates/task-list.stache';
 import Pagination from '../../base-objects/pagination';
-import Permission from '../../../permission';
+import {isAllowedFor} from '../../../permission';
 import {REFRESH_RELATED} from '../../../events/eventTypes';
 import TaskGroupTask from '../../../models/business-models/task-group-task';
 
@@ -24,7 +24,7 @@ const viewModel = canMap.extend({
       get() {
         const workflow = this.attr('workflow');
         return (
-          Permission.is_allowed_for('update', this.attr('baseInstance')) &&
+          isAllowedFor('update', this.attr('baseInstance')) &&
           workflow && workflow.attr('status') !== 'Inactive'
         );
       },

--- a/src/ggrc-client/js/components/workflow/task-list/tests/task-list_spec.js
+++ b/src/ggrc-client/js/components/workflow/task-list/tests/task-list_spec.js
@@ -5,7 +5,7 @@
 
 import Component from '../task-list';
 import {getComponentVM} from '../../../../../js_specs/spec_helpers';
-import Permission from '../../../../permission';
+import * as Permission from '../../../../permission';
 import {REFRESH_RELATED} from '../../../../events/eventTypes';
 import TaskGroupTask from '../../../../models/business-models/task-group-task';
 
@@ -25,10 +25,10 @@ describe('task-list component', () => {
       describe('returns false', () => {
         it('when there are no "update" permissions for the passed task group',
           function () {
-            spyOn(Permission, 'is_allowed_for').and.returnValue(false);
+            spyOn(Permission, 'isAllowedFor').and.returnValue(false);
             const result = viewModel.attr('showCreateTaskButton');
             expect(result).toBe(false);
-            expect(Permission.is_allowed_for).toHaveBeenCalledWith(
+            expect(Permission.isAllowedFor).toHaveBeenCalledWith(
               'update',
               viewModel.attr('baseInstance')
             );

--- a/src/ggrc-client/js/components/workflow/tests/workflow-activate_spec.js
+++ b/src/ggrc-client/js/components/workflow/tests/workflow-activate_spec.js
@@ -7,7 +7,7 @@ import canMap from 'can-map';
 import {getComponentVM} from '../../../../js_specs/spec_helpers';
 import Component from '../workflow-activate';
 import * as helpers from '../../../plugins/utils/workflow-utils';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 import * as WidgetsUtils from '../../../plugins/utils/widgets-utils';
 import {countsMap as workflowCountsMap} from '../../../apps/workflows';
 
@@ -49,7 +49,7 @@ describe('workflow-activate component', function () {
       workflow = new canMap();
       workflow.refresh_all = jasmine.createSpy('refresh_all');
       spyOn(viewModel, 'initWorkflow');
-      spyOn(Permission, 'refresh');
+      spyOn(Permission, 'refreshPermissions');
       spyOn(viewModel, 'updateActiveCycleCounts');
       spyOn(helpers, 'redirectToCycle');
     });
@@ -67,7 +67,7 @@ describe('workflow-activate component', function () {
         await viewModel.repeatOnHandler(workflow);
         expect(viewModel.initWorkflow).toHaveBeenCalledWith(workflow);
         expect(viewModel.initWorkflow).toHaveBeenCalledBefore(
-          Permission.refresh
+          Permission.refreshPermissions
         );
         done();
       }
@@ -75,8 +75,8 @@ describe('workflow-activate component', function () {
 
     it('should refresh permissions', async function (done) {
       await viewModel.repeatOnHandler(workflow);
-      expect(Permission.refresh).toHaveBeenCalled();
-      expect(Permission.refresh).toHaveBeenCalledBefore(
+      expect(Permission.refreshPermissions).toHaveBeenCalled();
+      expect(Permission.refreshPermissions).toHaveBeenCalledBefore(
         viewModel.updateActiveCycleCounts
       );
       done();
@@ -122,7 +122,7 @@ describe('workflow-activate component', function () {
 
     it('should restore button when permission refresh fails',
       async function (done) {
-        Permission.refresh.and.returnValue(Promise.reject());
+        Permission.refreshPermissions.and.returnValue(Promise.reject());
         try {
           await viewModel.repeatOnHandler(workflow);
         } catch (err) {

--- a/src/ggrc-client/js/components/workflow/workflow-activate.js
+++ b/src/ggrc-client/js/components/workflow/workflow-activate.js
@@ -12,7 +12,7 @@ import {
 import {
   initCounts,
 } from '../../plugins/utils/widgets-utils';
-import Permission from '../../permission';
+import {refreshPermissions} from '../../permission';
 import {countsMap as workflowCountsMap} from '../../apps/workflows';
 
 const viewModel = canMap.extend({
@@ -35,7 +35,7 @@ const viewModel = canMap.extend({
     this.attr('waiting', true);
     try {
       await this.initWorkflow(workflow);
-      await Permission.refresh();
+      await refreshPermissions();
       await this.updateActiveCycleCounts(workflow);
       await workflow.refresh_all('task_groups', 'task_group_tasks');
       redirectToCycle();

--- a/src/ggrc-client/js/controllers/dashboard_controller.js
+++ b/src/ggrc-client/js/controllers/dashboard_controller.js
@@ -35,7 +35,6 @@ const DashboardControl = canControl.extend({
   },
 }, {
   init: function (el, options) {
-    this.options = new canMap(this.options);
     this.init_tree_view_settings();
     this.init_page_title();
     this.init_page_header();
@@ -132,7 +131,7 @@ const DashboardControl = canControl.extend({
   },
 
   tryToRefetchOnce(descriptor) {
-    const refetchOnce = this.options.attr('refetchOnce');
+    const refetchOnce = this.options.refetchOnce;
 
     if (!refetchOnce.size) {
       return false;
@@ -143,7 +142,7 @@ const DashboardControl = canControl.extend({
 
   addRefetchOnceItems(modelNames) {
     modelNames = typeof modelNames === 'string' ? [modelNames] : modelNames;
-    const refetchOnce = this.options.attr('refetchOnce');
+    const refetchOnce = this.options.refetchOnce;
 
     modelNames.forEach((modelName) => {
       refetchOnce.add(modelName);

--- a/src/ggrc-client/js/controllers/info_pin_controller.js
+++ b/src/ggrc-client/js/controllers/info_pin_controller.js
@@ -127,8 +127,8 @@ export default canControl.extend({
 
     this.prepareView(opts, el, maximizedState);
 
-    if (instance.info_pane_preload) {
-      instance.info_pane_preload();
+    if (instance.infoPanePreload) {
+      instance.infoPanePreload();
     }
 
     this.changeMaximizedState(maximizedState);

--- a/src/ggrc-client/js/controllers/info_widget_controller.js
+++ b/src/ggrc-client/js/controllers/info_widget_controller.js
@@ -38,8 +38,8 @@ export default canControl.extend({
       this.options.widget_view = GGRC.templates_path +
         this.element.data('widget-view');
     }
-    if (this.options.instance.info_pane_preload) {
-      this.options.instance.info_pane_preload();
+    if (this.options.instance.infoPanePreload) {
+      this.options.instance.infoPanePreload();
     }
     this.options.context = new canMap({
       model: this.options.model,

--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -257,8 +257,8 @@ export default canControl.extend({
     if (!instance._transient) {
       instance.attr('_transient', new canMap({}));
     }
-    if (instance.form_preload) {
-      preloadDfd = instance.form_preload(
+    if (instance.formPreload) {
+      preloadDfd = instance.formPreload(
         this.options.new_object_form,
         this.options.object_params,
         getPageInstance());

--- a/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
+++ b/src/ggrc-client/js/controllers/tests/modals_controller_spec.js
@@ -196,28 +196,28 @@ describe('ModalsController', function () {
         expect(ctrlInst.element.trigger).toHaveBeenCalledWith('loaded');
       });
 
-      it('calls form_preload of instance if it is defined', () => {
+      it('calls formPreload of instance if it is defined', () => {
         let pageInstance = {};
         spyOn(currentPageUtils, 'getPageInstance')
           .and.returnValue(pageInstance);
-        instance.form_preload = jasmine.createSpy();
+        instance.formPreload = jasmine.createSpy();
 
         method(instance);
 
-        expect(instance.form_preload).toHaveBeenCalledWith(
+        expect(instance.formPreload).toHaveBeenCalledWith(
           ctrlInst.options.new_object_form,
           ctrlInst.options.object_params,
           pageInstance
         );
       });
 
-      describe('if form_preload returns deferred', () => {
+      describe('if formPreload returns deferred', () => {
         let formPreloadDfd;
 
         beforeEach(() => {
           formPreloadDfd = $.Deferred();
           instance.backup = jasmine.createSpy('backup');
-          instance.form_preload = jasmine.createSpy('form_preload').and
+          instance.formPreload = jasmine.createSpy('formPreload').and
             .returnValue(formPreloadDfd);
         });
 
@@ -237,7 +237,7 @@ describe('ModalsController', function () {
         });
       });
 
-      it('returns resolved deferred if form_preload is not defined', (done) => {
+      it('returns resolved deferred if formPreload is not defined', (done) => {
         method(instance).done(() => {
           done();
         });

--- a/src/ggrc-client/js/entrypoints/admin/bootstrap.js
+++ b/src/ggrc-client/js/entrypoints/admin/bootstrap.js
@@ -19,7 +19,7 @@ import CustomAttributeDefinition from '../../models/custom-attributes/custom-att
 import AccessControlRole from '../../models/custom-roles/access-control-role';
 import Roleable from '../../models/custom-roles/roleable';
 import Person from '../../models/business-models/person';
-import WidgetList from '../../modules/widget_list';
+import WidgetList, {getWidgetListFor} from '../../modules/widget_list';
 import ListView from '../../controllers/tree/list_view_controller';
 import TreeViewControl from '../../controllers/tree/tree-view';
 import {DashboardControl} from '../../controllers/dashboard_controller';
@@ -198,7 +198,7 @@ new WidgetList('ggrc_admin', {
 });
 
 new DashboardControl('#pageContent', {
-  widget_descriptors: WidgetList.get_widget_list_for('admin'),
+  widget_descriptors: getWidgetListFor('admin'),
   menu_tree_spec: GGRC.admin_menu_spec,
   header_view: `${GGRC.templates_path}/base_objects/page_header.stache`,
   innernav_view: `${GGRC.templates_path}/base_objects/inner-nav.stache`,

--- a/src/ggrc-client/js/helpers.js
+++ b/src/ggrc-client/js/helpers.js
@@ -20,7 +20,11 @@ import {
   getRole,
   isAuditor,
 } from './plugins/utils/acl-utils';
-import Permission from './permission';
+import {
+  isAllowed,
+  isAllowedFor,
+  isAllowedAny,
+} from './permission';
 import modalModels from './models/modal-models';
 import {isScopeModel} from './plugins/utils/models-utils';
 import {
@@ -235,18 +239,18 @@ canStache.registerHelper('is_allowed', function (...args) {
 
   // Check permissions
   actions.forEach(function (action) {
-    if (resource && Permission.is_allowed_for(action, resource)) {
+    if (resource && isAllowedFor(action, resource)) {
       passed = true;
       return;
     }
     if (contextId !== undefined) {
-      passed = passed && Permission.is_allowed(action, resourceType,
+      passed = passed && isAllowed(action, resourceType,
         contextId);
     }
     if (passed && contextOverride === 'for' && resource) {
-      passed = passed && Permission.is_allowed_for(action, resource);
+      passed = passed && isAllowedFor(action, resource);
     } else if (passed && contextOverride === 'any' && resourceType) {
-      passed = passed && Permission.is_allowed_any(action, resourceType);
+      passed = passed && isAllowedAny(action, resourceType);
     }
   });
 
@@ -260,7 +264,7 @@ canStache.registerHelper('any_allowed', function (action, data, options) {
   data = resolveComputed(data);
 
   data.forEach(function (item) {
-    passed.push(Permission.is_allowed_any(action, item.model_name));
+    passed.push(isAllowedAny(action, item.model_name));
   });
   hasPassed = passed.some(function (val) {
     return val;
@@ -379,7 +383,7 @@ canStache.registerHelper('is_dashboard_or_all', function (options) {
 });
 
 canStache.registerHelper('current_user_is_admin', function (options) {
-  if (Permission.is_allowed('__GGRC_ADMIN__')) {
+  if (isAllowed('__GGRC_ADMIN__')) {
     return options.fn(options.contexts);
   }
   return options.inverse(options.contexts);

--- a/src/ggrc-client/js/models/business-models/access-group.js
+++ b/src/ggrc-client/js/models/business-models/access-group.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AaccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/access_groups/{id}',
   destroy: 'DELETE /api/access_groups/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AaccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/account-balance.js
+++ b/src/ggrc-client/js/models/business-models/account-balance.js
@@ -4,11 +4,11 @@
  */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/account_balances/{id}',
   destroy: 'DELETE /api/account_balances/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/assessment-template.js
+++ b/src/ggrc-client/js/models/business-models/assessment-template.js
@@ -5,8 +5,8 @@
 
 import canList from 'can-list';
 import Cacheable from '../cacheable';
-import refetchHash from '../mixins/refetch-hash';
-import assessmentIssueTracker from '../mixins/assessment-issue-tracker';
+import RefetchHash from '../mixins/refetch-hash';
+import AssessmentIssueTracker from '../mixins/assessment-issue-tracker';
 import Stub from '../stub';
 
 /**
@@ -26,8 +26,8 @@ export default Cacheable.extend({
   table_singular: 'assessment_template',
   table_plural: 'assessment_templates',
   mixins: [
-    refetchHash,
-    assessmentIssueTracker,
+    RefetchHash,
+    AssessmentIssueTracker,
   ],
   findOne: 'GET /api/assessment_templates/{id}',
   findAll: 'GET /api/assessment_templates',
@@ -108,7 +108,7 @@ export default Cacheable.extend({
    * @param {*} params - additional params
    * @param {*} pageInstance - current page instance
    */
-  form_preload: function (isNew, params, pageInstance) {
+  formPreload: function (isNew, params, pageInstance) {
     if (!this.audit || !this.audit.id || !this.audit.type) {
       if (pageInstance.type === 'Audit') {
         this.attr('audit', pageInstance);

--- a/src/ggrc-client/js/models/business-models/assessment.js
+++ b/src/ggrc-client/js/models/business-models/assessment.js
@@ -12,12 +12,12 @@ import {prepareCustomAttributes} from '../../plugins/utils/ca-utils';
 import {getRole} from '../../plugins/utils/acl-utils';
 import {sortByName} from '../../plugins/utils/label-utils';
 import tracker from '../../tracker';
-import caUpdate from '../mixins/ca-update';
-import autoStatusChangeable from '../mixins/auto-status-changeable';
-import accessControlList from '../mixins/access-control-list';
-import refetchHash from '../mixins/refetch-hash';
-import assessmentIssueTracker from '../mixins/assessment-issue-tracker';
-import relatedAssessmentsLoader from '../mixins/related-assessments-loader';
+import CaUpdate from '../mixins/ca-update';
+import AutoStatusChangeable from '../mixins/auto-status-changeable';
+import AccessControlList from '../mixins/access-control-list';
+import RefetchHash from '../mixins/refetch-hash';
+import AssessmentIssueTracker from '../mixins/assessment-issue-tracker';
+import RelatedAssessmentsLoader from '../mixins/related-assessments-loader';
 import {REFRESH_MAPPING, REFRESHED} from '../../events/eventTypes';
 
 export default Cacheable.extend({
@@ -30,10 +30,9 @@ export default Cacheable.extend({
   destroy: 'DELETE /api/assessments/{id}',
   create: 'POST /api/assessments',
   mixins: [
-    caUpdate,
-    autoStatusChangeable,
-    accessControlList, refetchHash,
-    assessmentIssueTracker, relatedAssessmentsLoader,
+    CaUpdate, AutoStatusChangeable,
+    AccessControlList, RefetchHash,
+    AssessmentIssueTracker, RelatedAssessmentsLoader,
   ],
   is_custom_attributable: true,
   isRoleable: true,
@@ -256,7 +255,7 @@ export default Cacheable.extend({
       }
     });
   },
-  before_create: function () {
+  beforeCreate: function () {
     if (!this.audit) {
       throw new Error('Cannot save assessment, audit not set.');
     } else if (!this.audit.context) {
@@ -290,7 +289,7 @@ export default Cacheable.extend({
     this._transformBackupProperty(['design', 'operationally']);
     return this._super(checkAssociations);
   },
-  form_preload: function (newObjectForm, params, pageInstance) {
+  formPreload: function (newObjectForm, params, pageInstance) {
     let currentUser = GGRC.current_user;
 
     if (!this.audit || !this.audit.id || !this.audit.type) {
@@ -304,7 +303,7 @@ export default Cacheable.extend({
     }
 
     // Make sure before create is called before save
-    this.before_create();
+    this.beforeCreate();
 
     if (this.audit) {
       const auditors = this.audit.findRoles('Auditors');
@@ -362,7 +361,7 @@ export default Cacheable.extend({
               delete this._pending_refresh;
               if (model) {
                 model = this.constructor.model(model, this);
-                this.after_refresh && this.after_refresh();
+                this.afterRefresh && this.afterRefresh();
                 model.backup();
                 return model;
               }

--- a/src/ggrc-client/js/models/business-models/audit.js
+++ b/src/ggrc-client/js/models/business-models/audit.js
@@ -6,10 +6,10 @@
 import canList from 'can-list';
 import Cacheable from '../cacheable';
 import {getRole} from '../../plugins/utils/acl-utils';
-import accessControlList from '../mixins/access-control-list';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import issueTracker from '../mixins/issue-tracker';
+import AccessControlList from '../mixins/access-control-list';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import IssueTracker from '../mixins/issue-tracker';
 import Stub from '../stub';
 import Program from './program';
 
@@ -23,10 +23,10 @@ export default Cacheable.extend({
   destroy: 'DELETE /api/audits/{id}',
   create: 'POST /api/audits',
   mixins: [
-    accessControlList,
-    uniqueTitle,
-    caUpdate,
-    issueTracker,
+    AccessControlList,
+    UniqueTitle,
+    CaUpdate,
+    IssueTracker,
   ],
   is_custom_attributable: true,
   is_clonable: true,

--- a/src/ggrc-client/js/models/business-models/contract.js
+++ b/src/ggrc-client/js/models/business-models/contract.js
@@ -4,7 +4,7 @@
 */
 
 import Directive from './directive';
-import accessControlList from '../mixins/access-control-list';
+import AccessControlList from '../mixins/access-control-list';
 
 export default Directive.extend({
   root_object: 'contract',
@@ -20,7 +20,7 @@ export default Directive.extend({
   create: 'POST /api/contracts',
   update: 'PUT /api/contracts/{id}',
   destroy: 'DELETE /api/contracts/{id}',
-  mixins: [accessControlList],
+  mixins: [AccessControlList],
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/control.js
+++ b/src/ggrc-client/js/models/business-models/control.js
@@ -4,10 +4,10 @@
 */
 
 import Cacheable from '../cacheable';
-import caUpdate from '../mixins/ca-update';
-import proposable from '../mixins/proposable';
-import relatedAssessmentsLoader from '../mixins/related-assessments-loader';
-import changeableExternally from '../mixins/changeable-externally';
+import CaUpdate from '../mixins/ca-update';
+import Proposable from '../mixins/proposable';
+import RelatedAssessmentsLoader from '../mixins/related-assessments-loader';
+import ChangeableExternally from '../mixins/changeable-externally';
 
 export default Cacheable.extend({
   root_object: 'control',
@@ -19,10 +19,10 @@ export default Cacheable.extend({
   update: 'PUT /api/controls/{id}',
   destroy: 'DELETE /api/controls/{id}',
   mixins: [
-    caUpdate,
-    proposable,
-    relatedAssessmentsLoader,
-    changeableExternally,
+    CaUpdate,
+    Proposable,
+    RelatedAssessmentsLoader,
+    ChangeableExternally,
   ],
   migrationDate: '03/26/2019',
   is_custom_attributable: true,

--- a/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
@@ -12,10 +12,10 @@ import Workflow from './workflow';
 import {REFRESH_SUB_TREE} from '../../events/eventTypes';
 import {getPageType} from '../../plugins/utils/current-page-utils';
 import {getClosestWeekday} from '../../plugins/utils/date-utils';
-import isOverdue from '../mixins/is-overdue';
-import accessControlList from '../mixins/access-control-list';
-import caUpdate from '../mixins/ca-update';
-import cycleTaskNotifications from '../mixins/notifications/cycle-task-notifications';
+import IsOverdue from '../mixins/is-overdue';
+import AccessControlList from '../mixins/access-control-list';
+import CaUpdate from '../mixins/ca-update';
+import CycleTaskNotifications from '../mixins/notifications/cycle-task-notifications';
 import Stub from '../stub';
 import {reify} from '../../plugins/utils/reify-utils';
 
@@ -67,10 +67,10 @@ export default Cacheable.extend({
   root_object: 'cycle_task_group_object_task',
   root_collection: 'cycle_task_group_object_tasks',
   mixins: [
-    isOverdue,
-    accessControlList,
-    caUpdate,
-    cycleTaskNotifications,
+    IsOverdue,
+    AccessControlList,
+    CaUpdate,
+    CycleTaskNotifications,
   ],
   category: 'workflow',
   findAll: 'GET /api/cycle_task_group_object_tasks',
@@ -254,7 +254,7 @@ export default Cacheable.extend({
     }
     populateFromWorkflow(this, workflow);
   },
-  form_preload: function (newObjectForm, objectParams) {
+  formPreload: function (newObjectForm, objectParams) {
     let form = this;
     let cycle;
     let startDate;

--- a/src/ggrc-client/js/models/business-models/cycle-task-group.js
+++ b/src/ggrc-client/js/models/business-models/cycle-task-group.js
@@ -4,7 +4,7 @@
 */
 
 import Cacheable from '../cacheable';
-import isOverdue from '../mixins/is-overdue';
+import IsOverdue from '../mixins/is-overdue';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -16,7 +16,7 @@ export default Cacheable.extend({
   create: 'POST /api/cycle_task_groups',
   update: 'PUT /api/cycle_task_groups/{id}',
   destroy: 'DELETE /api/cycle_task_groups/{id}',
-  mixins: [isOverdue],
+  mixins: [IsOverdue],
   attributes: {
     cycle: Stub,
     task_group: Stub,

--- a/src/ggrc-client/js/models/business-models/cycle.js
+++ b/src/ggrc-client/js/models/business-models/cycle.js
@@ -4,7 +4,7 @@
 */
 
 import Cacheable from '../cacheable';
-import Permission from '../../permission';
+import {refreshPermissions} from '../../permission';
 import isOverdue from '../mixins/is-overdue';
 import Stub from '../stub';
 import Workflow from './workflow';
@@ -16,7 +16,7 @@ function refreshWorkflow(ev, instance) {
     return;
   }
 
-  Permission.refresh();
+  refreshPermissions();
 
   const workflowId = instance.attr('workflow.id');
   const model = Workflow.findInCacheById(workflowId);

--- a/src/ggrc-client/js/models/business-models/cycle.js
+++ b/src/ggrc-client/js/models/business-models/cycle.js
@@ -5,7 +5,7 @@
 
 import Cacheable from '../cacheable';
 import {refreshPermissions} from '../../permission';
-import isOverdue from '../mixins/is-overdue';
+import IsOverdue from '../mixins/is-overdue';
 import Stub from '../stub';
 import Workflow from './workflow';
 import {getPageInstance} from '../../plugins/utils/current-page-utils';
@@ -35,7 +35,7 @@ export default Cacheable.extend({
   create: 'POST /api/cycles',
   update: 'PUT /api/cycles/{id}',
   destroy: 'DELETE /api/cycles/{id}',
-  mixins: [isOverdue],
+  mixins: [IsOverdue],
   attributes: {
     workflow: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/data-asset.js
+++ b/src/ggrc-client/js/models/business-models/data-asset.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/data_assets/{id}',
   destroy: 'DELETE /api/data_assets/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/directive.js
+++ b/src/ggrc-client/js/models/business-models/directive.js
@@ -4,9 +4,9 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import baseNotifications from '../mixins/notifications/base-notifications';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import BaseNotifications from '../mixins/notifications/base-notifications';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -17,7 +17,7 @@ export default Cacheable.extend({
   root_model: 'Directive',
   findAll: '/api/directives',
   findOne: '/api/directives/{id}',
-  mixins: [uniqueTitle, caUpdate, baseNotifications],
+  mixins: [UniqueTitle, CaUpdate, BaseNotifications],
   tree_view_options: {
     attr_list: Cacheable.attr_list.concat([
       {

--- a/src/ggrc-client/js/models/business-models/document.js
+++ b/src/ggrc-client/js/models/business-models/document.js
@@ -7,8 +7,8 @@ import loFind from 'lodash/find';
 import Cacheable from '../cacheable';
 import {getRole} from '../../plugins/utils/acl-utils';
 import {backendGdriveClient} from '../../plugins/ggrc-gapi-client';
-import accessControlList from '../mixins/access-control-list';
-import caUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import CaUpdate from '../mixins/ca-update';
 import Stub from '../stub';
 
 const getAccessControlList = () => {
@@ -32,8 +32,8 @@ export default Cacheable.extend({
   update: 'PUT /api/documents/{id}',
   destroy: 'DELETE /api/documents/{id}',
   mixins: [
-    accessControlList,
-    caUpdate,
+    AccessControlList,
+    CaUpdate,
   ],
   statuses: [
     'Active',

--- a/src/ggrc-client/js/models/business-models/evidence.js
+++ b/src/ggrc-client/js/models/business-models/evidence.js
@@ -6,8 +6,8 @@
 import loFind from 'lodash/find';
 import Cacheable from '../cacheable';
 import {getRole} from '../../plugins/utils/acl-utils';
-import accessControlList from '../mixins/access-control-list';
-import caUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import CaUpdate from '../mixins/ca-update';
 import Stub from '../stub';
 
 const getAccessControlList = () => {
@@ -31,8 +31,8 @@ export default Cacheable.extend({
   update: 'PUT /api/evidence/{id}',
   destroy: 'DELETE /api/evidence/{id}',
   mixins: [
-    accessControlList,
-    caUpdate,
+    AccessControlList,
+    CaUpdate,
   ],
   attributes: {
     context: Stub,

--- a/src/ggrc-client/js/models/business-models/facility.js
+++ b/src/ggrc-client/js/models/business-models/facility.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/facilities/{id}',
   destroy: 'DELETE /api/facilities/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/issue.js
+++ b/src/ggrc-client/js/models/business-models/issue.js
@@ -4,10 +4,10 @@
 */
 
 import Cacheable from '../cacheable';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import baseNotifications from '../mixins/notifications/base-notifications';
-import issueTracker from '../mixins/issue-tracker';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import BaseNotifications from '../mixins/notifications/base-notifications';
+import IssueTracker from '../mixins/issue-tracker';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -20,10 +20,10 @@ export default Cacheable.extend({
   destroy: 'DELETE /api/issues/{id}',
   create: 'POST /api/issues',
   mixins: [
-    caUpdate,
-    accessControlList,
-    baseNotifications,
-    issueTracker,
+    CaUpdate,
+    AccessControlList,
+    BaseNotifications,
+    IssueTracker,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/key-report.js
+++ b/src/ggrc-client/js/models/business-models/key-report.js
@@ -4,11 +4,11 @@
  */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/key_reports/{id}',
   destroy: 'DELETE /api/key_reports/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/market.js
+++ b/src/ggrc-client/js/models/business-models/market.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/markets/{id}',
   destroy: 'DELETE /api/markets/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/metric.js
+++ b/src/ggrc-client/js/models/business-models/metric.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/metrics/{id}',
   destroy: 'DELETE /api/metrics/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   attributes: {
     context: Stub,

--- a/src/ggrc-client/js/models/business-models/objective.js
+++ b/src/ggrc-client/js/models/business-models/objective.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import baseNotifications from '../mixins/notifications/base-notifications';
-import relatedAssessmentsLoader from '../mixins/related-assessments-loader';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import BaseNotifications from '../mixins/notifications/base-notifications';
+import RelatedAssessmentsLoader from '../mixins/related-assessments-loader';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -23,11 +23,11 @@ export default Cacheable.extend({
   update: 'PUT /api/objectives/{id}',
   destroy: 'DELETE /api/objectives/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    baseNotifications,
-    relatedAssessmentsLoader,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    BaseNotifications,
+    RelatedAssessmentsLoader,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/org-group.js
+++ b/src/ggrc-client/js/models/business-models/org-group.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/org_groups/{id}',
   destroy: 'DELETE /api/org_groups/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/person.js
+++ b/src/ggrc-client/js/models/business-models/person.js
@@ -6,7 +6,7 @@
 import loIsFunction from 'lodash/isFunction';
 import Cacheable from '../cacheable';
 import tracker from '../../tracker';
-import caUpdate from '../mixins/ca-update';
+import CaUpdate from '../mixins/ca-update';
 import Stub from '../stub';
 import {loadPersonProfile} from '../../plugins/utils/user-utils';
 import {ggrcGet} from '../../plugins/ajax_extensions';
@@ -27,7 +27,7 @@ export default Cacheable.extend({
     language: Stub,
     user_roles: Stub.List,
   },
-  mixins: [caUpdate],
+  mixins: [CaUpdate],
   defaults: {
     name: '',
     email: '',
@@ -133,7 +133,7 @@ export default Cacheable.extend({
         console.warn(`Request on '${url}' failed!`);
       });
   },
-  form_preload(newObjectForm) {
+  formPreload(newObjectForm) {
     if (newObjectForm) {
       return $.Deferred().resolve();
     }

--- a/src/ggrc-client/js/models/business-models/policy.js
+++ b/src/ggrc-client/js/models/business-models/policy.js
@@ -4,7 +4,7 @@
 */
 
 import Directive from './directive';
-import accessControlList from '../mixins/access-control-list';
+import AccessControlList from '../mixins/access-control-list';
 
 export default Directive.extend({
   root_object: 'policy',
@@ -24,7 +24,7 @@ export default Directive.extend({
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {},
-  mixins: [accessControlList],
+  mixins: [AccessControlList],
   sub_tree_view_options: {
     default_filter: ['DataAsset'],
   },

--- a/src/ggrc-client/js/models/business-models/process.js
+++ b/src/ggrc-client/js/models/business-models/process.js
@@ -4,11 +4,11 @@
  */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -27,11 +27,11 @@ export default Cacheable.extend({
   update: 'PUT /api/processes/{id}',
   destroy: 'DELETE /api/processes/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/product-group.js
+++ b/src/ggrc-client/js/models/business-models/product-group.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/product_groups/{id}',
   destroy: 'DELETE /api/product_groups/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   attributes: {
     context: Stub,

--- a/src/ggrc-client/js/models/business-models/product.js
+++ b/src/ggrc-client/js/models/business-models/product.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/products/{id}',
   destroy: 'DELETE /api/products/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/program.js
+++ b/src/ggrc-client/js/models/business-models/program.js
@@ -5,12 +5,12 @@
 
 import Cacheable from '../cacheable';
 import {getRole} from '../../plugins/utils/acl-utils';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import programNotifications from '../mixins/notifications/program-notifications';
-import proposable from '../mixins/proposable';
-import megaObject from '../mixins/mega-object';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ProgramNotifications from '../mixins/notifications/program-notifications';
+import Proposable from '../mixins/proposable';
+import MegaObject from '../mixins/mega-object';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -23,12 +23,12 @@ export default Cacheable.extend({
   update: 'PUT /api/programs/{id}',
   destroy: 'DELETE /api/programs/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    programNotifications,
-    proposable,
-    megaObject,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ProgramNotifications,
+    Proposable,
+    MegaObject,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/project.js
+++ b/src/ggrc-client/js/models/business-models/project.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/projects/{id}',
   destroy: 'DELETE /api/projects/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/regulation.js
+++ b/src/ggrc-client/js/models/business-models/regulation.js
@@ -4,7 +4,7 @@
 */
 
 import Directive from './directive';
-import accessControlList from '../mixins/access-control-list';
+import AccessControlList from '../mixins/access-control-list';
 
 export default Directive.extend({
   root_object: 'regulation',
@@ -23,7 +23,7 @@ export default Directive.extend({
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {},
-  mixins: [accessControlList],
+  mixins: [AccessControlList],
   sub_tree_view_options: {
     default_filter: ['Requirement'],
   },

--- a/src/ggrc-client/js/models/business-models/requirement.js
+++ b/src/ggrc-client/js/models/business-models/requirement.js
@@ -4,10 +4,10 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import baseNotifications from '../mixins/notifications/base-notifications';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import BaseNotifications from '../mixins/notifications/base-notifications';
 import Stub from '../stub';
 import Relationship from '../service-models/relationship';
 
@@ -30,10 +30,10 @@ export default Cacheable.extend({
   is_custom_attributable: true,
   isRoleable: true,
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    baseNotifications,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    BaseNotifications,
   ],
   attributes: {
     context: Stub,

--- a/src/ggrc-client/js/models/business-models/risk.js
+++ b/src/ggrc-client/js/models/business-models/risk.js
@@ -4,8 +4,8 @@
  */
 
 import Cacheable from '../cacheable';
-import proposable from '../mixins/proposable';
-import changeableExternally from '../mixins/changeable-externally';
+import Proposable from '../mixins/proposable';
+import ChangeableExternally from '../mixins/changeable-externally';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -18,8 +18,8 @@ export default Cacheable.extend({
   update: 'PUT /api/risks/{id}',
   destroy: 'DELETE /api/risks/{id}',
   mixins: [
-    proposable,
-    changeableExternally,
+    Proposable,
+    ChangeableExternally,
   ],
   migrationDate: '06/13/2019',
   is_custom_attributable: true,

--- a/src/ggrc-client/js/models/business-models/standard.js
+++ b/src/ggrc-client/js/models/business-models/standard.js
@@ -4,7 +4,7 @@
 */
 
 import Directive from './directive';
-import accessControlList from '../mixins/access-control-list';
+import AccessControlList from '../mixins/access-control-list';
 
 export default Directive.extend({
   root_object: 'standard',
@@ -23,7 +23,7 @@ export default Directive.extend({
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {},
-  mixins: [accessControlList],
+  mixins: [AccessControlList],
   sub_tree_view_options: {
     default_filter: ['Requirement'],
   },

--- a/src/ggrc-client/js/models/business-models/system.js
+++ b/src/ggrc-client/js/models/business-models/system.js
@@ -4,11 +4,11 @@
  */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/systems/{id}',
   destroy: 'DELETE /api/systems/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/task-group-task.js
+++ b/src/ggrc-client/js/models/business-models/task-group-task.js
@@ -8,8 +8,8 @@ import Cacheable from '../cacheable';
 import Workflow from './workflow';
 import TaskGroup from './task-group';
 import {getClosestWeekday} from '../../plugins/utils/date-utils';
-import contactable from '../mixins/contactable';
-import accessControlList from '../mixins/access-control-list';
+import Contactable from '../mixins/contactable';
+import AccessControlList from '../mixins/access-control-list';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -20,7 +20,7 @@ export default Cacheable.extend({
   update: 'PUT /api/task_group_tasks/{id}',
   destroy: 'DELETE /api/task_group_tasks/{id}',
 
-  mixins: [contactable, accessControlList],
+  mixins: [Contactable, AccessControlList],
   attributes: {
     context: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/task-group.js
+++ b/src/ggrc-client/js/models/business-models/task-group.js
@@ -4,7 +4,7 @@
  */
 
 import Cacheable from '../cacheable';
-import contactable from '../mixins/contactable';
+import Contactable from '../mixins/contactable';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -16,7 +16,7 @@ export default Cacheable.extend({
   create: 'POST /api/task_groups',
   update: 'PUT /api/task_groups/{id}',
   destroy: 'DELETE /api/task_groups/{id}',
-  mixins: [contactable],
+  mixins: [Contactable],
   attributes: {
     workflow: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/technology-environment.js
+++ b/src/ggrc-client/js/models/business-models/technology-environment.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/technology_environments/{id}',
   destroy: 'DELETE /api/technology_environments/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   attributes: {
     context: Stub,

--- a/src/ggrc-client/js/models/business-models/tests/assessment_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/assessment_spec.js
@@ -18,7 +18,7 @@ import * as AjaxUtils from '../../../plugins/ajax_extensions';
 describe('Assessment model', function () {
   'use strict';
 
-  describe('before_create() method', function () {
+  describe('beforeCreate() method', function () {
     let assessment;
     let audit;
     let auditWithoutContext;
@@ -36,33 +36,33 @@ describe('Assessment model', function () {
 
     it('sets the program and context properties', function () {
       assessment.attr('audit', audit);
-      assessment.before_create();
+      assessment.beforeCreate();
       expect(assessment.context.id).toEqual(context.id);
     });
 
     it('throws an error if audit is not defined', function () {
       expect(function () {
-        assessment.before_create();
+        assessment.beforeCreate();
       }).toThrow(new Error('Cannot save assessment, audit not set.'));
     });
 
     it('throws an error if audit program/context are not defined', function () {
       assessment.attr('audit', auditWithoutContext);
       expect(function () {
-        assessment.before_create();
+        assessment.beforeCreate();
       }).toThrow(new Error(
         'Cannot save assessment, audit context not set.'));
     });
     it('sets empty string to design property', function () {
       assessment.attr('audit', audit);
       assessment.attr('design', undefined);
-      assessment.before_create();
+      assessment.beforeCreate();
       expect(assessment.attr('design')).toEqual('');
     });
     it('sets empty string to operationally property', function () {
       assessment.attr('audit', audit);
       assessment.attr('operationally', undefined);
-      assessment.before_create();
+      assessment.beforeCreate();
       expect(assessment.attr('operationally')).toEqual('');
     });
   });
@@ -153,7 +153,7 @@ describe('Assessment model', function () {
     });
   });
 
-  describe('form_preload() method', function () {
+  describe('formPreload() method', function () {
     beforeEach(() => {
       spyOn(modelsUtils, 'getInstance').and.returnValue(GGRC.current_user);
     });
@@ -169,7 +169,7 @@ describe('Assessment model', function () {
 
     it('populates access control roles based on audit roles', function () {
       let model = makeFakeInstance({model: Assessment})();
-      spyOn(model, 'before_create');
+      spyOn(model, 'beforeCreate');
       spyOn(aclUtils, 'getRole').and.returnValues(
         {id: 10, name: 'Creators', object_type: 'Assessment'},
         {id: 11, name: 'Assignees', object_type: 'Assessment'},
@@ -200,7 +200,7 @@ describe('Assessment model', function () {
           return roles[name];
         },
       });
-      model.form_preload(true);
+      model.formPreload(true);
       // Expect 7 new access_control_roles to be created
       expect(model.access_control_list.length).toBe(7);
       checkAcRoles(model, 10, [1]);
@@ -210,7 +210,7 @@ describe('Assessment model', function () {
     it('defaults correctly when auditors/audit captains are undefined',
       function () {
         let model = makeFakeInstance({model: Assessment})();
-        spyOn(model, 'before_create');
+        spyOn(model, 'beforeCreate');
         spyOn(aclUtils, 'getRole').and.returnValues(
           {id: 10, name: 'Creators', object_type: 'Assessment'},
           {id: 11, name: 'Assignees', object_type: 'Assessment'},
@@ -227,7 +227,7 @@ describe('Assessment model', function () {
             return roles[name];
           },
         });
-        model.form_preload(true);
+        model.formPreload(true);
         // Expect 7 new access_control_roles to be created
         expect(model.access_control_list.length).toBe(2);
         checkAcRoles(model, 10, [1]);

--- a/src/ggrc-client/js/models/business-models/tests/assessment_template_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/assessment_template_spec.js
@@ -14,12 +14,12 @@ describe('AssessmentTemplate model', () => {
     instance = makeFakeInstance({model: AssessmentTemplate})();
   });
 
-  describe('form_preload method', () => {
+  describe('formPreload method', () => {
     it('adds custom_attribute_definitions field', () => {
       expect(instance.custom_attribute_definitions)
         .toBeUndefined();
 
-      instance.form_preload(true, null, {});
+      instance.formPreload(true, null, {});
 
       expect(instance.custom_attribute_definitions instanceof canList)
         .toBeTruthy();

--- a/src/ggrc-client/js/models/business-models/tests/cycle-task-group-object-task_spec.js
+++ b/src/ggrc-client/js/models/business-models/tests/cycle-task-group-object-task_spec.js
@@ -88,7 +88,7 @@ describe('CycleTaskGroupObjectTask model', function () {
     );
   });
 
-  describe('form_preload method', function () {
+  describe('formPreload method', function () {
     let instance;
 
     beforeEach(function () {
@@ -121,7 +121,7 @@ describe('CycleTaskGroupObjectTask model', function () {
       spyOn(workflow, 'refresh_all').and
         .returnValue(resolveChain);
 
-      instance.form_preload(true, {workflow: workflow});
+      instance.formPreload(true, {workflow: workflow});
 
       resolveChain.then(() => {
         expect(instance.attr('workflow.id')).toEqual('workflow id');

--- a/src/ggrc-client/js/models/business-models/threat.js
+++ b/src/ggrc-client/js/models/business-models/threat.js
@@ -4,10 +4,10 @@
  */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import baseNotifications from '../mixins/notifications/base-notifications';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import BaseNotifications from '../mixins/notifications/base-notifications';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -20,10 +20,10 @@ export default Cacheable.extend({
   update: 'PUT /api/threats/{id}',
   destroy: 'DELETE /api/threats/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    baseNotifications,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    BaseNotifications,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/vendor.js
+++ b/src/ggrc-client/js/models/business-models/vendor.js
@@ -4,11 +4,11 @@
 */
 
 import Cacheable from '../cacheable';
-import uniqueTitle from '../mixins/unique-title';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
-import scopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
-import questionnaire from '../mixins/questionnaire';
+import UniqueTitle from '../mixins/unique-title';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
+import ScopeObjectNotifications from '../mixins/notifications/scope-object-notifications';
+import Questionnaire from '../mixins/questionnaire';
 import Stub from '../stub';
 
 export default Cacheable.extend({
@@ -21,11 +21,11 @@ export default Cacheable.extend({
   update: 'PUT /api/vendors/{id}',
   destroy: 'DELETE /api/vendors/{id}',
   mixins: [
-    uniqueTitle,
-    caUpdate,
-    accessControlList,
-    scopeObjectNotifications,
-    questionnaire,
+    UniqueTitle,
+    CaUpdate,
+    AccessControlList,
+    ScopeObjectNotifications,
+    Questionnaire,
   ],
   is_custom_attributable: true,
   isRoleable: true,

--- a/src/ggrc-client/js/models/business-models/workflow.js
+++ b/src/ggrc-client/js/models/business-models/workflow.js
@@ -5,15 +5,15 @@
 
 import Cacheable from '../cacheable';
 import TaskGroup from './task-group';
-import caUpdate from '../mixins/ca-update';
-import accessControlList from '../mixins/access-control-list';
+import CaUpdate from '../mixins/ca-update';
+import AccessControlList from '../mixins/access-control-list';
 import Stub from '../stub';
 
 export default Cacheable.extend({
   root_object: 'workflow',
   root_collection: 'workflows',
   category: 'workflow',
-  mixins: [caUpdate, accessControlList],
+  mixins: [CaUpdate, AccessControlList],
   findAll: 'GET /api/workflows',
   findOne: 'GET /api/workflows/{id}',
   create: 'POST /api/workflows',

--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -157,7 +157,7 @@ export default canModel.extend({
 
     if (staticProps.mixins) {
       loForEach(staticProps.mixins, function (mixin) {
-        mixin.add_to(that);
+        mixin.addTo(that);
       });
       delete this.mixins;
     }
@@ -647,7 +647,7 @@ export default canModel.extend({
               return that.constructor.model(response);
             })
             .then((model) => {
-              that.after_refresh && that.after_refresh();
+              that.afterRefresh && that.afterRefresh();
               return model;
             })
             .done(function (response) {
@@ -736,20 +736,20 @@ export default canModel.extend({
     this.dispatch('modelBeforeSave');
 
     if (isNew) {
-      if (this.before_create) {
-        this.before_create();
+      if (this.beforeCreate) {
+        this.beforeCreate();
       }
     }
 
     let saveXHR = saveCallback.call(this)
       .then((result) => {
         if (!isNew) {
-          this.after_update && this.after_update();
+          this.afterUpdate && this.afterUpdate();
         }
-        this.after_save && this.after_save();
+        this.afterSave && this.afterSave();
         return result;
       }, (xhr, status, message) => {
-        this.save_error && this.save_error(xhr.responseText);
+        this.saveError && this.saveError(xhr.responseText);
         return new $.Deferred().reject(xhr, status, message);
       })
       .fail((response) => {

--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -25,7 +25,7 @@ import {
 import resolveConflict from './conflict-resolution/conflict-resolution';
 import PersistentNotifier from '../plugins/persistent-notifier';
 import SaveQueue from './save_queue';
-import RefreshQueue from './refresh_queue';
+import {refreshAll} from './refresh_queue';
 import tracker from '../tracker';
 import {delayLeavingPageUntil} from '../plugins/utils/current-page-utils';
 import Stub from './stub';
@@ -781,11 +781,11 @@ export default canModel.extend({
   refresh_all: function () {
     let props = Array.prototype.slice.call(arguments, 0);
 
-    return RefreshQueue.refresh_all(this, props);
+    return refreshAll(this, props);
   },
   refresh_all_force: function () {
     let props = Array.prototype.slice.call(arguments, 0);
 
-    return RefreshQueue.refresh_all(this, props, true);
+    return refreshAll(this, props, true);
   },
 });

--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -24,7 +24,7 @@ import {
 } from '../plugins/utils/snapshot-utils';
 import resolveConflict from './conflict-resolution/conflict-resolution';
 import PersistentNotifier from '../plugins/persistent-notifier';
-import SaveQueue from './save_queue';
+import enqueue from './save_queue';
 import {refreshAll} from './refresh_queue';
 import tracker from '../tracker';
 import {delayLeavingPageUntil} from '../plugins/utils/current-page-utils';
@@ -774,7 +774,7 @@ export default canModel.extend({
     this._dfd = new $.Deferred();
     delayLeavingPageUntil(this._dfd);
 
-    SaveQueue.enqueue(this, this._super);
+    enqueue(this, this._super);
 
     return this._dfd;
   },

--- a/src/ggrc-client/js/models/mappers/mappings.js
+++ b/src/ggrc-client/js/models/mappers/mappings.js
@@ -10,7 +10,7 @@ import canMap from 'can-map';
 import '../../plugins/utils/models-utils';
 
 import * as businessModels from '../business-models';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import config from './mappings-ggrc';
 
 /*
@@ -46,12 +46,12 @@ function getMappingList(type) {
  * @return {Boolean} whether user has permissions for mappings
  */
 function userHasPermissions(source, target) {
-  let hasPermissions = Permission.is_allowed_for('update', source)
+  let hasPermissions = isAllowedFor('update', source)
     || source.isNew();
 
   if (target instanceof canMap) {
     hasPermissions = hasPermissions
-      && Permission.is_allowed_for('update', target);
+      && isAllowedFor('update', target);
   }
 
   return hasPermissions;

--- a/src/ggrc-client/js/models/mappers/tests/mappings_spec.js
+++ b/src/ggrc-client/js/models/mappers/tests/mappings_spec.js
@@ -6,7 +6,7 @@
 import loDifference from 'lodash/difference';
 import canMap from 'can-map';
 import * as Mappings from '../mappings';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 
 describe('Mappings', () => {
   let allTypes = [];
@@ -140,14 +140,14 @@ describe('Mappings', () => {
 
   describe('allowedToMap() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
     });
 
     it('checks that types are mappable', () => {
       let result = Mappings.allowedToMap('SourceType', 'TargetType');
 
       expect(result).toBeFalsy();
-      expect(Permission.is_allowed_for).not.toHaveBeenCalled();
+      expect(Permission.isAllowedFor).not.toHaveBeenCalled();
     });
 
     it('checks map collection', () => {
@@ -164,9 +164,9 @@ describe('Mappings', () => {
       let result = Mappings.allowedToMap('Program', 'Document');
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for)
+      expect(Permission.isAllowedFor)
         .toHaveBeenCalledWith('update', 'Program');
-      expect(Permission.is_allowed_for.calls.count()).toEqual(1);
+      expect(Permission.isAllowedFor.calls.count()).toEqual(1);
     });
 
     it('checks permissions to update target', () => {
@@ -175,33 +175,33 @@ describe('Mappings', () => {
       let result = Mappings.allowedToMap(source, target);
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for.calls.count()).toEqual(2);
-      expect(Permission.is_allowed_for.calls.argsFor(0))
+      expect(Permission.isAllowedFor.calls.count()).toEqual(2);
+      expect(Permission.isAllowedFor.calls.argsFor(0))
         .toEqual(['update', source]);
-      expect(Permission.is_allowed_for.calls.argsFor(1))
+      expect(Permission.isAllowedFor.calls.argsFor(1))
         .toEqual(['update', target]);
     });
   });
 
   describe('allowedToCreate() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
     });
 
     it('checks that types are mappable', () => {
       let result = Mappings.allowedToCreate('SourceType', 'TargetType');
 
       expect(result).toBeFalsy();
-      expect(Permission.is_allowed_for).not.toHaveBeenCalled();
+      expect(Permission.isAllowedFor).not.toHaveBeenCalled();
     });
 
     it('checks permissions to update source', () => {
       let result = Mappings.allowedToCreate('Program', 'Audit');
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for)
+      expect(Permission.isAllowedFor)
         .toHaveBeenCalledWith('update', 'Program');
-      expect(Permission.is_allowed_for.calls.count()).toEqual(1);
+      expect(Permission.isAllowedFor.calls.count()).toEqual(1);
     });
 
     it('checks permissions to update target', () => {
@@ -210,33 +210,33 @@ describe('Mappings', () => {
       let result = Mappings.allowedToCreate(source, target);
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for.calls.count()).toEqual(2);
-      expect(Permission.is_allowed_for.calls.argsFor(0))
+      expect(Permission.isAllowedFor.calls.count()).toEqual(2);
+      expect(Permission.isAllowedFor.calls.argsFor(0))
         .toEqual(['update', source]);
-      expect(Permission.is_allowed_for.calls.argsFor(1))
+      expect(Permission.isAllowedFor.calls.argsFor(1))
         .toEqual(['update', target]);
     });
   });
 
   describe('allowedToUnmap() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
     });
 
     it('checks that types are unmappable', () => {
       let result = Mappings.allowedToUnmap('SourceType', 'TargetType');
 
       expect(result).toBeFalsy();
-      expect(Permission.is_allowed_for).not.toHaveBeenCalled();
+      expect(Permission.isAllowedFor).not.toHaveBeenCalled();
     });
 
     it('checks permissions to update source', () => {
       let result = Mappings.allowedToUnmap('Program', 'Document');
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for)
+      expect(Permission.isAllowedFor)
         .toHaveBeenCalledWith('update', 'Program');
-      expect(Permission.is_allowed_for.calls.count()).toEqual(1);
+      expect(Permission.isAllowedFor.calls.count()).toEqual(1);
     });
 
     it('checks permissions to update target', () => {
@@ -245,10 +245,10 @@ describe('Mappings', () => {
       let result = Mappings.allowedToUnmap(source, target);
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for.calls.count()).toEqual(2);
-      expect(Permission.is_allowed_for.calls.argsFor(0))
+      expect(Permission.isAllowedFor.calls.count()).toEqual(2);
+      expect(Permission.isAllowedFor.calls.argsFor(0))
         .toEqual(['update', source]);
-      expect(Permission.is_allowed_for.calls.argsFor(1))
+      expect(Permission.isAllowedFor.calls.argsFor(1))
         .toEqual(['update', target]);
     });
   });

--- a/src/ggrc-client/js/models/mappers/tests/unmappings_spec.js
+++ b/src/ggrc-client/js/models/mappers/tests/unmappings_spec.js
@@ -7,7 +7,7 @@ import loKeys from 'lodash/keys';
 import loDifference from 'lodash/difference';
 import canMap from 'can-map';
 import * as Mappings from '../mappings';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 
 describe('Mappings', function () {
   let allTypes = [];
@@ -127,23 +127,23 @@ describe('Mappings', function () {
 
   describe('allowedToUnmap() method', () => {
     beforeEach(() => {
-      spyOn(Permission, 'is_allowed_for').and.returnValue(true);
+      spyOn(Permission, 'isAllowedFor').and.returnValue(true);
     });
 
     it('checks that types are mappable', () => {
       let result = Mappings.allowedToUnmap('SourceType', 'TargetType');
 
       expect(result).toBeFalsy();
-      expect(Permission.is_allowed_for).not.toHaveBeenCalled();
+      expect(Permission.isAllowedFor).not.toHaveBeenCalled();
     });
 
     it('checks permissions to update source', () => {
       let result = Mappings.allowedToUnmap('DataAsset', 'AccessGroup');
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for)
+      expect(Permission.isAllowedFor)
         .toHaveBeenCalledWith('update', 'DataAsset');
-      expect(Permission.is_allowed_for.calls.count()).toEqual(1);
+      expect(Permission.isAllowedFor.calls.count()).toEqual(1);
     });
 
     it('checks permissions to update target', () => {
@@ -152,10 +152,10 @@ describe('Mappings', function () {
       let result = Mappings.allowedToUnmap(source, target);
 
       expect(result).toBeTruthy();
-      expect(Permission.is_allowed_for.calls.count()).toEqual(2);
-      expect(Permission.is_allowed_for.calls.argsFor(0))
+      expect(Permission.isAllowedFor.calls.count()).toEqual(2);
+      expect(Permission.isAllowedFor.calls.argsFor(0))
         .toEqual(['update', source]);
-      expect(Permission.is_allowed_for.calls.argsFor(1))
+      expect(Permission.isAllowedFor.calls.argsFor(1))
         .toEqual(['update', target]);
     });
   });

--- a/src/ggrc-client/js/models/mixins/access-control-list.js
+++ b/src/ggrc-client/js/models/mixins/access-control-list.js
@@ -6,7 +6,7 @@
 import Mixin from './mixin';
 import {isSnapshot} from '../../plugins/utils/snapshot-utils';
 
-export default Mixin.extend({
+export default class AccessControlList extends Mixin {
   /**
    * This method clears ACL
    * before it's filled with the data from server or backup.
@@ -39,13 +39,15 @@ export default Mixin.extend({
     }
 
     return resource;
-  },
-  'after:init': function () {
+  }
+
+  'after:init'() {
     if (!this.access_control_list) {
       this.attr('access_control_list', []);
     }
-  },
+  }
+
   'before:restore'() {
     this.cleanupAcl();
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/assessment-issue-tracker.js
+++ b/src/ggrc-client/js/models/mixins/assessment-issue-tracker.js
@@ -19,11 +19,11 @@ export default class AssessmentIssueTracker extends Mixin {
     issueTrackerUtils.cleanUpWarnings(this);
   }
 
-  after_refresh() {
+  afterRefresh() {
     this.initIssueTracker();
   }
 
-  after_save() {
+  afterSave() {
     issueTrackerUtils.checkWarnings(this);
   }
 

--- a/src/ggrc-client/js/models/mixins/auto-status-changeable.js
+++ b/src/ggrc-client/js/models/mixins/auto-status-changeable.js
@@ -12,7 +12,7 @@ import {confirm} from '../../plugins/utils/modals';
  *
  * @class Mixins.autoStatusChangeable
  */
-export default Mixin.extend({}, {
+export default class AutoStatusChangeable extends Mixin {
   /**
    * Display a confirmation dialog before starting to edit the instance.
    *
@@ -23,7 +23,7 @@ export default Mixin.extend({}, {
    * @return {Promise} A promise resolved/rejected if the user chooses to
    *   confirm/reject the dialog.
    */
-  confirmBeginEdit: function () {
+  confirmBeginEdit() {
     let STATUS_NOT_STARTED = 'Not Started';
     let STATUS_IN_PROGRESS = 'In Progress';
     let IGNORED_STATES = [STATUS_NOT_STARTED, STATUS_IN_PROGRESS];
@@ -51,5 +51,5 @@ export default Mixin.extend({}, {
     }
 
     return confirmation.promise();
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/ca-update.js
+++ b/src/ggrc-client/js/models/mixins/ca-update.js
@@ -6,11 +6,11 @@
 import Mixin from './mixin';
 
 export default class CaUpdate extends Mixin {
-  after_save() {
+  afterSave() {
     this.dispatch('readyForRender');
   }
 
-  info_pane_preload() {
+  infoPanePreload() {
     this.refresh();
   }
 }

--- a/src/ggrc-client/js/models/mixins/ca-update.js
+++ b/src/ggrc-client/js/models/mixins/ca-update.js
@@ -5,11 +5,12 @@
 
 import Mixin from './mixin';
 
-export default Mixin.extend({}, {
-  after_save: function () {
+export default class CaUpdate extends Mixin {
+  after_save() {
     this.dispatch('readyForRender');
-  },
-  info_pane_preload: function () {
+  }
+
+  info_pane_preload() {
     this.refresh();
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/changeable-externally.js
+++ b/src/ggrc-client/js/models/mixins/changeable-externally.js
@@ -5,8 +5,8 @@
 
 import Mixin from './mixin';
 
-export default Mixin.extend({
-  'after:init'() {
+export default class ChangeableExternally extends Mixin {
+  static 'after:init'() {
     this.isChangeableExternally = true;
-  },
-}, {});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/contactable.js
+++ b/src/ggrc-client/js/models/mixins/contactable.js
@@ -7,7 +7,7 @@ import Mixin from './mixin';
 import Stub from '../stub';
 
 export default class Contactable extends Mixin {
-  before_create() {
+  beforeCreate() {
     let person = {
       id: GGRC.current_user.id,
       type: 'Person',
@@ -17,7 +17,7 @@ export default class Contactable extends Mixin {
     }
   }
 
-  form_preload(newObjectForm) {
+  formPreload(newObjectForm) {
     let person = {
       id: GGRC.current_user.id,
       type: 'Person',

--- a/src/ggrc-client/js/models/mixins/contactable.js
+++ b/src/ggrc-client/js/models/mixins/contactable.js
@@ -6,18 +6,8 @@
 import Mixin from './mixin';
 import Stub from '../stub';
 
-export default Mixin.extend({
-  // NB : Because the attributes object
-  //  isn't automatically cloned into subclasses by CanJS (this is an intentional
-  //  exception), when subclassing a class that uses this mixin, be sure to pull in the
-  //  parent class's attributes using `Object.assign(this.attributes, <parent_class>.attributes);`
-  //  in the child class's static init function.
-  'extend:attributes': {
-    contact: Stub,
-    secondary_contact: Stub,
-  },
-}, {
-  before_create: function () {
+export default class Contactable extends Mixin {
+  before_create() {
     let person = {
       id: GGRC.current_user.id,
       type: 'Person',
@@ -25,8 +15,9 @@ export default Mixin.extend({
     if (!this.contact) {
       this.attr('contact', person);
     }
-  },
-  form_preload: function (newObjectForm) {
+  }
+
+  form_preload(newObjectForm) {
     let person = {
       id: GGRC.current_user.id,
       type: 'Person',
@@ -37,5 +28,15 @@ export default Mixin.extend({
     } else if (this.contact) {
       this.attr('_transient.contact', this.contact);
     }
-  },
-});
+  }
+}
+
+// NB : Because the attributes object
+//  isn't automatically cloned into subclasses by CanJS (this is an intentional
+//  exception), when subclassing a class that uses this mixin, be sure to pull in the
+//  parent class's attributes using `Object.assign(this.attributes, <parent_class>.attributes);`
+//  in the child class's static init function.
+Contactable['extend:attributes'] = {
+  contact: Stub,
+  secondary_contact: Stub,
+};

--- a/src/ggrc-client/js/models/mixins/is-overdue.js
+++ b/src/ggrc-client/js/models/mixins/is-overdue.js
@@ -9,15 +9,15 @@ import Mixin from './mixin';
 /**
  * Specific Model mixin to check overdue status
  */
-export default Mixin.extend({
-}, {
-  'after:init': function () {
+export default class IsOverdue extends Mixin {
+  'after:init'() {
     this.attr('isOverdue', this._isOverdue());
     this.bind('change', function () {
       this.attr('isOverdue', this._isOverdue());
     }.bind(this));
-  },
-  _isOverdue: function () {
+  }
+
+  _isOverdue() {
     let doneState = this.attr('is_verification_needed') ?
       'Verified' : 'Finished';
     let endDate = moment(
@@ -30,5 +30,5 @@ export default Mixin.extend({
       return false;
     }
     return isOverdue;
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/issue-tracker.js
+++ b/src/ggrc-client/js/models/mixins/issue-tracker.js
@@ -16,11 +16,11 @@ export default class IssueTracker extends Mixin {
     issueTrackerUtils.cleanUpWarnings(this);
   }
 
-  after_refresh() {
+  afterRefresh() {
     this.initIssueTracker();
   }
 
-  after_save() {
+  afterSave() {
     issueTrackerUtils.checkWarnings(this);
   }
 

--- a/src/ggrc-client/js/models/mixins/issue-tracker.js
+++ b/src/ggrc-client/js/models/mixins/issue-tracker.js
@@ -7,57 +7,66 @@ import canMap from 'can-map';
 import Mixin from './mixin';
 import * as issueTrackerUtils from '../../plugins/utils/issue-tracker-utils';
 
-export default Mixin.extend(
-  issueTrackerUtils.issueTrackerStaticFields,
-  {
-    'after:init'() {
-      this.initIssueTracker();
-    },
-    'before:refresh'() {
-      issueTrackerUtils.cleanUpWarnings(this);
-    },
-    after_refresh() {
-      this.initIssueTracker();
-    },
-    after_save() {
-      issueTrackerUtils.checkWarnings(this);
-    },
-    initIssueTracker() {
-      if (!GGRC.ISSUE_TRACKER_ENABLED) {
-        return;
-      }
+export default class IssueTracker extends Mixin {
+  'after:init'() {
+    this.initIssueTracker();
+  }
 
-      if (!this.issue_tracker) {
-        this.attr('issue_tracker', new canMap({}));
-      }
+  'before:refresh'() {
+    issueTrackerUtils.cleanUpWarnings(this);
+  }
 
-      let config = this.constructor.buildIssueTrackerConfig
-        ? this.constructor.buildIssueTrackerConfig(this)
-        : {enabled: false};
+  after_refresh() {
+    this.initIssueTracker();
+  }
 
-      issueTrackerUtils.initIssueTrackerObject(
-        this,
-        config,
-        true
-      );
-    },
-    setDefaultHotlistAndComponent() {
-      let config = this.constructor.buildIssueTrackerConfig ?
-        this.constructor.buildIssueTrackerConfig(this) :
-        {};
+  after_save() {
+    issueTrackerUtils.checkWarnings(this);
+  }
 
-      this.attr('issue_tracker').attr({
-        hotlist_id: config.hotlist_id,
-        component_id: config.component_id,
-      });
-    },
-    issueCreated() {
-      return GGRC.ISSUE_TRACKER_ENABLED
-        && issueTrackerUtils.isIssueCreated(this);
-    },
-    issueTrackerEnabled() {
-      return GGRC.ISSUE_TRACKER_ENABLED
-        && issueTrackerUtils.isIssueTrackerEnabled(this);
-    },
-  },
+  initIssueTracker() {
+    if (!GGRC.ISSUE_TRACKER_ENABLED) {
+      return;
+    }
+
+    if (!this.issue_tracker) {
+      this.attr('issue_tracker', new canMap({}));
+    }
+
+    let config = this.constructor.buildIssueTrackerConfig
+      ? this.constructor.buildIssueTrackerConfig(this)
+      : {enabled: false};
+
+    issueTrackerUtils.initIssueTrackerObject(
+      this,
+      config,
+      true
+    );
+  }
+
+  setDefaultHotlistAndComponent() { // eslint-disable-line id-length
+    let config = this.constructor.buildIssueTrackerConfig ?
+      this.constructor.buildIssueTrackerConfig(this) :
+      {};
+
+    this.attr('issue_tracker').attr({
+      hotlist_id: config.hotlist_id,
+      component_id: config.component_id,
+    });
+  }
+
+  issueCreated() {
+    return GGRC.ISSUE_TRACKER_ENABLED
+      && issueTrackerUtils.isIssueCreated(this);
+  }
+
+  issueTrackerEnabled() {
+    return GGRC.ISSUE_TRACKER_ENABLED
+      && issueTrackerUtils.isIssueTrackerEnabled(this);
+  }
+}
+
+Object.assign(
+  IssueTracker,
+  issueTrackerUtils.issueTrackerStaticFields
 );

--- a/src/ggrc-client/js/models/mixins/mega-object.js
+++ b/src/ggrc-client/js/models/mixins/mega-object.js
@@ -9,9 +9,9 @@ import Mixin from './mixin';
   Mega object can be mapped to the same object type,
   e.g. map Program to Mega Program
 */
-export default Mixin.extend({
-  isMegaObject: true,
-  'after:init'() {
+
+export default class MegaObject extends Mixin {
+  static 'after:init'() {
     this.tree_view_options.mega_attr_list = [{
       attr_title: 'Map as',
       attr_name: 'map_as',
@@ -20,5 +20,7 @@ export default Mixin.extend({
       disable_sorting: true,
       mandatory: true,
     }];
-  },
-}, {});
+  }
+}
+
+MegaObject.isMegaObject = true;

--- a/src/ggrc-client/js/models/mixins/mixin.js
+++ b/src/ggrc-client/js/models/mixins/mixin.js
@@ -5,29 +5,31 @@
 
 import loIncludes from 'lodash/includes';
 import loIsFunction from 'lodash/isFunction';
-import loForEach from 'lodash/forEach';
-import canConstruct from 'can-construct';
 
-const Mixin = canConstruct.extend({
-  newInstance: function () {
+export default class Mixin {
+  constructor() {
     throw new Error('Mixins cannot be directly instantiated');
-  },
-  add_to: function (cls) {
+  }
+
+  static add_to(cls) {
     if (this === Mixin) {
       throw new Error('Must only add a subclass of Mixin to an object,' +
         ' not Mixin itself');
     }
     function setupFns(obj) {
       return function (fn, key) {
-        let blockedKeys = ['fullName', 'defaults', '_super', 'constructor'];
-        let aspect = ~key.indexOf(':') ?
-          key.substr(0, key.indexOf(':')) :
-          'after';
-        let oldfn;
+        let blockedKeys = ['constructor', 'length', 'name', 'prototype'];
+        let aspect;
+        let index = key.indexOf(':');
+        if (index !== -1) {
+          aspect = key.substr(0, index);
+          key = key.substr(index + 1);
+        } else {
+          aspect = 'after';
+        }
 
-        key = ~key.indexOf(':') ? key.substr(key.indexOf(':') + 1) : key;
-        if (fn !== Mixin[key] && !blockedKeys.includes(key)) {
-          oldfn = obj[key];
+        if (!blockedKeys.includes(key)) {
+          let oldfn = obj[key];
           // TODO support other ways of adding functions.
           //  E.g. "override" (doesn't call super fn at all)
           //       "sub" (sets this._super for mixin function)
@@ -68,12 +70,12 @@ const Mixin = canConstruct.extend({
     if (!loIncludes(cls._mixins, this)) {
       cls._mixins = cls._mixins || [];
       cls._mixins.push(this);
-      Object.keys(this).forEach(function (key) {
+      Object.getOwnPropertyNames(this).forEach((key) => {
         setupFns(cls)(this[key], key);
-      }.bind(this));
-      loForEach(this.prototype, setupFns(cls.prototype));
+      });
+      Object.getOwnPropertyNames(this.prototype).forEach((key) => {
+        setupFns(cls.prototype)(this.prototype[key], key);
+      });
     }
-  },
-}, {});
-
-export default Mixin;
+  }
+}

--- a/src/ggrc-client/js/models/mixins/mixin.js
+++ b/src/ggrc-client/js/models/mixins/mixin.js
@@ -11,7 +11,7 @@ export default class Mixin {
     throw new Error('Mixins cannot be directly instantiated');
   }
 
-  static add_to(cls) {
+  static addTo(cls) {
     if (this === Mixin) {
       throw new Error('Must only add a subclass of Mixin to an object,' +
         ' not Mixin itself');
@@ -70,9 +70,11 @@ export default class Mixin {
     if (!loIncludes(cls._mixins, this)) {
       cls._mixins = cls._mixins || [];
       cls._mixins.push(this);
+      // static properties
       Object.getOwnPropertyNames(this).forEach((key) => {
         setupFns(cls)(this[key], key);
       });
+      // prototype properties
       Object.getOwnPropertyNames(this.prototype).forEach((key) => {
         setupFns(cls.prototype)(this.prototype[key], key);
       });

--- a/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
@@ -5,7 +5,12 @@
 
 import Mixin from '../mixin';
 
-export default Mixin.extend({
-  send_by_default: true,
-  recipients: 'Admin,Primary Contacts,Secondary Contacts',
-});
+export default class BaseNotifications extends Mixin {
+  get send_by_default() {
+    return true;
+  }
+
+  get recipients() {
+    return 'Admin,Primary Contacts,Secondary Contacts';
+  }
+}

--- a/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
@@ -6,11 +6,9 @@
 import Mixin from '../mixin';
 
 export default class BaseNotifications extends Mixin {
-  get send_by_default() { // eslint-disable-line camelcase
-    return true;
-  }
-
-  get recipients() {
-    return 'Admin,Primary Contacts,Secondary Contacts';
-  }
 }
+
+Object.assign(BaseNotifications.prototype, {
+  send_by_default: true,
+  recipients: 'Admin,Primary Contacts,Secondary Contacts',
+});

--- a/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/base-notifications.js
@@ -6,7 +6,7 @@
 import Mixin from '../mixin';
 
 export default class BaseNotifications extends Mixin {
-  get send_by_default() {
+  get send_by_default() { // eslint-disable-line camelcase
     return true;
   }
 

--- a/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
@@ -6,11 +6,9 @@
 import Mixin from '../mixin';
 
 export default class CycleTaskNotifications extends Mixin {
-  get send_by_default() { // eslint-disable-line camelcase
-    return true;
-  }
-
-  get recipients() {
-    return 'Task Assignees,Task Secondary Assignees';
-  }
 }
+
+Object.assign(CycleTaskNotifications.prototype, {
+  send_by_default: true,
+  recipients: 'Task Assignees,Task Secondary Assignees',
+});

--- a/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
@@ -6,7 +6,7 @@
 import Mixin from '../mixin';
 
 export default class CycleTaskNotifications extends Mixin {
-  get send_by_default() {
+  get send_by_default() { // eslint-disable-line camelcase
     return true;
   }
 

--- a/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/cycle-task-notifications.js
@@ -5,7 +5,12 @@
 
 import Mixin from '../mixin';
 
-export default Mixin.extend({
-  send_by_default: true,
-  recipients: 'Task Assignees,Task Secondary Assignees',
-});
+export default class CycleTaskNotifications extends Mixin {
+  get send_by_default() {
+    return true;
+  }
+
+  get recipients() {
+    return 'Task Assignees,Task Secondary Assignees';
+  }
+}

--- a/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
@@ -5,8 +5,13 @@
 
 import Mixin from '../mixin';
 
-export default Mixin.extend({
-  send_by_default: true,
-  recipients: 'Program Managers,Program Editors,Program Readers,' +
-  'Primary Contacts,Secondary Contacts',
-});
+export default class ProgramNotifications extends Mixin {
+  get send_by_default() {
+    return true;
+  }
+
+  get recipients() {
+    return 'Program Managers,Program Editors,Program Readers,' +
+      'Primary Contacts,Secondary Contacts';
+  }
+}

--- a/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
@@ -6,7 +6,7 @@
 import Mixin from '../mixin';
 
 export default class ProgramNotifications extends Mixin {
-  get send_by_default() {
+  get send_by_default() { // eslint-disable-line camelcase
     return true;
   }
 

--- a/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/program-notifications.js
@@ -6,12 +6,10 @@
 import Mixin from '../mixin';
 
 export default class ProgramNotifications extends Mixin {
-  get send_by_default() { // eslint-disable-line camelcase
-    return true;
-  }
-
-  get recipients() {
-    return 'Program Managers,Program Editors,Program Readers,' +
-      'Primary Contacts,Secondary Contacts';
-  }
 }
+
+Object.assign(ProgramNotifications.prototype, {
+  send_by_default: true,
+  recipients: 'Program Managers,Program Editors,Program Readers,' +
+    'Primary Contacts,Secondary Contacts',
+});

--- a/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
@@ -5,10 +5,16 @@
 
 import Mixin from '../mixin';
 
-export default Mixin.extend({
-  send_by_default: true,
-  recipients: 'Admin,Assignee,Verifier,Compliance Contacts,' +
-  'Primary Contacts,Secondary Contacts,Product Managers,' +
-  'Technical Leads,Technical / Program Managers,Legal Counsels,System Owners,' +
-  'Line of Defense One Contacts,Vice Presidents',
-});
+export default class ScopeObjectNotifications extends Mixin {
+  get send_by_default() {
+    return true;
+  }
+
+  get recipients() {
+    return 'Admin,Assignee,Verifier,Compliance Contacts,' +
+    'Primary Contacts,Secondary Contacts,Product Managers,' +
+    'Technical Leads,Technical / ' +
+    'Program Managers,Legal Counsels,System Owners,' +
+    'Line of Defense One Contacts,Vice Presidents';
+  }
+}

--- a/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
@@ -6,7 +6,7 @@
 import Mixin from '../mixin';
 
 export default class ScopeObjectNotifications extends Mixin {
-  get send_by_default() {
+  get send_by_default() { // eslint-disable-line camelcase
     return true;
   }
 

--- a/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
+++ b/src/ggrc-client/js/models/mixins/notifications/scope-object-notifications.js
@@ -6,15 +6,14 @@
 import Mixin from '../mixin';
 
 export default class ScopeObjectNotifications extends Mixin {
-  get send_by_default() { // eslint-disable-line camelcase
-    return true;
-  }
+}
 
-  get recipients() {
-    return 'Admin,Assignee,Verifier,Compliance Contacts,' +
+
+Object.assign(ScopeObjectNotifications.prototype, {
+  send_by_default: true,
+  recipients: 'Admin,Assignee,Verifier,Compliance Contacts,' +
     'Primary Contacts,Secondary Contacts,Product Managers,' +
     'Technical Leads,Technical / ' +
     'Program Managers,Legal Counsels,System Owners,' +
-    'Line of Defense One Contacts,Vice Presidents';
-  }
-}
+    'Line of Defense One Contacts,Vice Presidents',
+});

--- a/src/ggrc-client/js/models/mixins/proposable.js
+++ b/src/ggrc-client/js/models/mixins/proposable.js
@@ -7,7 +7,7 @@ import Mixin from './mixin';
 import {REFRESH_PROPOSAL_DIFF} from '../../events/eventTypes';
 
 export default class Proposable extends Mixin {
-  after_update() {
+  afterUpdate() {
     this.dispatch({
       ...REFRESH_PROPOSAL_DIFF,
     });

--- a/src/ggrc-client/js/models/mixins/proposable.js
+++ b/src/ggrc-client/js/models/mixins/proposable.js
@@ -6,12 +6,12 @@
 import Mixin from './mixin';
 import {REFRESH_PROPOSAL_DIFF} from '../../events/eventTypes';
 
-export default Mixin.extend({
-  isProposable: true,
-}, {
+export default class Proposable extends Mixin {
   after_update() {
     this.dispatch({
       ...REFRESH_PROPOSAL_DIFF,
     });
-  },
-});
+  }
+}
+
+Proposable.isProposable = true;

--- a/src/ggrc-client/js/models/mixins/questionnaire.js
+++ b/src/ggrc-client/js/models/mixins/questionnaire.js
@@ -5,8 +5,8 @@
 
 import Mixin from './mixin';
 
-export default Mixin.extend({
-  'after:init'() {
+export default class Questionnaire extends Mixin {
+  static 'after:init'() {
     if (GGRC.GGRC_Q_INTEGRATION_URL) {
       const attrTitle = 'Questionnaire';
       const attrList = this.tree_view_options.attr_list;
@@ -25,5 +25,5 @@ export default Mixin.extend({
       });
       this.isQuestionnaireable = true;
     }
-  },
-}, {});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/refetch-hash.js
+++ b/src/ggrc-client/js/models/mixins/refetch-hash.js
@@ -8,8 +8,8 @@ import Mixin from './mixin';
 /**
  * A mixin to generate hash with refetch param.
  */
-export default Mixin.extend({
-  getHashFragment: function () {
+export default class RefetchHash extends Mixin {
+  getHashFragment() {
     let widgetName = this.constructor.table_singular;
     if (window.location.hash
       .startsWith(['#', widgetName].join(''))) {
@@ -18,5 +18,5 @@ export default Mixin.extend({
 
     return [widgetName,
       '&refetch=true'].join('');
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/related-assessments-loader.js
+++ b/src/ggrc-client/js/models/mixins/related-assessments-loader.js
@@ -7,7 +7,7 @@ import Mixin from './mixin';
 import {isSnapshot} from '../../plugins/utils/snapshot-utils';
 import {ggrcGet} from '../../plugins/ajax_extensions';
 
-export default Mixin.extend({}, {
+export default class RelatedAssessmentsLoader extends Mixin {
   /**
    *
    * @param {Array} limit - Limit of loaded numbers
@@ -32,5 +32,5 @@ export default Mixin.extend({}, {
       params.order_by = orderAsString;
     }
     return ggrcGet('/api/related_assessments', params);
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/tests/access-control-list_spec.js
+++ b/src/ggrc-client/js/models/mixins/tests/access-control-list_spec.js
@@ -8,7 +8,7 @@ import {
 } from '../../../../js_specs/spec_helpers';
 import * as snapshotUtils from '../../../plugins/utils/snapshot-utils';
 import Cacheable from '../../cacheable';
-import accessControlList from '../../../models/mixins/access-control-list';
+import AccessControlList from '../../../models/mixins/access-control-list';
 
 describe('accessControlList mixin', () => {
   describe('"cleanupAcl" method: ', () => {
@@ -26,7 +26,7 @@ describe('accessControlList mixin', () => {
         model: Cacheable,
         staticProps: {
           mixins: [
-            accessControlList,
+            AccessControlList,
           ],
         },
       });

--- a/src/ggrc-client/js/models/mixins/unique-title.js
+++ b/src/ggrc-client/js/models/mixins/unique-title.js
@@ -5,20 +5,22 @@
 
 import Mixin from './mixin';
 
-export default Mixin.extend({}, {
-  save_error: function (val) {
+export default class UniqueTitle extends Mixin {
+  save_error(val) {
     if (/title values must be unique\.$/.test(val)) {
       this.attr('_transient_title', val);
     }
-  },
-  after_save: function () {
+  }
+
+  after_save() {
     this.removeAttr('_transient_title');
-  },
-  'before:attr': function (key, val) {
+  }
+
+  'before:attr'(key, val) {
     if (key === 'title' &&
       arguments.length > 1 &&
       this._transient) {
       this.attr('_transient_title', null);
     }
-  },
-});
+  }
+}

--- a/src/ggrc-client/js/models/mixins/unique-title.js
+++ b/src/ggrc-client/js/models/mixins/unique-title.js
@@ -6,13 +6,13 @@
 import Mixin from './mixin';
 
 export default class UniqueTitle extends Mixin {
-  save_error(val) {
+  saveError(val) {
     if (/title values must be unique\.$/.test(val)) {
       this.attr('_transient_title', val);
     }
   }
 
-  after_save() {
+  afterSave() {
     this.removeAttr('_transient_title');
   }
 

--- a/src/ggrc-client/js/models/refresh_queue.js
+++ b/src/ggrc-client/js/models/refresh_queue.js
@@ -6,26 +6,20 @@
 import {filteredMap} from '../plugins/ggrc_utils';
 import loForEach from 'lodash/forEach';
 import canModel from 'can-model';
-import canConstruct from 'can-construct';
 import {reify} from '../plugins/utils/reify-utils';
 import allModels from './all-models';
 
-/*  RefreshQueue
- *
- *  enqueue(objs, force=false) -> queue or null
- *  trigger() -> Deferred
- */
-
-const ModelRefreshQueue = canConstruct.extend({}, {
-  init: function (model) {
+class ModelRefreshQueue {
+  constructor(model) {
     this.model = model;
     this.ids = [];
     this.deferred = new $.Deferred();
     this.triggered = false;
     this.completed = false;
     this.updated_at = Date.now();
-  },
-  enqueue: function (id) {
+  }
+
+  enqueue(id) {
     if (this.triggered) {
       return null;
     }
@@ -34,17 +28,17 @@ const ModelRefreshQueue = canConstruct.extend({}, {
       this.updated_at = Date.now();
     }
     return this;
-  },
-  trigger: function () {
-    let self = this;
+  }
+
+  trigger() {
     if (!this.triggered) {
       this.triggered = true;
       if (this.ids.length && this.model) {
-        this.model.findAll({id__in: this.ids.join(',')}).then(function () {
-          self.completed = true;
-          self.deferred.resolve();
-        }, function () {
-          self.deferred.reject(...arguments);
+        this.model.findAll({id__in: this.ids.join(',')}).then(() => {
+          this.completed = true;
+          this.deferred.resolve();
+        }, () => {
+          this.deferred.reject(...arguments);
         });
       } else {
         this.completed = true;
@@ -52,38 +46,40 @@ const ModelRefreshQueue = canConstruct.extend({}, {
       }
     }
     return this.deferred;
-  },
-  trigger_with_debounce: function (delay, manager) {
+  }
+
+  triggerWithDebounce(delay, manager) {
     let msToWait = (delay || 0) + this.updated_at - Date.now();
 
     if (!this.triggered) {
       if (msToWait < 0 &&
-        (!manager || manager.triggered_queues().length < 6)) {
+        (!manager || manager.triggeredQueues().length < 6)) {
         this.trigger();
       } else {
         setTimeout(
-          () => this.trigger_with_debounce(delay, manager), msToWait);
+          () => this.triggerWithDebounce(delay, manager), msToWait);
       }
     }
 
     return this.deferred;
-  },
-});
+  }
+}
 
-const RefreshQueueManager = canConstruct.extend({}, {
-  init: function () {
+class RefreshQueueManager {
+  constructor() {
     this.null_queue = new ModelRefreshQueue(null);
     this.queues = [];
-  },
-  triggered_queues: function () {
+  }
+
+  triggeredQueues() {
     return filteredMap(this.queues, (queue) => {
       if (queue.triggered) {
         return queue;
       }
     });
-  },
-  enqueue: function (obj, force) {
-    let self = this;
+  }
+
+  enqueue(obj, force) {
     let model = obj.constructor;
     let modelName = model.model_singular;
     let foundQueue = null;
@@ -101,7 +97,7 @@ const RefreshQueueManager = canConstruct.extend({}, {
 
     if (!force) {
       // Check if the ID is already contained in another queue
-      this.queues.forEach(function (queue) {
+      this.queues.forEach((queue) => {
         if (!foundQueue &&
           queue.model === model && queue.ids.indexOf(id) > -1) {
           foundQueue = queue;
@@ -110,7 +106,7 @@ const RefreshQueueManager = canConstruct.extend({}, {
     }
 
     if (!foundQueue) {
-      this.queues.forEach(function (queue) {
+      this.queues.forEach((queue) => {
         if (!foundQueue &&
           queue.model === model &&
           !queue.triggered && queue.ids.length < 150) {
@@ -122,84 +118,36 @@ const RefreshQueueManager = canConstruct.extend({}, {
         foundQueue = new ModelRefreshQueue(model);
         this.queues.push(foundQueue);
         foundQueue.enqueue(id);
-        foundQueue.deferred.done(function () {
-          let index = self.queues.indexOf(foundQueue);
+        foundQueue.deferred.done(() => {
+          let index = this.queues.indexOf(foundQueue);
           if (index > -1) {
-            self.queues.splice(index, 1);
+            this.queues.splice(index, 1);
           }
         });
       }
     }
 
     return foundQueue;
-  },
-});
+  }
+}
 
-const RefreshQueue = canConstruct.extend({
-  refresh_queue_manager: new RefreshQueueManager(),
-  refresh_all: function (instance, props, force) {
-    let dfd = new $.Deferred();
+const refreshQueueManager = new RefreshQueueManager();
 
-    refreshAll(instance, props, dfd);
-    return dfd;
-
-    // Helper function called recursively for each property
-    function refreshAll(instance, props, dfd) {
-      let prop = props[0];
-      let nextProps = props.slice(1);
-      let next = instance[prop];
-      let refreshQueue = new RefreshQueue();
-      let dfds = [];
-      let deferred;
-
-      if (next) {
-        refreshQueue.enqueue(next, force);
-        deferred = refreshQueue.trigger();
-      }
-
-      if (deferred) {
-        deferred.then(function (refreshedItems) {
-          if (nextProps.length) {
-            loForEach(refreshedItems, function (item) {
-              let df = new $.Deferred();
-              refreshAll(item, nextProps, df);
-              dfds.push(df);
-            });
-            // Resolve the original deferred only when all list deferreds
-            //   have been resolved
-            $.when(...dfds).then(function (items) {
-              dfd.resolve(items);
-            }, function () {
-              dfd.reject.apply(this, arguments);
-            });
-            return;
-          }
-          // All items were refreshed, resolve the deferred
-          if (next.push || next.list) {
-            // Last refreshed property was a list
-            dfd.resolve(refreshedItems);
-          }
-          // Last refreshed property was a single instance, return it as such
-          dfd.resolve(refreshedItems[0]);
-        }, function () {
-          dfd.reject.apply(this, arguments);
-        });
-      } else {
-        console.warn('refresh_all failed at', prop);
-      }
-    }
-  },
-}, {
-  init: function () {
+/*  RefreshQueue
+ *
+ *  enqueue(objs, force=false) -> queue or null
+ *  trigger() -> Deferred
+ */
+class RefreshQueue {
+  constructor() {
     this.objects = [];
     this.queues = [];
     this.deferred = new $.Deferred();
     this.triggered = false;
     this.completed = false;
+  }
 
-    return this;
-  },
-  enqueue: function (objs, force) {
+  enqueue(objs, force) {
     let queue;
     if (!objs) {
       return;
@@ -216,15 +164,15 @@ const RefreshQueue = canConstruct.extend({
 
     this.objects.push(objs);
     if (force || !objs.selfLink) {
-      queue = this.constructor.refresh_queue_manager.enqueue(objs, force);
+      queue = refreshQueueManager.enqueue(objs, force);
       if (this.queues.indexOf(queue) === -1) {
         this.queues.push(queue);
       }
     }
     return this;
-  },
-  trigger: function (delay) {
-    let self = this;
+  }
+
+  trigger(delay) {
     let deferreds = [];
 
     if (!delay) {
@@ -232,24 +180,79 @@ const RefreshQueue = canConstruct.extend({
     }
 
     this.triggered = true;
-    this.queues.forEach(function (queue) {
+    this.queues.forEach((queue) => {
       deferreds.push(
-        queue.trigger_with_debounce(delay,
-          self.constructor.refresh_queue_manager));
+        queue.triggerWithDebounce(delay, refreshQueueManager));
     });
 
     if (deferreds.length) {
-      $.when(...deferreds).then(function () {
-        self.deferred.resolve(filteredMap(self.objects, (obj) => reify(obj)));
-      }, function () {
-        self.deferred.reject(...arguments);
+      $.when(...deferreds).then(() => {
+        this.deferred.resolve(filteredMap(this.objects, (obj) => reify(obj)));
+      }, () => {
+        this.deferred.reject(...arguments);
       });
     } else {
       return this.deferred.resolve(this.objects);
     }
 
     return this.deferred;
-  },
-});
+  }
+}
+
+function refreshAll(instance, props, force) {
+  let dfd = new $.Deferred();
+
+  refreshAllProperties(instance, props, dfd);
+  return dfd;
+
+  // Helper function called recursively for each property
+  function refreshAllProperties(instance, props, dfd) {
+    let prop = props[0];
+    let nextProps = props.slice(1);
+    let next = instance[prop];
+    let refreshQueue = new RefreshQueue();
+    let dfds = [];
+    let deferred;
+
+    if (next) {
+      refreshQueue.enqueue(next, force);
+      deferred = refreshQueue.trigger();
+    }
+
+    if (deferred) {
+      deferred.then(function (refreshedItems) {
+        if (nextProps.length) {
+          loForEach(refreshedItems, function (item) {
+            let df = new $.Deferred();
+            refreshAllProperties(item, nextProps, df);
+            dfds.push(df);
+          });
+          // Resolve the original deferred only when all list deferreds
+          //   have been resolved
+          $.when(...dfds).then(function (items) {
+            dfd.resolve(items);
+          }, function () {
+            dfd.reject.apply(this, arguments);
+          });
+          return;
+        }
+        // All items were refreshed, resolve the deferred
+        if (next.push || next.list) {
+          // Last refreshed property was a list
+          dfd.resolve(refreshedItems);
+        }
+        // Last refreshed property was a single instance, return it as such
+        dfd.resolve(refreshedItems[0]);
+      }, function () {
+        dfd.reject.apply(this, arguments);
+      });
+    } else {
+      console.warn('refreshAll failed at', prop);
+    }
+  }
+}
 
 export default RefreshQueue;
+export {
+  refreshAll,
+};

--- a/src/ggrc-client/js/models/refresh_queue.js
+++ b/src/ggrc-client/js/models/refresh_queue.js
@@ -219,7 +219,7 @@ function refreshAll(instance, props, force) {
     }
 
     if (deferred) {
-      deferred.then(function (refreshedItems) {
+      deferred.then((refreshedItems) => {
         if (nextProps.length) {
           loForEach(refreshedItems, function (item) {
             let df = new $.Deferred();
@@ -228,10 +228,10 @@ function refreshAll(instance, props, force) {
           });
           // Resolve the original deferred only when all list deferreds
           //   have been resolved
-          $.when(...dfds).then(function (items) {
+          $.when(...dfds).then((items) => {
             dfd.resolve(items);
-          }, function () {
-            dfd.reject.apply(this, arguments);
+          }, () => {
+            dfd.reject(...arguments);
           });
           return;
         }
@@ -242,8 +242,8 @@ function refreshAll(instance, props, force) {
         }
         // Last refreshed property was a single instance, return it as such
         dfd.resolve(refreshedItems[0]);
-      }, function () {
-        dfd.reject.apply(this, arguments);
+      }, () => {
+        dfd.reject(...arguments);
       });
     } else {
       console.warn('refreshAll failed at', prop);

--- a/src/ggrc-client/js/models/refresh_queue.js
+++ b/src/ggrc-client/js/models/refresh_queue.js
@@ -67,7 +67,6 @@ class ModelRefreshQueue {
 
 class RefreshQueueManager {
   constructor() {
-    this.null_queue = new ModelRefreshQueue(null);
     this.queues = [];
   }
 

--- a/src/ggrc-client/js/models/save_queue.js
+++ b/src/ggrc-client/js/models/save_queue.js
@@ -7,7 +7,6 @@ import loIsNumber from 'lodash/isNumber';
 import loForEach from 'lodash/forEach';
 import loMap from 'lodash/map';
 import {ggrcAjax} from '../plugins/ajax_extensions';
-import canConstruct from 'can-construct';
 import tracker from '../tracker';
 
 /*  SaveQueue
@@ -24,166 +23,162 @@ import tracker from '../tracker';
   *
   *  enqueue(obj: Cacheable, save_args) -> null
   */
-export default canConstruct.extend({
+const DELAY = 100; // Number of ms to wait before the first batch is fired
+const BATCH = GGRC.config.MAX_INSTANCES || 3; // Maximum number of POST/PUT requests at any given time
+const BATCH_SIZE = 1000;
+const _queue = [];
+const _buckets = {};
+let _timeout = null;
 
-  DELAY: 100, // Number of ms to wait before the first batch is fired
-  BATCH: GGRC.config.MAX_INSTANCES || 3, // Maximum number of POST/PUT requests at any given time
-  BATCH_SIZE: 1000,
-  _queue: [],
-  _buckets: {},
-  _timeout: null,
-
-  _enqueue_bucket: function (bucket) {
-    let that = this;
-    return function () {
-      let size = bucket.background ? bucket.objs.length : that.BATCH_SIZE;
-      let objs = bucket.objs.splice(0, size);
-      let body = loMap(objs, function (obj) {
-        let list = {};
-        list[bucket.type] = obj.serialize();
-        return list;
-      });
-      let modelType = objs[0].constructor.model_singular;
-      let stopFn = tracker.start(modelType,
-        tracker.USER_JOURNEY_KEYS.API,
-        tracker.USER_ACTIONS.CREATE_OBJECT(objs.length));
-      let dfd = ggrcAjax({
-        type: 'POST',
-        url: '/api/' + bucket.plural,
-        data: body,
-        beforeSend: function (xhr) {
-          if (bucket.background) {
-            xhr.setRequestHeader('X-GGRC-BackgroundTask', 'true');
-          }
-        },
-      }).promise();
-      dfd.always(function (data, type) {
-        if (type === 'error') {
-          stopFn(true);
-          objs.forEach(function (obj) {
-            obj._dfd.reject(data);
-          });
+function _enqueueBucket(bucket) {
+  return function () {
+    let size = bucket.background ? bucket.objs.length : BATCH_SIZE;
+    let objs = bucket.objs.splice(0, size);
+    let body = loMap(objs, function (obj) {
+      let list = {};
+      list[bucket.type] = obj.serialize();
+      return list;
+    });
+    let modelType = objs[0].constructor.model_singular;
+    let stopFn = tracker.start(modelType,
+      tracker.USER_JOURNEY_KEYS.API,
+      tracker.USER_ACTIONS.CREATE_OBJECT(objs.length));
+    let dfd = ggrcAjax({
+      type: 'POST',
+      url: '/api/' + bucket.plural,
+      data: body,
+      beforeSend: function (xhr) {
+        if (bucket.background) {
+          xhr.setRequestHeader('X-GGRC-BackgroundTask', 'true');
         }
-        if ('background_task' in data) {
-          stopFn(true);
-          let task = data.background_task;
-          // Resolve all the dfds with the task
-          objs.forEach(function (obj) {
-            obj._dfd.resolve(task);
-          });
-        }
+      },
+    }).promise();
+    dfd.always(function (data, type) {
+      if (type === 'error') {
+        stopFn(true);
+        objs.forEach(function (obj) {
+          obj._dfd.reject(data);
+        });
+      }
+      if ('background_task' in data) {
+        stopFn(true);
+        let task = data.background_task;
+        // Resolve all the dfds with the task
+        objs.forEach(function (obj) {
+          obj._dfd.resolve(task);
+        });
+      }
 
-        stopFn();
+      stopFn();
 
-        // Push the response to a queue for later processing.
-        bucket.save_responses.push([objs, data]);
-      }).always(function () {
-        if (bucket.objs.length) {
-          that._step(that._enqueue_bucket(bucket));
-        } else {
-          // Process all of the batches of save responses.
-          that._process_save_responses(bucket);
-          bucket.in_flight = false;
-        }
-      });
-
-      return dfd;
-    };
-  },
-
-  _process_save_responses: function (bucket) {
-    bucket.save_responses.forEach(function (resp) {
-      let objs = resp[0];
-      let data = resp[1];
-      let cb = function (single) {
-        return function () {
-          this.created(single[1][bucket.type]);
-          return $.Deferred().resolve(this);
-        };
-      };
-      loForEach(objs, function (obj, idx) {
-        let single = data[idx];
-        // Add extra check to avoid possible exceptions
-        single = Array.isArray(single) ? single : false;
-        if (single && single[0] >= 200 && single[0] < 300) {
-          obj._save(cb(single));
-        } else {
-          obj._dfd.reject(obj, single);
-        }
-      });
+      // Push the response to a queue for later processing.
+      bucket.save_responses.push([objs, data]);
+    }).always(function () {
+      if (bucket.objs.length) {
+        _step(_enqueueBucket(bucket));
+      } else {
+        // Process all of the batches of save responses.
+        _processSaveResponses(bucket);
+        bucket.in_flight = false;
+      }
     });
 
-    bucket.save_responses.length = 0;
-  },
+    return dfd;
+  };
+}
 
-  _step: function (elem) {
-    this._queue.push(elem);
-    if (loIsNumber(this._timeout)) {
-      clearTimeout(this._timeout);
-    }
-    this._timeout = setTimeout(() => {
-      new this(this._queue.splice(0, this._queue.length));
-    }, this.DELAY);
-  },
-
-  enqueue: function (obj, _saveSuper) {
-    let type;
-    let bucket;
-    let bucketName;
-    let plural;
-    let elem = function () {
-      let stopFn = tracker
-        .start(obj.constructor.model_singular,
-          tracker.USER_JOURNEY_KEYS.API,
-          tracker.USER_ACTIONS.UPDATE_OBJECT);
-      return obj._save(_saveSuper).then((objects) => {
-        stopFn();
-        return objects;
-      }, stopFn.bind(null, true));
+function _processSaveResponses(bucket) {
+  bucket.save_responses.forEach(function (resp) {
+    let objs = resp[0];
+    let data = resp[1];
+    let cb = function (single) {
+      return function () {
+        this.created(single[1][bucket.type]);
+        return $.Deferred().resolve(this);
+      };
     };
-    if (obj.isNew()) {
-      type = obj.constructor.table_singular;
-      bucketName = type + (obj.run_in_background ? '_bg' : '');
-      bucket = this._buckets[bucketName];
+    loForEach(objs, function (obj, idx) {
+      let single = data[idx];
+      // Add extra check to avoid possible exceptions
+      single = Array.isArray(single) ? single : false;
+      if (single && single[0] >= 200 && single[0] < 300) {
+        obj._save(cb(single));
+      } else {
+        obj._dfd.reject(obj, single);
+      }
+    });
+  });
 
-      if (bucket === undefined) {
-        plural = obj.constructor.table_plural;
-        bucket = {
-          objs: [],
-          type: type,
-          plural: plural,
-          background: obj.run_in_background,
-          // List of batch request responses that are yet to be processed.
-          save_responses: [],
-          in_flight: false, // is there a "thread" running for this bucket
-        };
-        this._buckets[bucketName] = bucket;
-      }
-      bucket.objs.push(obj);
-      if (bucket.in_flight) {
-        return;
-      }
-      elem = this._enqueue_bucket(bucket);
-      bucket.in_flight = true;
+  bucket.save_responses.length = 0;
+}
+
+function _step(elem) {
+  _queue.push(elem);
+  if (loIsNumber(_timeout)) {
+    clearTimeout(_timeout);
+  }
+  _timeout = setTimeout(() => {
+    _resolve(_queue.splice(0, _queue.length));
+  }, DELAY);
+}
+
+function _resolve(queue) {
+  let objs;
+  if (!queue.length) {
+    // Finished
+    return;
+  }
+  objs = queue.splice(0, BATCH);
+  $.when(...objs.map((fn) => {
+    return fn();
+  }))
+    .always(_resolve.bind(null, queue)); // Move on to the next one
+}
+
+function enqueue(obj, _saveSuper) {
+  let type;
+  let bucket;
+  let bucketName;
+  let plural;
+  let elem = function () {
+    let stopFn = tracker
+      .start(obj.constructor.model_singular,
+        tracker.USER_JOURNEY_KEYS.API,
+        tracker.USER_ACTIONS.UPDATE_OBJECT);
+    return obj._save(_saveSuper).then((objects) => {
+      stopFn();
+      return objects;
+    }, stopFn.bind(null, true));
+  };
+  if (obj.isNew()) {
+    type = obj.constructor.table_singular;
+    bucketName = type + (obj.run_in_background ? '_bg' : '');
+    bucket = _buckets[bucketName];
+
+    if (bucket === undefined) {
+      plural = obj.constructor.table_plural;
+      bucket = {
+        objs: [],
+        type: type,
+        plural: plural,
+        background: obj.run_in_background,
+        // List of batch request responses that are yet to be processed.
+        save_responses: [],
+        in_flight: false, // is there a "thread" running for this bucket
+      };
+      _buckets[bucketName] = bucket;
     }
-    this._step(elem);
-  },
-}, {
-  init: function (queue) {
-    this._queue = queue;
-    this._resolve();
-  },
-  _resolve: function () {
-    let objs;
-    if (!this._queue.length) {
-      // Finished
+    bucket.objs.push(obj);
+    if (bucket.in_flight) {
       return;
     }
-    objs = this._queue.splice(0, this.constructor.BATCH);
-    $.when(...objs.map((fn) => {
-      return fn.apply(this.constructor);
-    }))
-      .always(this._resolve.bind(this)); // Move on to the next one
-  },
-});
+    elem = _enqueueBucket(bucket);
+    bucket.in_flight = true;
+  }
+  _step(elem);
+}
 
+export default enqueue;
+export {
+  _processSaveResponses,
+};

--- a/src/ggrc-client/js/models/service-models/comment.js
+++ b/src/ggrc-client/js/models/service-models/comment.js
@@ -22,7 +22,7 @@ export default Cacheable.extend({
       },
     },
   },
-  form_preload: function (isNew, params, pageInstance) {
+  formPreload: function (isNew, params, pageInstance) {
     this.attr('comment', pageInstance);
   },
   /**

--- a/src/ggrc-client/js/models/tests/save_queue_spec.js
+++ b/src/ggrc-client/js/models/tests/save_queue_spec.js
@@ -3,7 +3,7 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-import SaveQueue from '../save_queue';
+import {_processSaveResponses} from '../save_queue';
 
 describe('SaveQueue module', function () {
   'use strict';
@@ -15,7 +15,7 @@ describe('SaveQueue module', function () {
     beforeEach(function () {
       let thisContext = {};
 
-      method = SaveQueue._process_save_responses.bind(thisContext);
+      method = _processSaveResponses.bind(thisContext);
 
       bucket = {
         objs: [],

--- a/src/ggrc-client/js/modules/widget_descriptor.js
+++ b/src/ggrc-client/js/modules/widget_descriptor.js
@@ -3,7 +3,6 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-import canConstruct from 'can-construct';
 import SummaryWidgetController from '../controllers/summary_widget_controller';
 import DashboardWidget from '../controllers/dashboard_widget_controller';
 import InfoWidget from '../controllers/info_widget_controller';
@@ -11,181 +10,187 @@ import {getWidgetConfig} from '../plugins/utils/widgets-utils';
 import Program from '../models/business-models/program';
 
 const widgetDescriptors = {};
-// A widget descriptor has the minimum five properties:
-// widget_id:  the unique ID string for the widget
-// widget_name: the display title for the widget in the UI
-// widget_icon: the CSS class for the widget in the UI
-// content_controller: The controller class for the widget's content section
-// content_controller_options: options passed directly to the content controller; the
-//   precise options depend on the controller itself.  They usually require instance
-//   and/or model and some view.
-export default canConstruct.extend({
-  /*
-    make an info widget descriptor for a GGRC object
-    You must provide:
-    instance - an instance that is a subclass of Cacheable
-    widgetView [optional] - a template for rendering the info.
-  */
-  make_info_widget: function (instance, widgetView) {
-    let defaultInfoWidgetView = GGRC.templates_path +
-                                    '/base_objects/info.stache';
-    return new this(
-      instance.constructor.model_singular + ':info', {
-        widget_id: 'info',
-        widget_name: function () {
-          if (instance.constructor.title_singular === 'Person') {
-            return 'Info';
-          }
-          return instance.constructor.title_singular + ' Info';
-        },
-        widget_icon: 'info-circle',
-        content_controller: InfoWidget,
-        content_controller_options: {
-          instance: instance,
-          model: instance.constructor,
-          widget_view: widgetView || defaultInfoWidgetView,
-        },
-        order: 5,
-        uncountable: true,
-      });
-  },
-  /*
-    make an summary widget descriptor for a GGRC object
-    You must provide:
-    instance - an instance that is a subclass of Cacheable
-    widgetView [optional] - a template for rendering the info.
-  */
-  make_summary_widget: function (instance, widgetView) {
-    let defaultView = GGRC.templates_path +
-      '/base_objects/summary.stache';
-    return new this(
-      instance.constructor.model_singular + ':summary', {
-        widget_id: 'summary',
-        widget_name: function () {
-          return instance.constructor.title_singular + ' Summary';
-        },
-        widget_icon: 'pie-chart',
-        content_controller: SummaryWidgetController,
-        content_controller_options: {
-          instance: instance,
-          model: instance.constructor,
-          widget_view: widgetView || defaultView,
-        },
-        order: 3,
-        uncountable: true,
-      });
-  },
-  make_dashboard_widget: function (instance, widgetView) {
-    let defaultView = GGRC.templates_path +
-      '/base_objects/dashboard.stache';
-    return new this(
-      instance.constructor.model_singular + ':dashboard', {
-        widget_id: 'dashboard',
-        widget_name: function () {
-          if (instance.constructor.title_singular === 'Person') {
-            return 'Dashboard';
-          }
-          return instance.constructor.title_singular + ' Dashboard';
-        },
-        widget_icon: 'tachometer',
-        content_controller: DashboardWidget,
-        content_controller_options: {
-          instance: instance,
-          model: instance.constructor,
-          widget_view: widgetView || defaultView,
-        },
-        order: 6,
-        uncountable: true,
-      });
-  },
-  /*
-    make a tree view widget descriptor with mostly default-for-GGRC settings.
-    You must provide:
-    instance - an instance that is a subclass of Cacheable
-    farModel - a Cacheable class
-    extenders [optional] - an array of objects that will extend the default widget config.
-  */
-  make_tree_view: function (instance, farModel, extenders, id) {
-    let descriptor;
-    let objectConfig = getWidgetConfig(id);
 
-    // Should not even try to create descriptor if configuration options are missing
-    if (!instance || !farModel) {
-      console.warn(
-        `Arguments are missing or have incorrect format ${arguments}`);
-      return null;
-    }
+/*
+  A widget descriptor has the minimum five properties:
+  widget_id:  the unique ID string for the widget
+  widget_name: the display title for the widget in the UI
+  widget_icon: the CSS class for the widget in the UI
+  content_controller: The controller class for the widget's content section
+  content_controller_options: options passed directly to the content controller; the
+    precise options depend on the controller itself.  They usually require instance
+    and/or model and some view.
+*/
+function createWidgetDescriptor(id, opts) {
+  if (!opts && typeof id === 'object') {
+    opts = id;
+    id = opts.widget_id;
+  }
 
-    let widgetId = objectConfig.isObjectVersion ?
-      farModel.table_singular + '_version' :
-      (objectConfig.isMegaObject ?
-        farModel.table_singular + '_' + objectConfig.relation :
-        farModel.table_singular);
+  if (widgetDescriptors[id]) {
+    $.extend(widgetDescriptors[id], opts);
+    return widgetDescriptors[id];
+  }
 
-    descriptor = {
-      widgetType: 'treeview',
-      treeViewDepth: 2,
-      widget_id: widgetId,
-      widget_guard: function () {
-        if (
-          farModel.title_plural === 'Audits' &&
-          instance instanceof Program
-        ) {
-          return 'context' in instance && !!(instance.context.id);
-        }
-        return true;
-      },
+  const widgetDescriptor = {};
+  $.extend(widgetDescriptor, opts);
+  widgetDescriptors[id] = widgetDescriptor;
+  return widgetDescriptor;
+}
+
+/*
+  make an info widget descriptor for a GGRC object
+  You must provide:
+  instance - an instance that is a subclass of Cacheable
+  widgetView [optional] - a template for rendering the info.
+*/
+function makeInfoWidget(instance, widgetView) {
+  let defaultInfoWidgetView = GGRC.templates_path +
+    '/base_objects/info.stache';
+  return createWidgetDescriptor(
+    instance.constructor.model_singular + ':info', {
+      widget_id: 'info',
       widget_name: function () {
-        let farModelName =
-          objectConfig.isObjectVersion || objectConfig.isMegaObject ?
-            objectConfig.widgetName :
-            farModel.title_plural;
-
-        return farModelName;
+        if (instance.constructor.title_singular === 'Person') {
+          return 'Info';
+        }
+        return instance.constructor.title_singular + ' Info';
       },
-      widget_icon: farModel.table_singular,
-      object_category: farModel.category || 'default',
+      widget_icon: 'info-circle',
+      content_controller: InfoWidget,
+      content_controller_options: {
+        instance: instance,
+        model: instance.constructor,
+        widget_view: widgetView || defaultInfoWidgetView,
+      },
+      order: 5,
+      uncountable: true,
+    });
+}
+
+/*
+  make an summary widget descriptor for a GGRC object
+  You must provide:
+  instance - an instance that is a subclass of Cacheable
+  widgetView [optional] - a template for rendering the info.
+*/
+function makeSummaryWidget(instance, widgetView) {
+  let defaultView = GGRC.templates_path +
+    '/base_objects/summary.stache';
+  return createWidgetDescriptor(
+    instance.constructor.model_singular + ':summary', {
+      widget_id: 'summary',
+      widget_name: function () {
+        return instance.constructor.title_singular + ' Summary';
+      },
+      widget_icon: 'pie-chart',
+      content_controller: SummaryWidgetController,
+      content_controller_options: {
+        instance: instance,
+        model: instance.constructor,
+        widget_view: widgetView || defaultView,
+      },
+      order: 3,
+      uncountable: true,
+    });
+}
+
+function makeDashboardWidget(instance, widgetView) {
+  let defaultView = GGRC.templates_path +
+    '/base_objects/dashboard.stache';
+  return createWidgetDescriptor(
+    instance.constructor.model_singular + ':dashboard', {
+      widget_id: 'dashboard',
+      widget_name: function () {
+        if (instance.constructor.title_singular === 'Person') {
+          return 'Dashboard';
+        }
+        return instance.constructor.title_singular + ' Dashboard';
+      },
+      widget_icon: 'tachometer',
+      content_controller: DashboardWidget,
+      content_controller_options: {
+        instance: instance,
+        model: instance.constructor,
+        widget_view: widgetView || defaultView,
+      },
+      order: 6,
+      uncountable: true,
+    });
+}
+
+/*
+  make a tree view widget descriptor with mostly default-for-GGRC settings.
+  You must provide:
+  instance - an instance that is a subclass of Cacheable
+  farModel - a Cacheable class
+  extenders [optional] - an array of objects that will extend the default widget config.
+*/
+function makeTreeView(instance, farModel, extenders, id) {
+  let descriptor;
+  let objectConfig = getWidgetConfig(id);
+
+  // Should not even try to create descriptor if configuration options are missing
+  if (!instance || !farModel) {
+    console.warn(
+      `Arguments are missing or have incorrect format ${arguments}`);
+    return null;
+  }
+
+  let widgetId = objectConfig.isObjectVersion ?
+    farModel.table_singular + '_version' :
+    (objectConfig.isMegaObject ?
+      farModel.table_singular + '_' + objectConfig.relation :
+      farModel.table_singular);
+
+  descriptor = {
+    widgetType: 'treeview',
+    treeViewDepth: 2,
+    widget_id: widgetId,
+    widget_guard: function () {
+      if (
+        farModel.title_plural === 'Audits' &&
+        instance instanceof Program
+      ) {
+        return 'context' in instance && !!(instance.context.id);
+      }
+      return true;
+    },
+    widget_name: function () {
+      let farModelName =
+        objectConfig.isObjectVersion || objectConfig.isMegaObject ?
+          objectConfig.widgetName :
+          farModel.title_plural;
+
+      return farModelName;
+    },
+    widget_icon: farModel.table_singular,
+    object_category: farModel.category || 'default',
+    model: farModel,
+    objectVersion: objectConfig.isObjectVersion,
+    content_controller_options: {
+      parent_instance: instance,
       model: farModel,
       objectVersion: objectConfig.isObjectVersion,
-      content_controller_options: {
-        parent_instance: instance,
-        model: farModel,
-        objectVersion: objectConfig.isObjectVersion,
-        megaRelated: objectConfig.isMegaObject,
-        countsName: objectConfig.countsName,
-        widgetId,
-      },
-    };
+      megaRelated: objectConfig.isMegaObject,
+      countsName: objectConfig.countsName,
+      widgetId,
+    },
+  };
 
-    $.extend(...([true, descriptor].concat(extenders || [])));
+  $.extend(...([true, descriptor].concat(extenders || [])));
 
-    return new this(
-      instance.constructor.model_singular + ':' +
-      id || instance.constructor.model_singular,
-      descriptor
-    );
-  },
-  newInstance: function (id, opts) {
-    let ret;
-    if (!opts && typeof id === 'object') {
-      opts = id;
-      id = opts.widget_id;
-    }
+  return createWidgetDescriptor(
+    instance.constructor.model_singular + ':' +
+    id || instance.constructor.model_singular,
+    descriptor
+  );
+}
 
-    if (widgetDescriptors[id]) {
-      if (widgetDescriptors[id] instanceof this) {
-        $.extend(widgetDescriptors[id], opts);
-      } else {
-        ret = this._super.apply(this);
-        $.extend(ret, widgetDescriptors[id], opts);
-        widgetDescriptors[id] = ret;
-      }
-      return widgetDescriptors[id];
-    }
-
-    ret = this._super(...arguments);
-    $.extend(ret, opts);
-    widgetDescriptors[id] = ret;
-    return ret;
-  },
-}, {});
+export {
+  createWidgetDescriptor,
+  makeInfoWidget,
+  makeSummaryWidget,
+  makeDashboardWidget,
+  makeTreeView,
+};

--- a/src/ggrc-client/js/modules/widget_list.js
+++ b/src/ggrc-client/js/modules/widget_list.js
@@ -15,7 +15,6 @@ import {
   makeTreeView,
   createWidgetDescriptor,
 } from './widget_descriptor';
-import {getPageInstance} from '../plugins/utils/current-page-utils';
 
 const modules = {};
 
@@ -126,16 +125,7 @@ function getWidgetListFor(pageType) {
   return descriptors;
 }
 
-/*
-  returns a keyed object of widget descriptors that represents the current page.
-*/
-function getCurrentPageWidgets() {
-  return getWidgetListFor(
-    getPageInstance().constructor.model_singular);
-}
-
 export default WidgetList;
 export {
   getWidgetListFor,
-  getCurrentPageWidgets,
 };

--- a/src/ggrc-client/js/modules/widget_list.js
+++ b/src/ggrc-client/js/modules/widget_list.js
@@ -5,12 +5,19 @@
 
 import loMerge from 'lodash/merge';
 import loForEach from 'lodash/forEach';
-import canConstruct from 'can-construct';
 import SummaryWidgetController from '../controllers/summary_widget_controller';
 import DashboardWidget from '../controllers/dashboard_widget_controller';
 import InfoWidget from '../controllers/info_widget_controller';
-import WidgetDescriptor from './widget_descriptor';
+import {
+  makeInfoWidget,
+  makeSummaryWidget,
+  makeDashboardWidget,
+  makeTreeView,
+  createWidgetDescriptor,
+} from './widget_descriptor';
 import {getPageInstance} from '../plugins/utils/current-page-utils';
+
+const modules = {};
 
 /*
   WidgetList - an extensions-ready repository for widget descriptor configs.
@@ -25,102 +32,110 @@ import {getPageInstance} from '../plugins/utils/current-page-utils';
   See the comments for WidgetDescriptor for details in what is necessary to define
   a widget descriptor.
 */
-export default canConstruct.extend({
-  modules: {},
-  /*
-    get_widget_list_for: return a keyed object of widget descriptors for the specified page type.
 
-    pageType - one of a GGRC object model's shortName, or "admin"
-
-    The widget descriptors are built on the first call of this function; subsequently they are retrieved from the
-      widget descriptor cache.
-  */
-  get_widget_list_for: function (pageType) {
-    let widgets = {};
-    let descriptors = {};
-
-    loForEach(this.modules, function (module) {
-      loForEach(module[pageType], function (descriptor, id) {
-        if (!widgets[id]) {
-          widgets[id] = descriptor;
-        } else {
-          loMerge(widgets[id], descriptor);
-        }
-      });
-    });
-
-    loForEach(widgets, function (widget, widgetId) {
-      let ctrl = widget.content_controller;
-      let options = widget.content_controller_options;
-
-      if (ctrl && ctrl === InfoWidget) {
-        descriptors[widgetId] = WidgetDescriptor.make_info_widget(
-          options && options.instance ||
-            widget.instance,
-          options && options.widget_view || widget.widget_view
-        );
-      } else if (ctrl && ctrl === SummaryWidgetController) {
-        descriptors[widgetId] = WidgetDescriptor.make_summary_widget(
-          options && options.instance ||
-            widget.instance,
-          options && options.widget_view || widget.widget_view
-        );
-      } else if (ctrl && ctrl === DashboardWidget) {
-        descriptors[widgetId] = WidgetDescriptor.make_dashboard_widget(
-          options && options.instance ||
-            widget.instance,
-          options && options.widget_view || widget.widget_view
-        );
-      } else if (widget.widgetType === 'treeview') {
-        descriptors[widgetId] = WidgetDescriptor.make_tree_view(
-          options && (options.instance || options.parent_instance) ||
-            widget.instance,
-          options && options.model || widget.far_model ||
-            widget.model,
-          widget,
-          widgetId
-        );
-      } else {
-        descriptors[widgetId] = new WidgetDescriptor(
-          pageType + ':' + widgetId, widget);
-      }
-    });
-
-    loForEach(descriptors, function (descriptor, id) {
-      if (!descriptor || descriptor.suppressed) {
-        delete descriptors[id];
-      }
-    });
-
-    return descriptors;
-  },
-  /*
-    returns a keyed object of widget descriptors that represents the current page.
-  */
-  get_current_page_widgets: function () {
-    return this.get_widget_list_for(
-      getPageInstance().constructor.model_singular);
-  },
-}, {
-  init: function (name, opts) {
-    this.constructor.modules[name] = this;
+class WidgetList {
+  constructor(name, opts) {
+    modules[name] = this;
     Object.assign(this, opts);
-  },
+  }
+
   /*
     Here instead of using the object format described in the class comments, you may instead
-    add widgets to the WidgetList by using add_widget.
+    add widgets to the WidgetList by using addWidget.
 
     pageType - the shortName of a GGRC object class, or "admin"
     id - the desired widget's id.
     descriptor - a widget descriptor appropriate for the widget type. FIXME - the descriptor's
       widget_id value must match the value passed as "id"
   */
-  add_widget: function (pageType, id, descriptor) {
+  addWidget(pageType, id, descriptor) {
     this[pageType] = this[pageType] || {};
     if (this[pageType][id]) {
       loMerge(this[pageType][id], descriptor);
     } else {
       this[pageType][id] = descriptor;
     }
-  },
-});
+  }
+}
+
+/*
+  getWidgetListFor: return a keyed object of widget descriptors for the specified page type.
+
+  pageType - one of a GGRC object model's shortName, or "admin"
+
+  The widget descriptors are built on the first call of this function; subsequently they are retrieved from the
+    widget descriptor cache.
+*/
+function getWidgetListFor(pageType) {
+  let widgets = {};
+  let descriptors = {};
+
+  loForEach(modules, (module) => {
+    loForEach(module[pageType], (descriptor, id) => {
+      if (!widgets[id]) {
+        widgets[id] = descriptor;
+      } else {
+        loMerge(widgets[id], descriptor);
+      }
+    });
+  });
+
+  loForEach(widgets, (widget, widgetId) => {
+    let ctrl = widget.content_controller;
+    let options = widget.content_controller_options;
+
+    if (ctrl && ctrl === InfoWidget) {
+      descriptors[widgetId] = makeInfoWidget(
+        options && options.instance ||
+          widget.instance,
+        options && options.widget_view || widget.widget_view
+      );
+    } else if (ctrl && ctrl === SummaryWidgetController) {
+      descriptors[widgetId] = makeSummaryWidget(
+        options && options.instance ||
+          widget.instance,
+        options && options.widget_view || widget.widget_view
+      );
+    } else if (ctrl && ctrl === DashboardWidget) {
+      descriptors[widgetId] = makeDashboardWidget(
+        options && options.instance ||
+          widget.instance,
+        options && options.widget_view || widget.widget_view
+      );
+    } else if (widget.widgetType === 'treeview') {
+      descriptors[widgetId] = makeTreeView(
+        options && (options.instance || options.parent_instance) ||
+          widget.instance,
+        options && options.model || widget.far_model ||
+          widget.model,
+        widget,
+        widgetId
+      );
+    } else {
+      descriptors[widgetId] = createWidgetDescriptor(
+        pageType + ':' + widgetId, widget);
+    }
+  });
+
+  loForEach(descriptors, (descriptor, id) => {
+    if (!descriptor || descriptor.suppressed) {
+      delete descriptors[id];
+    }
+  });
+
+  return descriptors;
+}
+
+/*
+  returns a keyed object of widget descriptors that represents the current page.
+*/
+function getCurrentPageWidgets() {
+  return getWidgetListFor(
+    getPageInstance().constructor.model_singular);
+}
+
+export default WidgetList;
+export {
+  getWidgetListFor,
+  getCurrentPageWidgets,
+};

--- a/src/ggrc-client/js/permission.js
+++ b/src/ggrc-client/js/permission.js
@@ -8,7 +8,7 @@ import loToArray from 'lodash/toArray';
 import loReduce from 'lodash/reduce';
 import {ggrcAjax} from './plugins/ajax_extensions';
 import canCompute from 'can-compute';
-import {getPageInstance} from './plugins/utils/current-page-utils';
+import './plugins/utils/current-page-utils'; // fixes a cyclic dependency and should be fixed in a proper way
 import Stub from '../js/models/stub';
 import {getInstance} from '../js/plugins/utils/models-utils';
 import {reify} from '../js/plugins/utils/reify-utils';
@@ -219,12 +219,6 @@ function isAllowedAny(action, resourceType) {
   return !!allowed;
 }
 
-function pageContextId() {
-  let pageInstance = getPageInstance();
-  return (pageInstance && pageInstance.context &&
-          pageInstance.context.id) || null;
-}
-
 function refreshPermissions() {
   return ggrcAjax({
     url: '/permissions',
@@ -246,6 +240,5 @@ export {
   isAllowed,
   isAllowedFor,
   isAllowedAny,
-  pageContextId,
   refreshPermissions,
 };

--- a/src/ggrc-client/js/permission.js
+++ b/src/ggrc-client/js/permission.js
@@ -8,16 +8,14 @@ import loToArray from 'lodash/toArray';
 import loReduce from 'lodash/reduce';
 import {ggrcAjax} from './plugins/ajax_extensions';
 import canCompute from 'can-compute';
-import canConstruct from 'can-construct';
 import {getPageInstance} from './plugins/utils/current-page-utils';
 import Stub from '../js/models/stub';
 import {getInstance} from '../js/plugins/utils/models-utils';
 import {reify} from '../js/plugins/utils/reify-utils';
 
-let ADMIN_PERMISSION;
 let _CONDITIONS_MAP = {
   contains: function (instance, args) {
-    let value = Permission._resolve_permission_variable(args.value);
+    let value = _resolvePermissionVariable(args.value);
     let listValue = instance[args.list_property] || [];
     let i;
     for (i = 0; i < listValue.length; i++) {
@@ -28,7 +26,7 @@ let _CONDITIONS_MAP = {
     return false;
   },
   is: function (instance, args) {
-    let value = Permission._resolve_permission_variable(args.value);
+    let value = _resolvePermissionVariable(args.value);
     let propertyValue = loReduce(args.property_name.split('.'),
       function (obj, key) {
         let value = obj.attr(key);
@@ -40,7 +38,7 @@ let _CONDITIONS_MAP = {
     return value === propertyValue;
   },
   'in': function (instance, args) {
-    let value = Permission._resolve_permission_variable(args.value);
+    let value = _resolvePermissionVariable(args.value);
     let propertyValue = instance[args.property_name];
     if (propertyValue instanceof Stub) {
       propertyValue = reify(propertyValue);
@@ -60,184 +58,194 @@ let _CONDITIONS_MAP = {
 };
 let permissionsCompute = canCompute(GGRC.permissions);
 
-const Permission = canConstruct.extend({
-  _admin_permission_for_context: function (contextId) {
-    return new Permission(
-      ADMIN_PERMISSION.action, ADMIN_PERMISSION.resource_type, contextId);
-  },
-
-  _all_resource_permission: function (permission) {
-    return new Permission(
-      permission.action, ADMIN_PERMISSION.resource_type, permission.context_id);
-  },
-
-  _permission_match: function (permissions, permission) {
-    let resourceTypes = permissions[permission.action] || {};
-    let resourceType = resourceTypes[permission.resource_type] || {};
-    let contexts = resourceType.contexts || [];
-
-    return (contexts.indexOf(permission.context_id) > -1);
-  },
-
-  _is_allowed: function (permissions, permission) {
-    if (!permissions) {
-      return false; // ?
-    }
-    if (this._permission_match(
-      permissions,
-      new Permission(
-        permission.action,
-        permission.resource_type, null))) {
-      return true;
-    }
-    if (this._permission_match(permissions, permission)) {
-      return true;
-    }
-    if (this._permission_match(permissions,
-      this._all_resource_permission(permission))) {
-      return true;
-    }
-    if (this._permission_match(permissions, ADMIN_PERMISSION)) {
-      return true;
-    }
-    if (this._permission_match(permissions,
-      this._admin_permission_for_context(permission.context_id))) {
-      return true;
-    }
-    // Check for System Admin permission
-    if (this._permission_match(permissions,
-      this._admin_permission_for_context(0))) {
-      return true;
-    }
-    return false;
-  },
-
-  _resolve_permission_variable: function (value) {
-    if ($.type(value) === 'string') {
-      if (value[0] === '$') {
-        if (value === '$current_user') {
-          return getInstance('Person', GGRC.current_user.id);
-        }
-        throw new Error('unknown permission variable: ' + value);
-      }
-    }
-    return value;
-  },
-
-  _is_allowed_for: function (permissions, instance, action) {
-    // Check for admin permission
-    let checkAdmin = function (contextId) {
-      let permission = this._admin_permission_for_context(contextId);
-      let conditions;
-      let i;
-      let condition;
-      if (this._permission_match(permissions, permission)) {
-        conditions = loToArray(exists(permissions,
-          permission.action,
-          permission.resource_type,
-          'conditions',
-          contextId));
-        if (!conditions.length) {
-          return true;
-        }
-        for (i = 0; i < conditions.length; i++) {
-          condition = conditions[i];
-          if (_CONDITIONS_MAP[condition.condition](
-            instance, condition.terms, action)) {
-            return true;
-          }
-        }
-        return false;
-      }
-      return false;
-    }.bind(this);
-
-    let actionObj = permissions[action] || {};
-    let shortName = instance.constructor && instance.constructor.model_singular;
-    let instanceType = instance.type || shortName;
-    let typeObj = actionObj[instanceType] || {};
-    let conditionsByContext = typeObj.conditions || {};
-    let resources = typeObj.resources || [];
-    let context = instance.context || {id: null};
-    let conditions = conditionsByContext[context.id] || [];
-    let condition;
-    let i;
-
-    conditions = conditions.concat(conditionsByContext.null || []);
-
-    if (checkAdmin(0) || checkAdmin(null)) {
-      return true;
-    }
-    if (~resources.indexOf(instance.id)) {
-      return true;
-    }
-    if (conditions.length === 0 && (this._is_allowed(permissions,
-      new Permission(action, instanceType, null)) ||
-      this._is_allowed(permissions,
-        new Permission(action, instanceType, context.id)))) {
-      return true;
-    }
-    // Check any conditions applied per instance
-    // If there are no conditions, the user has unconditional access to
-    // the current instance. We can safely return true in this case.
-    if (conditions.length === 0) {
-      return false;
-    }
-    for (i = 0; i < conditions.length; i++) {
-      condition = conditions[i];
-      if (_CONDITIONS_MAP[condition.condition](
-        instance, condition.terms, action)) {
-        return true;
-      }
-    }
-    return false;
-  },
-
-  is_allowed: function (action, resourceType, contextId) {
-    return this._is_allowed(
-      permissionsCompute(), new this(action, resourceType, contextId));
-  },
-
-  is_allowed_for: function (action, resource) {
-    return this._is_allowed_for(permissionsCompute(), resource, action);
-  },
-
-  is_allowed_any: function (action, resourceType) {
-    let allowed = this.is_allowed(action, resourceType);
-    let perms = permissionsCompute();
-
-    if (!allowed) {
-      allowed = exists(perms, action, resourceType, 'contexts', 'length');
-    }
-    return !!allowed;
-  },
-
-  page_context_id: function () {
-    let pageInstance = getPageInstance();
-    return (pageInstance && pageInstance.context &&
-            pageInstance.context.id) || null;
-  },
-
-  refresh: function () {
-    return ggrcAjax({
-      url: '/permissions',
-      type: 'get',
-      dataType: 'json',
-    }).then(function (perm) {
-      permissionsCompute(perm);
-      GGRC.permissions = perm;
-    });
-  },
-}, {
-  // prototype
-  setup: function (action, resourceType, contextId) {
+class Permission {
+  constructor(action, resourceType, contextId) {
     this.action = action;
     this.resource_type = resourceType;
     this.context_id = contextId;
-    return this;
-  },
-});
+  }
+}
 
-ADMIN_PERMISSION = new Permission('__GGRC_ADMIN__', '__GGRC_ALL__', 0);
+const ADMIN_PERMISSION = new Permission('__GGRC_ADMIN__', '__GGRC_ALL__', 0);
 
-export default Permission;
+function _adminPermissionForContext(contextId) { // eslint-disable-line id-length
+  return new Permission(
+    ADMIN_PERMISSION.action, ADMIN_PERMISSION.resource_type, contextId);
+}
+
+function _allResourcePermission(permission) {
+  return new Permission(
+    permission.action, ADMIN_PERMISSION.resource_type, permission.context_id);
+}
+
+function _permissionMatch(permissions, permission) {
+  let resourceTypes = permissions[permission.action] || {};
+  let resourceType = resourceTypes[permission.resource_type] || {};
+  let contexts = resourceType.contexts || [];
+
+  return (contexts.indexOf(permission.context_id) > -1);
+}
+
+function _isAllowed(permissions, permission) {
+  if (!permissions) {
+    return false;
+  }
+  if (_permissionMatch(
+    permissions,
+    new Permission(
+      permission.action,
+      permission.resource_type, null))) {
+    return true;
+  }
+  if (_permissionMatch(permissions, permission)) {
+    return true;
+  }
+  if (_permissionMatch(permissions,
+    _allResourcePermission(permission))) {
+    return true;
+  }
+  if (_permissionMatch(permissions, ADMIN_PERMISSION)) {
+    return true;
+  }
+  if (_permissionMatch(permissions,
+    _adminPermissionForContext(permission.context_id))) {
+    return true;
+  }
+  // Check for System Admin permission
+  if (_permissionMatch(permissions,
+    _adminPermissionForContext(0))) {
+    return true;
+  }
+  return false;
+}
+
+function _resolvePermissionVariable(value) { // eslint-disable-line id-length
+  if ($.type(value) === 'string') {
+    if (value[0] === '$') {
+      if (value === '$current_user') {
+        return getInstance('Person', GGRC.current_user.id);
+      }
+      throw new Error('unknown permission variable: ' + value);
+    }
+  }
+  return value;
+}
+
+function _isAllowedFor(permissions, instance, action) {
+  // Check for admin permission
+  let checkAdmin = function (contextId) {
+    let permission = _adminPermissionForContext(contextId);
+    let conditions;
+    let i;
+    let condition;
+    if (_permissionMatch(permissions, permission)) {
+      conditions = loToArray(exists(permissions,
+        permission.action,
+        permission.resource_type,
+        'conditions',
+        contextId));
+      if (!conditions.length) {
+        return true;
+      }
+      for (i = 0; i < conditions.length; i++) {
+        condition = conditions[i];
+        if (_CONDITIONS_MAP[condition.condition](
+          instance, condition.terms, action)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  };
+
+  let actionObj = permissions[action] || {};
+  let shortName = instance.constructor && instance.constructor.model_singular;
+  let instanceType = instance.type || shortName;
+  let typeObj = actionObj[instanceType] || {};
+  let conditionsByContext = typeObj.conditions || {};
+  let resources = typeObj.resources || [];
+  let context = instance.context || {id: null};
+  let conditions = conditionsByContext[context.id] || [];
+  let condition;
+  let i;
+
+  conditions = conditions.concat(conditionsByContext.null || []);
+
+  if (checkAdmin(0) || checkAdmin(null)) {
+    return true;
+  }
+  if (~resources.indexOf(instance.id)) {
+    return true;
+  }
+  if (conditions.length === 0 && (_isAllowed(permissions,
+    new Permission(action, instanceType, null)) ||
+    _isAllowed(permissions,
+      new Permission(action, instanceType, context.id)))) {
+    return true;
+  }
+  // Check any conditions applied per instance
+  // If there are no conditions, the user has unconditional access to
+  // the current instance. We can safely return true in this case.
+  if (conditions.length === 0) {
+    return false;
+  }
+  for (i = 0; i < conditions.length; i++) {
+    condition = conditions[i];
+    if (_CONDITIONS_MAP[condition.condition](
+      instance, condition.terms, action)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAllowed(action, resourceType, contextId) {
+  return _isAllowed(
+    permissionsCompute(), new Permission(action, resourceType, contextId));
+}
+
+function isAllowedFor(action, resource) {
+  return _isAllowedFor(permissionsCompute(), resource, action);
+}
+
+function isAllowedAny(action, resourceType) {
+  let allowed = isAllowed(action, resourceType);
+  let perms = permissionsCompute();
+
+  if (!allowed) {
+    allowed = exists(perms, action, resourceType, 'contexts', 'length');
+  }
+  return !!allowed;
+}
+
+function pageContextId() {
+  let pageInstance = getPageInstance();
+  return (pageInstance && pageInstance.context &&
+          pageInstance.context.id) || null;
+}
+
+function refreshPermissions() {
+  return ggrcAjax({
+    url: '/permissions',
+    type: 'get',
+    dataType: 'json',
+  }).then(function (perm) {
+    permissionsCompute(perm);
+    GGRC.permissions = perm;
+  });
+}
+
+export {
+  _adminPermissionForContext,
+  _allResourcePermission,
+  _permissionMatch,
+  _isAllowed,
+  _resolvePermissionVariable,
+  _isAllowedFor,
+  isAllowed,
+  isAllowedFor,
+  isAllowedAny,
+  pageContextId,
+  refreshPermissions,
+};

--- a/src/ggrc-client/js/plugins/tests/utils/object-review-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/object-review-utils_spec.js
@@ -5,7 +5,7 @@
 
 import {saveReview} from '../../../plugins/utils/object-review-utils';
 import Review from '../../../models/service-models/review';
-import Permission from '../../../permission';
+import * as Permission from '../../../permission';
 
 describe('object-review-utils', () => {
   let review;
@@ -22,7 +22,7 @@ describe('object-review-utils', () => {
 
       spyOn(review, 'save').and.returnValue(saveDfd.resolve(review));
       spyOn(review, 'refresh').and.returnValue(refreshDfd.resolve(review));
-      spyOn(Permission, 'refresh').and.returnValue($.when());
+      spyOn(Permission, 'refreshPermissions').and.returnValue($.when());
       reviewableInstance = jasmine.createSpyObj('reviewableInstance',
         {refresh: $.when()});
     });
@@ -42,7 +42,7 @@ describe('object-review-utils', () => {
 
       it('should refresh Permissions and reviewable object', (done) => {
         saveReview(review, reviewableInstance).then(() => {
-          expect(Permission.refresh).toHaveBeenCalled();
+          expect(Permission.refreshPermissions).toHaveBeenCalled();
           expect(reviewableInstance.refresh).toHaveBeenCalled();
           done();
         });
@@ -62,7 +62,7 @@ describe('object-review-utils', () => {
 
       it('should not refresh Permissions and reviewable object', () => {
         saveReview(review, reviewableInstance);
-        expect(Permission.refresh).not.toHaveBeenCalled();
+        expect(Permission.refreshPermissions).not.toHaveBeenCalled();
         expect(reviewableInstance.refresh).not.toHaveBeenCalled();
       });
     });

--- a/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
@@ -10,7 +10,7 @@ import * as CurrentPageUtils from '../../utils/current-page-utils';
 import * as WidgetsUtils from '../../utils/widgets-utils';
 import * as QueryAPI from '../../utils/query-api-utils';
 import * as Mappings from '../../../models/mappers/mappings';
-import WidgetList from '../../../modules/widget_list';
+import * as WidgetList from '../../../modules/widget_list';
 import QueryParser from '../../../generated/ggrc_filter_query_parser';
 
 describe('GGRC Utils Widgets', function () {
@@ -18,7 +18,7 @@ describe('GGRC Utils Widgets', function () {
     let method;
 
     beforeEach(function () {
-      spyOn(WidgetList, 'get_widget_list_for')
+      spyOn(WidgetList, 'getWidgetListFor')
         .and.returnValue({
           control: {},
           Assessment: {},
@@ -83,7 +83,7 @@ describe('GGRC Utils Widgets', function () {
     let method;
 
     beforeEach(function () {
-      spyOn(WidgetList, 'get_widget_list_for')
+      spyOn(WidgetList, 'getWidgetListFor')
         .and.returnValue({
           Control: {
             widgetType: 'treeview',
@@ -395,7 +395,7 @@ describe('GGRC Utils Widgets', function () {
           },
         };
 
-      spyOn(WidgetList, 'get_widget_list_for')
+      spyOn(WidgetList, 'getWidgetListFor')
         .and.returnValue(widgets);
 
       spyOn(AjaxExtensions, 'ggrcAjax')

--- a/src/ggrc-client/js/plugins/utils/object-review-utils.js
+++ b/src/ggrc-client/js/plugins/utils/object-review-utils.js
@@ -4,7 +4,7 @@
  */
 
 import Review from '../../models/service-models/review';
-import Permission from '../../permission';
+import {refreshPermissions} from '../../permission';
 
 const createReviewInstance = (reviewableInstance) => {
   return new Review({
@@ -27,7 +27,7 @@ const saveReview = (review, reviewableInstance) => {
        * ReviewableInstance should also be refreshed after POST review
        * to get review stub in properties
        */
-      return $.when(Permission.refresh(), reviewableInstance.refresh());
+      return $.when(refreshPermissions(), reviewableInstance.refresh());
     })
     /**
      * Refresh Review object to get E-tag

--- a/src/ggrc-client/js/plugins/utils/snapshot-utils.js
+++ b/src/ggrc-client/js/plugins/utils/snapshot-utils.js
@@ -7,7 +7,7 @@ import loFind from 'lodash/find';
 import canConstruct from 'can-construct';
 import canList from 'can-list';
 import canMap from 'can-map';
-import Permission from '../../permission';
+import {isAllowedFor} from '../../permission';
 import {hasRelatedAssessments} from './models-utils';
 import Person from '../../models/business-models/person';
 import Audit from '../../models/business-models/audit';
@@ -91,14 +91,14 @@ function toObject(instance) {
   content.type = instance.child_type;
   content.id = instance.id;
   content.originalObjectDeleted = instance.original_object_deleted;
-  content.canRead = Permission.is_allowed_for('read', {
+  content.canRead = isAllowedFor('read', {
     type: instance.child_type,
     id: instance.child_id,
   });
   content.updated_at = instance.updated_at;
   content.canGetLatestRevision =
     !instance.is_latest_revision &&
-    Permission.is_allowed_for('update', {
+    isAllowedFor('update', {
       type: instance.child_type,
       id: instance.child_id}) &&
     !instance.original_object_deleted &&

--- a/src/ggrc-client/js/plugins/utils/snapshot-utils.js
+++ b/src/ggrc-client/js/plugins/utils/snapshot-utils.js
@@ -4,7 +4,6 @@
 */
 
 import loFind from 'lodash/find';
-import canConstruct from 'can-construct';
 import canList from 'can-list';
 import canMap from 'can-map';
 import {isAllowedFor} from '../../permission';
@@ -79,8 +78,9 @@ function isAuditScopeModel(model) {
  * @return {Object} The object
  */
 function toObject(instance) {
-  let content = instance.revision.content instanceof canConstruct ?
-    instance.revision.content.attr() : instance.revision.content;
+  let content = instance.revision.content.attr
+    ? instance.revision.content.attr()
+    : instance.revision.content;
 
   content.originalLink = getParentUrl(instance);
   content.snapshot = new canMap(instance);

--- a/src/ggrc-client/js/plugins/utils/widgets-utils.js
+++ b/src/ggrc-client/js/plugins/utils/widgets-utils.js
@@ -28,7 +28,7 @@ import {
   isMegaObjectRelated,
   getMegaObjectConfig,
 } from './mega-object-utils';
-import WidgetList from '../../modules/widget_list';
+import {getWidgetListFor} from '../../modules/widget_list';
 import {
   getPageType,
   getPageInstance,
@@ -73,7 +73,7 @@ function getWidgetList(modelName, path) {
   if (!modelName) {
     return widgetList;
   }
-  widgetList = WidgetList.get_widget_list_for(modelName);
+  widgetList = getWidgetListFor(modelName);
   // Needs refactoring: Should be removed and replaced with Routing!!!
   isAssessmentsView = /^\/assessments_view/.test(path);
 

--- a/src/ggrc-client/js/plugins/utils/workflow-utils.js
+++ b/src/ggrc-client/js/plugins/utils/workflow-utils.js
@@ -5,7 +5,7 @@
 
 import loForEach from 'lodash/forEach';
 import {confirm} from '../../plugins/utils/modals';
-import Permission from '../../permission';
+import {refreshPermissions} from '../../permission';
 import Cycle from '../../models/business-models/cycle';
 import Stub from '../../models/stub';
 import {changeHash} from '../../router';
@@ -100,7 +100,7 @@ async function updateStatus(instance, status) {
 }
 
 function refreshTGRelatedItems(taskGroup) {
-  Permission.refresh();
+  refreshPermissions();
   taskGroup.refresh_all_force('workflow', 'context');
 }
 

--- a/src/ggrc-client/js/tests/permission_spec.js
+++ b/src/ggrc-client/js/tests/permission_spec.js
@@ -5,7 +5,7 @@
 
 import loMap from 'lodash/map';
 import * as AjaxExtensions from '../plugins/ajax_extensions';
-import Permission from '../permission';
+import * as Permission from '../permission';
 import {makeFakeInstance} from '../../js_specs/spec_helpers';
 import * as CurrentPageUtils from '../plugins/utils/current-page-utils';
 import UserRole from '../models/service-models/user-role';
@@ -13,17 +13,17 @@ import Audit from '../models/business-models/audit';
 import {getInstance} from '../plugins/utils/models-utils';
 
 describe('Permission', function () {
-  describe('_admin_permission_for_context() method', function () {
+  describe('_adminPermissionForContext() method', function () {
     it('returns new admin permission for specified context_id',
       function () {
-        let result = Permission._admin_permission_for_context(23);
+        let result = Permission._adminPermissionForContext(23);
         expect(result.action).toEqual('__GGRC_ADMIN__');
         expect(result.resource_type).toEqual('__GGRC_ALL__');
         expect(result.context_id).toEqual(23);
       });
   });
 
-  describe('_all_resource_permission() method', function () {
+  describe('_allResourcePermission() method', function () {
     let permission;
 
     beforeEach(function () {
@@ -33,14 +33,14 @@ describe('Permission', function () {
       };
     });
     it('returns new all resource permission', function () {
-      let result = Permission._all_resource_permission(permission);
+      let result = Permission._allResourcePermission(permission);
       expect(result.action).toEqual(permission.action);
       expect(result.resource_type).toEqual('__GGRC_ALL__');
       expect(result.context_id).toEqual(permission.context_id);
     });
   });
 
-  describe('_permission_match() method', function () {
+  describe('_permissionMatch() method', function () {
     let permissions;
 
     beforeEach(function () {
@@ -59,7 +59,7 @@ describe('Permission', function () {
           resource_type: 'Program',
           context_id: 1,
         };
-        expect(Permission._permission_match(permissions, permission))
+        expect(Permission._permissionMatch(permissions, permission))
           .toEqual(true);
       });
     it('returns false if permissions does not contain specified permission',
@@ -77,13 +77,13 @@ describe('Permission', function () {
         });
 
         permissionCollection.forEach((permission) => {
-          expect(Permission._permission_match(permissions, permission))
+          expect(Permission._permissionMatch(permissions, permission))
             .toEqual(false);
         });
       });
   });
 
-  describe('_is_allowed() method', function () {
+  describe('_isAllowed() method', function () {
     let permissions;
     let permission;
 
@@ -91,7 +91,7 @@ describe('Permission', function () {
       permissions = {};
     });
     it('returns false if permissions is undefined', function () {
-      expect(Permission._is_allowed()).toEqual(false);
+      expect(Permission._isAllowed()).toEqual(false);
     });
     it('returns true if there is permission for null context', function () {
       permission = {
@@ -103,7 +103,7 @@ describe('Permission', function () {
           contexts: [null],
         },
       };
-      expect(Permission._is_allowed(permissions, permission)).toEqual(true);
+      expect(Permission._isAllowed(permissions, permission)).toEqual(true);
     });
     it('returns true if admin permission is matched', function () {
       permission = {};
@@ -112,7 +112,7 @@ describe('Permission', function () {
           contexts: [0],
         },
       };
-      expect(Permission._is_allowed(permissions, permission)).toEqual(true);
+      expect(Permission._isAllowed(permissions, permission)).toEqual(true);
     });
     it('returns true if all resource permission is matched', function () {
       permission = {
@@ -124,7 +124,7 @@ describe('Permission', function () {
           contexts: [11],
         },
       };
-      expect(Permission._is_allowed(permissions, permission)).toEqual(true);
+      expect(Permission._isAllowed(permissions, permission)).toEqual(true);
     });
     it('returns true if admin permission for context is matched', function () {
       permission = {
@@ -135,7 +135,7 @@ describe('Permission', function () {
           contexts: [101],
         },
       };
-      expect(Permission._is_allowed(permissions, permission)).toEqual(true);
+      expect(Permission._isAllowed(permissions, permission)).toEqual(true);
     });
     it('returns false if permission is not matched', function () {
       permission = {
@@ -143,40 +143,40 @@ describe('Permission', function () {
         resource_type: 'Audit',
         context_id: 321,
       };
-      expect(Permission._is_allowed(permissions, permission)).toEqual(false);
+      expect(Permission._isAllowed(permissions, permission)).toEqual(false);
     });
   });
 
-  describe('_resolve_permission_variable', function () {
+  describe('_resolvePermissionVariable', function () {
     let value;
 
     it('returns "value" if its type is not string', function () {
       value = {};
-      expect(Permission._resolve_permission_variable(value)).toBe(value);
+      expect(Permission._resolvePermissionVariable(value)).toBe(value);
     });
     it('returns "value" if its type string and first symbol is not "$"',
       function () {
         value = 'mock';
-        expect(Permission._resolve_permission_variable(value)).toEqual(value);
+        expect(Permission._resolvePermissionVariable(value)).toEqual(value);
       });
     it('returns current user instance ' +
     'if value is equal to "$current_user"', function () {
       let currentUser = getInstance('Person', GGRC.current_user.id);
       value = '$current_user';
-      expect(Permission._resolve_permission_variable(value))
+      expect(Permission._resolvePermissionVariable(value))
         .toEqual(currentUser);
     });
     it('throws error if value is not equal to "$current_user"' +
     ' but its first symbol is "$"', function () {
       let foo = function () {
         value = '$user';
-        Permission._resolve_permission_variable(value);
+        Permission._resolvePermissionVariable(value);
       };
       expect(foo).toThrow(jasmine.any(Error));
     });
   });
 
-  describe('_is_allowed_for() method', function () {
+  describe('_isAllowedFor() method', function () {
     let permissions;
     let instance;
     let result;
@@ -199,7 +199,7 @@ describe('Permission', function () {
           },
         };
         instance = fakeUserRoleCreator();
-        result = Permission._is_allowed_for(permissions, instance, 'create');
+        result = Permission._isAllowedFor(permissions, instance, 'create');
         expect(result).toEqual(true);
       });
       it('return true if it is admin permission and matches all conditions',
@@ -220,7 +220,7 @@ describe('Permission', function () {
           };
           instance = fakeUserRoleCreator();
           instance.list_value = [{id: 0}];
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
       it('returns true if permissions resources contains instance id',
@@ -232,7 +232,7 @@ describe('Permission', function () {
           };
           instance = fakeUserRoleCreator();
           instance.attr('id', 10);
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
       it('returns true if there is permission with null context ' +
@@ -243,7 +243,7 @@ describe('Permission', function () {
           },
         };
         instance = fakeUserRoleCreator();
-        result = Permission._is_allowed_for(permissions, instance, 'create');
+        result = Permission._isAllowedFor(permissions, instance, 'create');
         expect(result).toEqual(true);
       });
       it('returns true if there is permission with specified context ' +
@@ -255,7 +255,7 @@ describe('Permission', function () {
         };
         instance = fakeUserRoleCreator();
         instance.attr('context', {id: 101});
-        result = Permission._is_allowed_for(permissions, instance, 'create');
+        result = Permission._isAllowedFor(permissions, instance, 'create');
         expect(result).toEqual(true);
       });
       describe('returns false if there is permission ' +
@@ -278,7 +278,7 @@ describe('Permission', function () {
           instance = fakeUserRoleCreator();
           instance.attr('context', {id: 101});
           instance.list_value = [{id: 100}];
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(false);
         });
         it('for "is" condition', function () {
@@ -301,7 +301,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.mockProperty = 'bad_value';
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(false);
         });
         it('for "in" condition', function () {
@@ -324,7 +324,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.mockProperty = 4;
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(false);
         });
         it('for "forbid" condition', function () {
@@ -350,7 +350,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.attr('type', 'bad_instance');
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(false);
         });
       });
@@ -374,7 +374,7 @@ describe('Permission', function () {
           instance = fakeUserRoleCreator();
           instance.attr('context', {id: 101});
           instance.list_value = [{id: 0}];
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
         it('for "is" condition', function () {
@@ -397,7 +397,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.attr('property_value', 'mockValue');
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
         it('for complex "is" condition', function () {
@@ -422,7 +422,7 @@ describe('Permission', function () {
             property_value: 'mockValue',
           });
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
         it('for "in" condition', function () {
@@ -445,7 +445,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.property_value = 'mockValue';
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
         it('for "forbid" condition', function () {
@@ -471,7 +471,7 @@ describe('Permission', function () {
           instance.attr('context', {id: 101});
           instance.attr('type', 'UserRole');
 
-          result = Permission._is_allowed_for(permissions, instance, 'create');
+          result = Permission._isAllowedFor(permissions, instance, 'create');
           expect(result).toEqual(true);
         });
       });
@@ -496,7 +496,7 @@ describe('Permission', function () {
         instance = makeFakeInstance({model: Audit})();
         instance.attr('context', {id: 101});
         instance.list_value = [{id: 100}];
-        result = Permission._is_allowed_for(permissions, instance, 'create');
+        result = Permission._isAllowedFor(permissions, instance, 'create');
         expect(result).toEqual(false);
       });
       it('returns true when condition matched', function () {
@@ -517,93 +517,65 @@ describe('Permission', function () {
         instance = makeFakeInstance({model: Audit})();
         instance.attr('context', {id: 101});
         instance.list_value = [{id: 0}];
-        result = Permission._is_allowed_for(permissions, instance, 'create');
+        result = Permission._isAllowedFor(permissions, instance, 'create');
         expect(result).toEqual(true);
       });
     });
   });
 
   describe('is_allowed() method', function () {
-    let object;
-
-    beforeEach(function () {
-      object = {
-        action: 'create',
-        resource_type: 'UserRole',
-        context_id: 1,
-      };
-
-      spyOn(Permission, '_is_allowed').and.returnValue(object);
-    });
-    it('delegates the check to the _is_allowed() method', function () {
-      let _isAllowedResult = Permission._is_allowed();
-      let isAllowedResult = Permission.is_allowed('create', 'UserRole', 1);
-
-      expect(isAllowedResult).toBe(_isAllowedResult);
-      expect(Permission._is_allowed)
-        .toHaveBeenCalledWith(
-          GGRC.permissions,
-          jasmine.objectContaining(object)
-        );
+    it('returns false if permission is not matched', function () {
+      let isAllowedResult = Permission.isAllowed('create', 'UserRole', 1);
+      expect(isAllowedResult).toBe(false);
     });
   });
 
-  describe('is_allowed_for() method', function () {
-    let object;
-
-    beforeEach(function () {
-      object = {};
-      spyOn(Permission, '_is_allowed_for').and.returnValue(object);
-    });
-    it('delegates the check to the _is_allowed_for() method', function () {
-      let _isAllowedForResult = Permission._is_allowed_for();
-      let isAllowedForResult = Permission.is_allowed_for('create', 'UserRole');
-
-      expect(isAllowedForResult).toBe(_isAllowedForResult);
-      expect(Permission._is_allowed_for)
-        .toHaveBeenCalledWith(GGRC.permissions, 'UserRole', 'create');
+  describe('isAllowedFor() method', function () {
+    it('returns false if there is permission with no conditions', function () {
+      let isAllowedForResult = Permission.isAllowedFor('create', 'UserRole');
+      expect(isAllowedForResult).toBe(false);
     });
   });
 
-  describe('is_allowed_any() method', function () {
+  describe('isAllowedAny() method', function () {
     it('returns true if it is allowed with null context', function () {
       GGRC.permissions.read.Program = {
         contexts: [null],
       };
-      expect(Permission.is_allowed_any('read', 'Program'))
+      expect(Permission.isAllowedAny('read', 'Program'))
         .toEqual(true);
     });
     it('returns true if there is at least one allowed context', function () {
       GGRC.permissions.read.Program = {
         contexts: [1],
       };
-      expect(Permission.is_allowed_any('read', 'Program'))
+      expect(Permission.isAllowedAny('read', 'Program'))
         .toEqual(true);
     });
     it('returns false if there is no allowed context', function () {
       GGRC.permissions.read.Program = {
         contexts: [],
       };
-      expect(Permission.is_allowed_any('read', 'Program'))
+      expect(Permission.isAllowedAny('read', 'Program'))
         .toEqual(false);
     });
   });
 
-  describe('page_context_id() method', function () {
+  describe('pageContextId() method', function () {
     it('return page instance context id', function () {
       let context = {
         id: 711,
       };
       spyOn(CurrentPageUtils, 'getPageInstance')
         .and.returnValue({context: context});
-      expect(Permission.page_context_id()).toEqual(context.id);
+      expect(Permission.pageContextId()).toEqual(context.id);
     });
     it('return null if page instance context is undefined', function () {
-      expect(Permission.page_context_id()).toEqual(null);
+      expect(Permission.pageContextId()).toEqual(null);
     });
   });
 
-  describe('refresh() method', function () {
+  describe('refreshPermissions() method', function () {
     let GGRC_PERMISSIONS;
 
     beforeAll(function () {
@@ -617,7 +589,7 @@ describe('Permission', function () {
       GGRC.permissions = GGRC_PERMISSIONS;
     });
     it('updates permissions', function (done) {
-      Permission.refresh().then(() => {
+      Permission.refreshPermissions().then(() => {
         expect(GGRC.permissions).toEqual('permissions');
         done();
       });

--- a/src/ggrc-client/js/tests/permission_spec.js
+++ b/src/ggrc-client/js/tests/permission_spec.js
@@ -7,7 +7,6 @@ import loMap from 'lodash/map';
 import * as AjaxExtensions from '../plugins/ajax_extensions';
 import * as Permission from '../permission';
 import {makeFakeInstance} from '../../js_specs/spec_helpers';
-import * as CurrentPageUtils from '../plugins/utils/current-page-utils';
 import UserRole from '../models/service-models/user-role';
 import Audit from '../models/business-models/audit';
 import {getInstance} from '../plugins/utils/models-utils';
@@ -558,20 +557,6 @@ describe('Permission', function () {
       };
       expect(Permission.isAllowedAny('read', 'Program'))
         .toEqual(false);
-    });
-  });
-
-  describe('pageContextId() method', function () {
-    it('return page instance context id', function () {
-      let context = {
-        id: 711,
-      };
-      spyOn(CurrentPageUtils, 'getPageInstance')
-        .and.returnValue({context: context});
-      expect(Permission.pageContextId()).toEqual(context.id);
-    });
-    it('return null if page instance context is undefined', function () {
-      expect(Permission.pageContextId()).toEqual(null);
     });
   });
 

--- a/src/ggrc-client/js_specs/models/cacheable_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_spec.js
@@ -25,7 +25,8 @@ describe('Cacheable model', () => {
   beforeEach(() => {
     origGcaDefs = GGRC.custom_attr_defs;
     dummyable = Mixin;
-    spyOn(dummyable, 'add_to');
+
+    spyOn(dummyable, 'addTo');
     ajaxSpy = spyOn(AjaxExtensions, 'ggrcAjax');
 
     DummyModel = makeFakeModel({
@@ -135,7 +136,7 @@ describe('Cacheable model', () => {
     });
 
     it('applies mixins based on the mixins property', () => {
-      expect(dummyable.add_to)
+      expect(dummyable.addTo)
         .toHaveBeenCalledWith(DummyModel);
     });
   });

--- a/src/ggrc-client/js_specs/models/cacheable_spec.js
+++ b/src/ggrc-client/js_specs/models/cacheable_spec.js
@@ -24,7 +24,7 @@ describe('Cacheable model', () => {
 
   beforeEach(() => {
     origGcaDefs = GGRC.custom_attr_defs;
-    dummyable = Mixin.extend({}, {});
+    dummyable = Mixin;
     spyOn(dummyable, 'add_to');
     ajaxSpy = spyOn(AjaxExtensions, 'ggrcAjax');
 


### PR DESCRIPTION
# Issue description

Replace can.Construct with class syntax or just a set of functions

# Steps to test the changes

It is necessary to test all the functionality where the can.Constructor was replaced by class syntax.
Main areas for testing:
1. Create an object, fill the fields and save.
2. Open an object, edit some fields and save.
3. Map to Program a snapshotable object and open it in Audit.

# Solution description

Actually can.Construct is used in some places. can.Construct was created like facade for prototypes. Replace can.Construct with class syntax.This improves code readability with basic class syntax. Also remove unused property `null_queue` in refresh_queue model, function `getCurrentPageWidgets` in widget_list module, function `pageContextId` in permission, check for `instanceof canConstruct` in snapshot-utils and `can-construct` dependency.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".