### PR TITLE
GGRC-7483 Cannot autogenerate tickets for assessments that are in 'In Progress' and 'Rework Needed' statuses

### DIFF
--- a/src/ggrc/integrations/constants.py
+++ b/src/ggrc/integrations/constants.py
@@ -100,12 +100,12 @@ STATUSES_MAPPING = {
 }
 
 CREATE_STATUSES_MAPPING = {
-  "Not Started": "ASSIGNED",
-  "In Progress": "ASSIGNED",
-  "In Review": "FIXED",
-  "Rework Needed": "ASSIGNED",
-  "Completed": "VERIFIED",
-  "Deprecated": "OBSOLETE"
+    "Not Started": "ASSIGNED",
+    "In Progress": "ASSIGNED",
+    "In Review": "FIXED",
+    "Rework Needed": "ASSIGNED",
+    "Completed": "VERIFIED",
+    "Deprecated": "OBSOLETE"
 }
 
 # Status transitions map for assessment with verifier.

--- a/src/ggrc/integrations/constants.py
+++ b/src/ggrc/integrations/constants.py
@@ -99,6 +99,15 @@ STATUSES_MAPPING = {
     "Deprecated": "OBSOLETE"
 }
 
+CREATE_STATUSES_MAPPING = {
+  "Not Started": "ASSIGNED",
+  "In Progress": "ASSIGNED",
+  "In Review": "FIXED",
+  "Rework Needed": "ASSIGNED",
+  "Completed": "VERIFIED",
+  "Deprecated": "OBSOLETE"
+}
+
 # Status transitions map for assessment with verifier.
 VERIFIER_STATUSES = {
     # (from_status, to_status, verified): 'issue_tracker_status'

--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -154,7 +154,8 @@ class AssessmentTrackerHandler(object):
 
     integration_utils.populate_issue_tracker_fields(
         assessment,
-        issue_tracker_info
+        issue_tracker_info,
+        create_mode=True,
     )
     issue_info = cls._update_with_assmt_data_for_ticket_create(
         assessment,
@@ -1493,9 +1494,7 @@ class AssessmentTrackerHandler(object):
         "reporter": issue_info["reporter"],
         "assignee": issue_info["assignee"],
         "verifier": issue_info["assignee"],
-        "status": constants.STATUSES_MAPPING.get(
-            assessment.status
-        ),
+        "status": constants.CREATE_STATUSES_MAPPING.get(assessment.status),
         "ccs": issue_info["cc_list"],
         "comment": cls._get_create_comment(assessment)
     }

--- a/src/ggrc/models/hooks/issue_tracker/integration_utils.py
+++ b/src/ggrc/models/hooks/issue_tracker/integration_utils.py
@@ -41,7 +41,7 @@ def normalize_issue_tracker_info(info):
 
 
 def populate_issue_tracker_fields(assmt, issue_tracker_info,
-                                  with_update=False):
+                                  with_update=False, create_mode=False):
   """Populate issue tracker fields values.
 
   Current list of fields with default values: component_id, hotlist_id,
@@ -81,9 +81,9 @@ def populate_issue_tracker_fields(assmt, issue_tracker_info,
     issue_tracker_info["title"] = assmt.title
 
   if not issue_tracker_info.get("status"):
-    issue_tracker_info["status"] = constants.STATUSES_MAPPING.get(
-        assmt.status
-    )
+    status_mapping = constants.CREATE_STATUSES_MAPPING if create_mode else \
+        constants.STATUSES_MAPPING
+    issue_tracker_info["status"] = status_mapping.get(assmt.status)
 
   if not issue_tracker_info.get('due_date'):
     issue_tracker_info['due_date'] = assmt.start_date

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -730,13 +730,24 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
     )
     self.assertNotEqual(int(issue_tracker_issue.issue_id), TICKET_ID)
 
+  @ddt.data(
+      ('Completed', 'VERIFIED'),
+      ('In Progress', 'ASSIGNED'),
+      ('Rework Needed', 'ASSIGNED'),
+      ('Deprecated', 'OBSOLETE'),
+      ('In Review', 'FIXED'),
+  )
+  @ddt.unpack
   @mock.patch('ggrc.integrations.issues.Client.create_issue')
   @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
-  def test_complete_assessment_create_issue(self, mock_create_issue):
-    """Test the creation of issue for completed assessment."""
+  def test_complete_assessment_create_issue(self,
+                                            assmt_status,
+                                            expected_status,
+                                            mock_create_issue):
+    """Test the creation of ticket for assessment in {0} state."""
     audit = factories.AuditFactory()
-
-    self.api.post(all_models.Assessment, {
+    # self._create_assessment_via_api(audit, assmt_status)
+    response = self.api.post(all_models.Assessment, {
         'assessment': {
             'title': 'Assessment1',
             'context': None,
@@ -744,10 +755,11 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
                 'id': audit.id,
                 'type': audit.type,
             },
-            'status': 'Completed',
+            'status': assmt_status,
         }
     })
-    asmt = all_models.Assessment.query.filter_by(title='Assessment1').one()
+    self.assert201(response)
+    asmt = all_models.Assessment.query.one()
 
     with mock.patch.object(
         assessment_integration.AssessmentTrackerHandler,
@@ -765,9 +777,8 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
       }
       self.api.put(asmt, {'issue_tracker': issue_params})
       mock_create_issue.assert_called_once()
-      # pylint: disable=W0212
-      self.assertEqual(mock_create_issue._mock_call_args[0][0]['status'],
-                       'VERIFIED')
+      self.assertEqual(mock_create_issue.call_args[0][0]['status'],
+                       expected_status)
 
   @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
   def test_update_issuetracker_info(self):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Steps to reproduce:
1. Log in ggrc app and open Audit with Issue Tracker OFF
2. Create 2 assessments and move to 'In Progress' and 'Rework Needed' statuses
3. Switch ON Issue Tracker for the Audit:
Component ID: 64445
Hotlist ID: 700706
4. Open Edit modal of any assessment which in 'In Progress' and 'Rework Needed' statuses and Switch ON Issue Tracker > Save
Actual Result: 'Unable to create a ticket' is displayed screenshot-1.png 
5. Open Audit Info tab and click on Generate button
Actual Result: Error while generating Assessments is shown. Issue Tracker doesn't allow to create a ticket in 'Accepted' state.
Expected Result: Allow to autogenerate tickets for assessments that are in 'In Progress' and 'Rework Needed' statuses and status of the ticket should be 'Assigned' in Issue Tracker
# Steps to test the changes

1. reproduce issue description. 
2. create ticket for not linked assessment in In progress or Rework Needed state.

these changes are deployed to maximb-with-import instance on our test env.
# Solution description

It was a problem with business requirements for statuses mapping. As Issue Tracker doesn't allow to creeate tickets in "ACCEPTED" state wi will create tickets in assigned state for these statuses. They would be updated by cron job. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
