### PR TITLE
GGRC-7496 Fix assessment export errors cased by caching and LCAs

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -597,6 +597,11 @@ class ExportBlockConverter(BlockConverter):
     """Generate 2D array with csv header description."""
     headers = []
     for field in self.fields:
+      if field not in self.object_headers:
+        # There may be cases when self.fields contains local custom attribute
+        # fields passed from FE, but self.object_headers does not have them
+        # since there are no such LCAs for objects being exported.
+        continue
       description = self.object_headers[field]["description"]
       display_name = self.object_headers[field]["display_name"]
       if self.object_headers[field]["mandatory"]:


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There is case when particular assessment is being exported and it does not have all LCAs that FE passed to BE. And since only CADs of objects being exported are cached, a `KeyError` occures.

# Steps to test the changes

1. Log in ggrc app;
2. Export any assessment but select LCAs which exported assessment does not have;

**Expected result: there should not be any errors during assessment export.**

# Solution description

Check if field is present in `self.object_headers` during `generate_csv_header` method before trying to get this field form `self.object_headers`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
