### PR TITLE
GGRC-7083 Fix creating custom role with wrong options

### DIFF
--- a/src/ggrc/services/resources/access_controle_role.py
+++ b/src/ggrc/services/resources/access_controle_role.py
@@ -21,9 +21,11 @@ class AccessControlRoleResource(common.Resource):
       access_control_role_options = item.get('access_control_role', {})
       if all(role in access_control_role_options for role in ROLE_PERMISSIONS):
         if (
-            access_control_role_options['delete'] and
-            access_control_role_options['update'] and not
+            (
+                access_control_role_options['delete'] or
+                access_control_role_options['update']
+            ) and not
             access_control_role_options['read']
         ):
           raise ValueError(u"User can't create role with permissions: "
-                           u"delete, edit and no read")
+                           u"delete or edit and no read")

--- a/test/integration/ggrc/access_control/test_access_control_role.py
+++ b/test/integration/ggrc/access_control/test_access_control_role.py
@@ -208,19 +208,25 @@ class TestAccessControlRole(TestCase):
     response = self.api.delete(acr)
     self.assertEqual(response.status_code, 405)
 
-  def test_create_with_wrong_options(self):
+  @ddt.data(
+      {"name": "Test 1", "update": False, "read": False, "delete": True},
+      {"name": "Test 2", "update": True, "read": False, "delete": False},
+      {"name": "Test 3", "update": True, "read": False, "delete": True},
+  )
+  @ddt.unpack
+  def test_create_with_wrong_options(self, name, update, read, delete):
     """ Test if user create ACR with wrong options."""
     options = [{
         'access_control_role':
             {
-                'name': 'Test',
                 'modal_title': 'Add Custom Role to type Regulation',
-                'read': False,
                 'object_type': 'Regulation',
                 'parent_type': 'Regulation',
-                'update': True,
                 'context': {'id': None},
-                'delete': True
+                'delete': delete,
+                'update': update,
+                'read': read,
+                'name': name
             }
     }]
     response = self.api.post(AccessControlRole, options)


### PR DESCRIPTION
# Issue description

User can to create custom role with configuration: (read: no and edit: yes or delete: yes).

# Steps to test the changes

1 Log in as Global Admin.
2 Try to add a custom role with configuration (read - no and edit - yes or delete - yes).
3 Custom role is NOT created.

# Solution description

Added checking of options during creating new custom role. If options are wrong we will raise ValueError and return 400 response code.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".