### PR TITLE
GGRC-6022 Fix to add folder via import

### DIFF
--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -722,8 +722,15 @@ class Folderable(WithProtectedAttributes):
       reflection.Attribute('folder', update=False),
   )
   _fulltext_attrs = ['folder']
-  _aliases = {"folder": "Folder"}
-
+  _aliases = {
+      "folder": {
+          "display_name": "Gdrive Folder ID",
+          "description": ("Add 'Folder ID' that is part of "
+                          "drive link to a folder "
+                          "'https://drive.google.com/corp/drive/folders/XXX', "
+                          "where XXX is a 'Folder ID'")
+      }
+  }
   PROTECTED_ATTRIBUTES = {"folder"}
 
 

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -124,7 +124,7 @@ class TestExportSnapshots(TestCase):
                                         control.documents_reference_url),
             "Assertions": u",".join(json.loads(control.assertions)),
             "Categories": u",".join(json.loads(control.categories)),
-            "Folder": u"",
+            "Gdrive Folder ID": u"",
             "Archived": u"yes" if audit.archived else u"no",
             # Computed attributes
             "Last Assessment Date": u"",
@@ -257,7 +257,7 @@ class TestExportSnapshots(TestCase):
             'Created Date': control.created_at.strftime(DATE_FORMAT_US),
             'Last Updated Date': control.updated_at.strftime(DATE_FORMAT_US),
             'Last Updated By': "",
-            "Folder": u"",
+            "Gdrive Folder ID": u"",
         }
         for snapshot, control in zip(snapshots, controls)
     }
@@ -444,7 +444,7 @@ class TestExportSnapshots(TestCase):
           'Created Date': control.created_at.strftime(DATE_FORMAT_US),
           'Last Updated Date': control.updated_at.strftime(DATE_FORMAT_US),
           'Last Updated By': "",
-          "Folder": u"",
+          "Gdrive Folder ID": u"",
           "Archived": u"yes" if audit.archived else u"no",
       }
       control_dicts[control.slug].update(**control_acr_people[control.slug])

--- a/test/integration/ggrc/converters/test_import_csv.py
+++ b/test/integration/ggrc/converters/test_import_csv.py
@@ -500,6 +500,21 @@ class TestBasicCsvImport(TestCase):
     self.assertEqual(models.all_models.Assessment.query.count(), 0)
     self.assertEqual(models.all_models.Revision.query.count(), 0)
 
+  def test_import_object_with_folder(self):
+    """Test checks to add folder via import"""
+    folder_id = '1WXB8oulc68ZWdFhX96Tv1PBLi8iwALR3'
+    response = self.import_data(OrderedDict([
+        ("object_type", "Program"),
+        ("Code*", "program-1"),
+        ("Program managers", "user@example.com"),
+        ("Title", "program-1"),
+        ("Gdrive Folder ID", folder_id)
+
+    ]))
+    self._check_csv_response(response, {})
+    program = models.Program.query.first()
+    self.assertEqual(program.folder, folder_id)
+
 
 @base.with_memcache
 class TestImportPermissions(TestCase):

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -104,7 +104,7 @@ class TestCustomAttributesDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
     }
     expected_names = element_names.union(mapping_names)
     self.assertEqual(expected_names, display_names)
@@ -157,7 +157,7 @@ class TestCustomAttributesDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Send by default",
         "Recipients",
         "Comments",
@@ -352,7 +352,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Send by default",
         "Recipients",
         "Comments",
@@ -391,7 +391,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Last Deprecated Date",
         "Component ID",
         "Hotlist ID",
@@ -549,7 +549,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Last Updated Date",
         "Last Updated By",
         "Ticket Tracker",
-        "Folder",
+        "Gdrive Folder ID",
         "Component ID",
         "Hotlist ID",
         "Severity",
@@ -597,7 +597,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
     }
     self._test_single_object(all_models.Policy, names, self.COMMON_EXPECTED)
 
@@ -626,7 +626,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Assessment Procedure",
         "Last Deprecated Date",
         "Effective Date",
-        "Folder",
+        "Gdrive Folder ID",
     }
     self._test_single_object(all_models.Requirement, names,
                              self.COMMON_EXPECTED)
@@ -663,7 +663,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
     }
 
     # Control has additional mandatory field - Assertions
@@ -696,7 +696,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Last Updated By",
         "Last Deprecated Date",
         "Effective Date",
-        "Folder",
+        "Gdrive Folder ID",
     }
     self._test_single_object(all_models.Objective, names, self.COMMON_EXPECTED)
 
@@ -746,7 +746,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Primary Contacts",
         "Secondary Contacts",
         "Line of Defense One Contacts",
@@ -780,7 +780,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Primary Contacts",
         "Secondary Contacts",
     }
@@ -812,7 +812,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Primary Contacts",
         "Secondary Contacts",
     }
@@ -839,7 +839,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Threat Source",
         "Vulnerability",
         "Threat Event",
@@ -895,7 +895,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Document File",
         "Primary Contacts",
         "Secondary Contacts",
@@ -932,7 +932,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
     }
     self._test_single_object(model, names, self.COMMON_EXPECTED)
 
@@ -970,7 +970,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Created Date",
         "Last Updated Date",
         "Last Updated By",
-        "Folder",
+        "Gdrive Folder ID",
         "Primary Contacts",
         "Secondary Contacts",
     }

--- a/test/integration/ggrc/converters/test_snapshot_block.py
+++ b/test/integration/ggrc/converters/test_snapshot_block.py
@@ -100,7 +100,7 @@ class TestSnapshotBlockConverter(TestCase):
         ('updated_at', 'Last Updated Date'),
         ('modified_by', 'Last Updated By'),
         ('created_at', 'Created Date'),
-        ('folder', "Folder"),
+        ('folder', "Gdrive Folder ID"),
     ]
     ac_roles = db.session.query(all_models.AccessControlRole.name).filter(
         all_models.AccessControlRole.object_type == "Control",

--- a/test/integration/ggrc/models/test_export_models.py
+++ b/test/integration/ggrc/models/test_export_models.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Tests export functionality."""
+from integration.ggrc import generator
+from integration.ggrc import TestCase
+from integration.ggrc.models import factories
+
+
+class TestBasicExport(TestCase):
+  """Test basic class for checking export."""
+
+  def setUp(self):
+    super(TestBasicExport, self).setUp()
+    self.client.get("/login")
+    self.generator = generator.ObjectGenerator()
+
+  def test_export_folder(self):
+    """Test checks folder attr export."""
+    folder_id = "1WXB8oulc68ZWdFhX96Tv1PBLi8iwALR3"
+    attr_name = "Gdrive Folder ID"
+    factories.AuditFactory(folder=folder_id)
+
+    data = [{
+        "object_name": "Audit",
+        "filters": {
+            "expression": {}
+        },
+        "fields": "all"
+    }]
+    response = self.export_parsed_csv(data)["Audit"][0]
+    self.assertTrue(attr_name in response)
+    self.assertTrue(response[attr_name] == folder_id)

--- a/test/integration/ggrc/test_csvs/issue_for_import.csv
+++ b/test/integration/ggrc/test_csvs/issue_for_import.csv
@@ -5,6 +5,6 @@ Deprecated
 Fixed
 Fixed and Verified ",,,New line separated list of Reference URLs.,,,,,,,List of people with 'Admin' role,"DELIMITER="";;"" double semi-colon separated values"
 Issue,Code*,Title*,Description,Notes,Remediation Plan,Effective Date,Last Deprecated Date,"Due Date*
-",State,Recipients,Send by default,Reference URL,Last Updated Date,Last Updated By,Created Date,Folder,Delete,Ticket Tracker,Admin*,Comments
+",State,Recipients,Send by default,Reference URL,Last Updated Date,Last Updated By,Created Date,Gdrive Folder ID,Delete,Ticket Tracker,Admin*,Comments
 ,ISSUE-1009,asdadsdasdadas,,,,,,11/20/2019,Draft,"Admin,Primary Contacts,Secondary Contacts",yes,,09/17/2018,user@example.com,09/17/2018,,,,user@example.com,
 ,,,,,,,,,,,,,,,,,,,,

--- a/test/integration/ggrc_workflows/converters/test_column_definitions.py
+++ b/test/integration/ggrc_workflows/converters/test_column_definitions.py
@@ -61,7 +61,7 @@ class TestWorkflowObjectColumnDefinitions(TestCase):
         'Created Date',
         'Last Updated Date',
         'Last Updated By',
-        'Folder',
+        'Gdrive Folder ID',
     }
     self.assertEqual(expected_names, display_names)
     vals = {val["display_name"]: val for val in definitions.itervalues()}


### PR DESCRIPTION
# Issue description

User can not add folder via import.

# Steps to test the changes

1. Export any object to Google Sheet, e.g. Control 
2. Add Folder to Control 
3. Import Control 
4. Open Control in UI and look at the folder: folder is displayed

# Solution description

folder display_name was changed and help_text was added for folder

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".