### PR TITLE
GGRC-6765 Replace `class` to `constructor` in templates and JS

### DIFF
--- a/src/ggrc-client/js/components/access-control-list/access-control-list-roles-helper.js
+++ b/src/ggrc-client/js/components/access-control-list/access-control-list-roles-helper.js
@@ -31,7 +31,7 @@ export default canComponent.extend({
     setAutoPopulatedRoles: function () {
       let instance = this.attr('instance');
       let autoPopulatedRoles =
-        loFilter(getRolesForType(instance.class.model_singular), {
+        loFilter(getRolesForType(instance.constructor.model_singular), {
           default_to_current_user: true,
         });
 

--- a/src/ggrc-client/js/components/add-issue-button/add-issue-button.js
+++ b/src/ggrc-client/js/components/add-issue-button/add-issue-button.js
@@ -28,8 +28,8 @@ export default canComponent.extend({
               title: instance.title,
               id: instance.id,
               type: instance.type,
-              title_singular: instance.class.title_singular,
-              table_singular: instance.class.table_singular,
+              title_singular: instance.constructor.title_singular,
+              table_singular: instance.constructor.table_singular,
             },
           };
 

--- a/src/ggrc-client/js/components/add-issue-button/tests/add-issue-button_spec.js
+++ b/src/ggrc-client/js/components/add-issue-button/tests/add-issue-button_spec.js
@@ -5,7 +5,7 @@
 
 import loAttempt from 'lodash/attempt';
 import loIsError from 'lodash/isError';
-import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import {getComponentVM, makeFakeInstance} from '../../../../js_specs/spec_helpers';
 import Component from '../add-issue-button';
 import '../add-issue-button';
 import {REFRESH_RELATED} from '../../../events/eventTypes';
@@ -78,12 +78,6 @@ describe('add-issue-button component', function () {
   describe('prepareJSON get() method', function () {
     let isJson;
 
-    beforeEach(function () {
-      viewModel.attr('relatedInstance', {
-        'class': {},
-      });
-    });
-
     beforeAll(function () {
       isJson = function (str) {
         return !loIsError(loAttempt(JSON.parse, str));
@@ -98,15 +92,11 @@ describe('add-issue-button component', function () {
     describe('for returned json-format string', function () {
       it('sets assessment field', function () {
         let result;
-        let relatedInstance = {
+        let relatedInstance = makeFakeInstance({model: Issue})({
           title: 'title',
           id: 1,
           type: 'type',
-          'class': {
-            title_singular: 'title singular',
-            table_singular: 'table singular',
-          },
-        };
+        });
 
         viewModel.attr('relatedInstance', relatedInstance);
         result = viewModel.attr('prepareJSON');
@@ -114,8 +104,8 @@ describe('add-issue-button component', function () {
           title: relatedInstance.title,
           id: relatedInstance.id,
           type: relatedInstance.type,
-          title_singular: relatedInstance.class.title_singular,
-          table_singular: relatedInstance.class.table_singular,
+          title_singular: relatedInstance.constructor.title_singular,
+          table_singular: relatedInstance.constructor.table_singular,
         });
       });
     });

--- a/src/ggrc-client/js/components/add-object-button/add-object-button.stache
+++ b/src/ggrc-client/js/components/add-object-button/add-object-button.stache
@@ -10,7 +10,7 @@
       text:from="text"
       objectType:from="singular"
       parentId:from="instance.id"
-      parentType:from="instance.class.model_singular">
+      parentType:from="instance.constructor.model_singular">
       {{content}}
     </assessment-template-clone-button>
   {{else}}

--- a/src/ggrc-client/js/components/add-tab-button/add-tab-button.stache
+++ b/src/ggrc-client/js/components/add-tab-button/add-tab-button.stache
@@ -31,7 +31,7 @@
                 data-object-singular="{{model.title_singular}}"
                 data-object-plural="{{model.table_plural}}"
                 data-object-params='{
-                  "{{instance.class.table_singular}}": {
+                  "{{instance.constructor.table_singular}}": {
                     "id": {{instance.id}},
                     "type": "{{instance.type}}"
                   },
@@ -67,8 +67,8 @@
                       data-toggle="unified-mapper"
                       data-join-option-type="{{model.model_singular}}"
                       data-join-object-id="{{instance.id}}"
-                      data-join-object-type="{{instance.class.model_singular}}"
-                      {{#if instance.class.isMegaObject}}
+                      data-join-object-type="{{instance.constructor.model_singular}}"
+                      {{#if instance.constructor.isMegaObject}}
                         {{#is instance.type model.model_singular}}
                           data-mega-object="true"
                           data-mega-object-widget="{{id}}"

--- a/src/ggrc-client/js/components/assessment-templates/people-list/people-list.js
+++ b/src/ggrc-client/js/components/assessment-templates/people-list/people-list.js
@@ -34,7 +34,7 @@ export default canComponent.extend({
           if (this.attr('selectedValue')) {
             let listName = this.attr('listName');
             let defaultValue = this.attr('instance')
-              .class.defaults.default_people[listName];
+              .constructor.defaults.default_people[listName];
             let currentValue = this.attr('selectedValue');
             let isPresent = newValue.attr().findIndex((el) => {
               return el.value === currentValue;

--- a/src/ggrc-client/js/components/assessment/info-pane/info-pane-issue-tracker-fields.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/info-pane-issue-tracker-fields.js
@@ -18,7 +18,7 @@ export default canComponent.extend({
       isTicketIdMandatory: {
         get() {
           let instance = this.attr('instance');
-          return instance.class.unchangeableIssueTrackerIdStatuses
+          return instance.constructor.unchangeableIssueTrackerIdStatuses
             .includes(instance.attr('status'));
         },
       },

--- a/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
@@ -16,7 +16,7 @@
         <inline-edit-control
           on:inlineSave="checkTicketId(scope.event)"
           isEditIconDenied:from="isEditDenied"
-          dropdownOptions:from="instance.class.issue_tracker_enable_options"
+          dropdownOptions:from="instance.constructor.issue_tracker_enable_options"
           instance:from="instance"
           value:from="issueTrackerEnabled"
           type:from="'dropdown'">
@@ -140,7 +140,7 @@
       isConfirmationNeeded:from="false"
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
-      dropdownOptions:from="instance.class.issue_tracker_priorities"
+      dropdownOptions:from="instance.constructor.issue_tracker_priorities"
       isEditIconDenied:from="isEditDenied"
       value:from="instance.issue_tracker.issue_priority"
       instance:from="instance">
@@ -154,7 +154,7 @@
       isConfirmationNeeded:from="false"
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
-      dropdownOptions:from="instance.class.issue_tracker_severities"
+      dropdownOptions:from="instance.constructor.issue_tracker_severities"
       isEditIconDenied:from="isEditDenied"
       value:from="instance.issue_tracker.issue_severity"
       instance:from="instance">

--- a/src/ggrc-client/js/components/assessment/mapped-control-related-objects/mapped-control-related-objects.stache
+++ b/src/ggrc-client/js/components/assessment/mapped-control-related-objects/mapped-control-related-objects.stache
@@ -24,14 +24,14 @@
           <h6>Description</h6>
           <read-more
             text:from="description"
-            handleMarkdown:from="instance.class.isChangeableExternally">
+            handleMarkdown:from="instance.constructor.isChangeableExternally">
           </read-more>
       </div>
       <div class="mapped-object-info__item">
           <h6>Notes</h6>
           <read-more
             text:from="notes"
-            handleMarkdown:from="instance.class.isChangeableExternally">
+            handleMarkdown:from="instance.constructor.isChangeableExternally">
           </read-more>
       </div>
 

--- a/src/ggrc-client/js/components/custom-roles/custom-roles-vm.js
+++ b/src/ggrc-client/js/components/custom-roles/custom-roles-vm.js
@@ -16,7 +16,7 @@ export default canMap.extend({
         }
 
         let readonly = this.attr('readOnly');
-        return instance.class.isProposable
+        return instance.constructor.isProposable
             || readonly
             || instance.attr('readonly');
       },

--- a/src/ggrc-client/js/components/custom-roles/tests/custom-roles_spec.js
+++ b/src/ggrc-client/js/components/custom-roles/tests/custom-roles_spec.js
@@ -4,9 +4,13 @@
 */
 
 import ViewModel from '../custom-roles-vm';
+import Program from '../../../models/business-models/program';
+import Assessment from '../../../models/business-models/assessment';
+import {makeFakeInstance} from '../../../../js_specs/spec_helpers';
 
 describe('custom-roles view model', () => {
   let vm;
+  let instance;
 
   beforeEach(() => {
     vm = new ViewModel();
@@ -22,58 +26,50 @@ describe('custom-roles view model', () => {
       });
     });
 
-    it('returns value of instance.class.isProposable if instance is defined ' +
-      'and readonly is FALSE',
+    it('returns false if instance is defined, isProposable is false and ' +
+    'readonly is false',
     () => {
-      vm.attr('readOnly', false);
-      let instance = {
-        'class': {
-          isProposable: true,
-        },
+      instance = makeFakeInstance({model: Assessment})({
         readonly: false,
-      };
+      });
       vm.attr('instance', instance);
+      vm.attr('readOnly', false);
 
-      expect(vm.attr('isReadonly')).toBe(true);
-
-      vm.attr('instance.class.isProposable', false);
       expect(vm.attr('isReadonly')).toBe(false);
     });
 
-    it('returns value of readOnly prop if instance is defined ' +
-      'and instance.class.isProposable is FALSE',
+    it('returns true if instance is defined, isProposable is true and ' +
+    'readonly is false',
     () => {
-      let instance = {
-        'class': {
-          isProposable: false,
-        },
+      instance = makeFakeInstance({model: Program})({
         readonly: false,
-      };
+      });
       vm.attr('instance', instance);
-
       vm.attr('readOnly', false);
-      expect(vm.attr('isReadonly')).toBe(false);
 
+      expect(vm.attr('isReadonly')).toBe(true);
+    });
+
+    it('returns true if instance is defined, isProposable is false and ' +
+    'readonly is true',
+    () => {
+      instance = makeFakeInstance({model: Assessment})({
+        readonly: true,
+      });
+      vm.attr('instance', instance);
+      vm.attr('readOnly', false);
+      expect(vm.attr('isReadonly')).toBe(true);
+    });
+
+    it('returns true if instance is defined, isProposable is false, ' +
+    'readonly is false and component readOnly is true',
+    () => {
+      instance = makeFakeInstance({model: Assessment})({
+        readonly: false,
+      });
+      vm.attr('instance', instance);
       vm.attr('readOnly', true);
       expect(vm.attr('isReadonly')).toBe(true);
-    });
-
-    it('returns value of instance readonly prop if ' +
-      'component readOnly is FALSE and instance.class.isProposable is FALSE',
-    () => {
-      vm.attr('readOnly', );
-      let instance = {
-        'class': {
-          isProposable: false,
-        },
-        readonly: true,
-      };
-      vm.attr('instance', instance);
-
-      expect(vm.attr('isReadonly')).toBe(true);
-
-      vm.attr('instance.readonly', false);
-      expect(vm.attr('isReadonly')).toBe(false);
     });
   });
 

--- a/src/ggrc-client/js/components/deferred-mapper.js
+++ b/src/ggrc-client/js/components/deferred-mapper.js
@@ -10,6 +10,7 @@ import canMap from 'can-map';
 import canComponent from 'can-component';
 import {
   isSnapshotType,
+  extendSnapshot,
 } from '../plugins/utils/snapshot-utils';
 import * as MapperUtils from '../plugins/utils/mapper-utils';
 import {
@@ -188,15 +189,8 @@ export default canComponent.extend({
       this.attr('list').splice(indexInList, 1);
     },
     addListItem(item) {
-      let snapshotObject;
-
-      if (isSnapshotType(item) &&
-        item.snapshotObject) {
-        snapshotObject = item.snapshotObject;
-        item.attr('title', snapshotObject.title);
-        item.attr('description', snapshotObject.description);
-        item.attr('class', snapshotObject.class);
-        item.attr('viewLink', snapshotObject.originalLink);
+      if (isSnapshotType(item) && item.snapshotObject) {
+        item = extendSnapshot(item, item.snapshotObject);
       } else if (!isSnapshotType(item) && isReifiable(item)) {
         // add full item object from cache
         // if it isn't snapshot

--- a/src/ggrc-client/js/components/delete-button/delete-button.js
+++ b/src/ggrc-client/js/components/delete-button/delete-button.js
@@ -34,7 +34,7 @@ export default canComponent.extend({
     },
     confirmDelete() {
       const instance = this.attr('instance');
-      const model = instance.class;
+      const model = instance.constructor;
       const modalSettings = {
         button_view:
           GGRC.templates_path + '/modals/delete_cancel_buttons.stache',

--- a/src/ggrc-client/js/components/delete-button/delete-button_spec.js
+++ b/src/ggrc-client/js/components/delete-button/delete-button_spec.js
@@ -4,6 +4,7 @@
 */
 
 import canMap from 'can-map';
+import canModel from 'can-model';
 import Component from './delete-button';
 import {getComponentVM} from '../../../js_specs/spec_helpers';
 import {Snapshot} from '../../models/service-models';
@@ -20,6 +21,7 @@ describe('delete-button component', () => {
 
   describe('setter of "instance"', () => {
     let cacheBackup;
+    let instance;
 
     beforeAll(() => {
       cacheBackup = Object.assign({}, Snapshot.cache);
@@ -29,38 +31,55 @@ describe('delete-button component', () => {
       Snapshot.cache = cacheBackup;
     });
 
-    it('returns new instance of Snapshot if setted value does not have class ' +
-    'and its type is "Snapsot"', () => {
-      vm.attr('instance', {
-        type: 'Snapshot',
+    it('returns new instance of Snapshot if it is not instance of canModel ' +
+      'and it is type is "Snapshot"', () => {
+      instance = new canMap({
         id: 1,
-      });
-
-      expect(vm.attr('instance')).toEqual(jasmine.any(Snapshot));
-      expect(vm.attr('instance')).toEqual(jasmine.objectContaining({
         type: 'Snapshot',
-        id: 1,
-      }));
-    });
-
-    it('returns setted instance if it has class', () => {
-      const instance = new canMap({
-        id: 2,
-        'class': 'mockClass',
       });
       vm.attr('instance', instance);
 
-      expect(vm.attr('instance')).toBe(instance);
+      expect(instance instanceof canModel).toBe(false);
+      expect(vm.attr('instance')).toEqual(jasmine.any(Snapshot));
+      expect(vm.attr('instance')).toEqual(jasmine.objectContaining({
+        id: 1,
+        type: 'Snapshot',
+      }));
     });
 
-    it('returns setted instance if it is not type of "Snapshot"', () => {
-      const instance = new canMap({
-        id: 3,
-        'class': 'mockClass',
+    it('returns setted instance if it is not instance of canModel ' +
+      'and it is type is not "Snapshot"', () => {
+      instance = new canMap({
+        id: 2,
         type: 'mockType',
       });
       vm.attr('instance', instance);
 
+      expect(instance instanceof canModel).toBe(false);
+      expect(vm.attr('instance')).toEqual(instance);
+    });
+
+    it('returns setted instance if it is instance of canModel ' +
+      'and it is type is "Snapshot"', () => {
+      instance = new canModel({
+        id: 3,
+        type: 'Snapshot',
+      });
+      vm.attr('instance', instance);
+
+      expect(instance instanceof canModel).toBe(true);
+      expect(vm.attr('instance')).toEqual(instance);
+    });
+
+    it('returns setted instance if it is instance of canModel ' +
+      'and it is not type of "Snapshot"', () => {
+      instance = new canModel({
+        id: 4,
+        type: 'mockType',
+      });
+      vm.attr('instance', instance);
+
+      expect(instance instanceof canModel).toBe(true);
       expect(vm.attr('instance')).toBe(instance);
     });
   });

--- a/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.js
+++ b/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.js
@@ -58,7 +58,8 @@ export default canComponent.extend({
           let instance = this.attr('instance');
           if (instance) {
             return 'No copy will be created. Original files will be added to ' +
-              'the destination ' + instance.class.title_singular + ' folder.';
+              'the destination ' + instance.constructor.title_singular +
+              ' folder.';
           }
         },
       },

--- a/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.stache
+++ b/src/ggrc-client/js/components/folder-attachments-list/folder-attachments-list.stache
@@ -42,7 +42,7 @@
             class="btn btn-small btn-white"
             data-toggle="unified-mapper"
             data-join-object-id="{{instance.id}}"
-            data-join-object-type="{{instance.class.model_singular}}"
+            data-join-object-type="{{instance.constructor.model_singular}}"
             data-join-option-type="Document">
             Attach
         </button>

--- a/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-folder-picker.stache
+++ b/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-folder-picker.stache
@@ -7,7 +7,7 @@
   {{#unless hideLabel}}
     <label class="multi-type-label">
       Attachment
-      <i class="fa fa-question-circle" rel="tooltip" data-original-title="If selected, all {{instance.class.title_singular}} attachments go here."></i>
+      <i class="fa fa-question-circle" rel="tooltip" data-original-title="If selected, all {{instance.constructor.title_singular}} attachments go here."></i>
     </label>
     <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
   {{/unless}}
@@ -33,7 +33,7 @@
               rel="tooltip"
               data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}"
               data-toggle="gdrive-picker"
-              data-model="{{instance.class.model_singular}}"
+              data-model="{{instance.constructor.model_singular}}"
               data-id="{{instance.id}}"
               data-type="folders"
               data-replace="true">
@@ -44,9 +44,9 @@
             {{^if no_detach}}
               <a class="icon-link mapped-folder__action-button"
                 href="javascript://" rel="tooltip"
-                data-original-title="Detach folder from {{instance.class.title_singular}}"
+                data-original-title="Detach folder from {{instance.constructor.title_singular}}"
                 data-toggle="gdrive-remover"
-                data-model="{{instance.class.model_singular}}"
+                data-model="{{instance.constructor.model_singular}}"
                 data-id="{{instance.id}}">
                   <action-toolbar-control>
                     <i class="fa fa-trash"></i>
@@ -61,18 +61,18 @@
       {{#if folder_error}}
         <div class="action-toolbar">
           <small>
-            <strong>Warning:</strong> You need permission to access {{instance.class.title_singular}} folder. <a href="https://drive.google.com/folderview?id={{folderId}}&usp=sharing#">Request access.</a>
+            <strong>Warning:</strong> You need permission to access {{instance.constructor.title_singular}} folder. <a href="https://drive.google.com/folderview?id={{folderId}}&usp=sharing#">Request access.</a>
           </small>
           <div class="action-toolbar__controls">
             {{^if readonly}}
-              <a class="icon-link entry-attachment" href="javascript://" rel="tooltip" data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}" data-toggle="gdrive-picker" data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}" data-type="folders" data-replace="true">
+              <a class="icon-link entry-attachment" href="javascript://" rel="tooltip" data-original-title="{{firstnonempty placeholder 'Choose a new folder'}}" data-toggle="gdrive-picker" data-model="{{instance.constructor.model_singular}}" data-id="{{instance.id}}" data-type="folders" data-replace="true">
                 <action-toolbar-control>
                   <i class="fa fa-pencil"></i>
                 </action-toolbar-control>
               </a>
               {{^if no_detach}}
-                <a class="icon-link" href="javascript://" rel="tooltip" data-original-title="Detach folder from {{instance.class.title_singular}}" data-toggle="gdrive-remover"
-                  data-model="{{instance.class.model_singular}}" data-id="{{instance.id}}">
+                <a class="icon-link" href="javascript://" rel="tooltip" data-original-title="Detach folder from {{instance.constructor.title_singular}}" data-toggle="gdrive-remover"
+                  data-model="{{instance.constructor.model_singular}}" data-id="{{instance.id}}">
                   <action-toolbar-control>
                     <i class="fa fa-trash"></i>
                   </action-toolbar-control>
@@ -87,7 +87,7 @@
           tabindex="{{firstnonempty tabindex '0'}}"
           class="btn btn-white entry-attachment  tree-item-add mapped-folder__add-button"
           data-toggle="gdrive-picker"
-          data-model="{{instance.class.model_singular}}"
+          data-model="{{instance.constructor.model_singular}}"
           data-type="folders"
           data-id="{{instance.id}}">
             Assign folder

--- a/src/ggrc-client/js/components/general-page-header/general-page-header.js
+++ b/src/ggrc-client/js/components/general-page-header/general-page-header.js
@@ -24,7 +24,7 @@ const viewModel = canMap.extend({
       get() {
         const instance = this.attr('instance');
         return (
-          instance.class.isProposable &&
+          instance.constructor.isProposable &&
           !isChangeableExternally(instance) &&
           !isSnapshot(instance)
         );

--- a/src/ggrc-client/js/components/general-page-header/templates/general-page-header.stache
+++ b/src/ggrc-client/js/components/general-page-header/templates/general-page-header.stache
@@ -29,7 +29,7 @@
           </div>
           {{#if snapshot}}
             <span class="pane-header__title-item">
-              <span class="state-value snapshot">{{instance.class.title_singular}} version as at {{dateTime instance.updated_at}}</span>
+              <span class="state-value snapshot">{{instance.constructor.title_singular}} version as at {{dateTime instance.updated_at}}</span>
             </span>
           {{/if}}
           {{#if status}}
@@ -68,8 +68,8 @@
                   data-toggle="modal-ajax-form"
                   data-modal-reset="reset"
                   data-modal-class="modal-wide"
-                  data-object-singular="{{instance.class.model_singular}}"
-                  data-object-plural="{{instance.class.table_plural}}"
+                  data-object-singular="{{instance.constructor.model_singular}}"
+                  data-object-plural="{{instance.constructor.table_plural}}"
                   data-object-id="{{instance.id}}">
                     Propose Changes
                 </a>

--- a/src/ggrc-client/js/components/global-custom-attributes/global-custom-attributes.js
+++ b/src/ggrc-client/js/components/global-custom-attributes/global-custom-attributes.js
@@ -53,7 +53,7 @@ export default canComponent.extend({
         return false;
       }
 
-      return instance.class.isProposable || instance.attr('readonly');
+      return instance.constructor.isProposable || instance.attr('readonly');
     },
     initCustomAttributes: function () {
       const instance = this.attr('instance');

--- a/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
+++ b/src/ggrc-client/js/components/issue-tracker/modal-issue-tracker-fields.js
@@ -25,9 +25,9 @@ export default canComponent.extend({
     setTicketIdMandatory() {
       let instance = this.attr('instance');
 
-      if (instance.class.unchangeableIssueTrackerIdStatuses) {
+      if (instance.constructor.unchangeableIssueTrackerIdStatuses) {
         this.attr('isTicketIdMandatory',
-          instance.class.unchangeableIssueTrackerIdStatuses
+          instance.constructor.unchangeableIssueTrackerIdStatuses
             .includes(instance.attr('status')));
       }
     },

--- a/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/issue-tracker/templates/modal-issue-tracker-fields.stache
@@ -25,7 +25,7 @@
     </div>
     <div class="ggrc-form-item__multiple-row">
       <dropdown-component class="issue-tracker__dropdown"
-          optionsList:from="instance.class.issue_tracker_enable_options"
+          optionsList:from="instance.constructor.issue_tracker_enable_options"
           name:bind="isIntegrationEnabled"
       ></dropdown-component>
       {{#if_instance_of instance 'Audit'}}
@@ -117,7 +117,7 @@
       <label class="ggrc-form-item__label">
         Ticket Priority
       </label>
-      <dropdown-component optionsList:from="instance.class.issue_tracker_priorities"
+      <dropdown-component optionsList:from="instance.constructor.issue_tracker_priorities"
                 name:bind="instance.issue_tracker.issue_priority">
       </dropdown-component>
     </div>
@@ -126,7 +126,7 @@
         Ticket Severity
       </label>
       <dropdown-component instance:from="instance"
-                optionsList:from="instance.class.issue_tracker_severities"
+                optionsList:from="instance.constructor.issue_tracker_severities"
                 name:bind="instance.issue_tracker.issue_severity">
       </dropdown-component>
     </div>

--- a/src/ggrc-client/js/components/issue/issue-unmap-item.js
+++ b/src/ggrc-client/js/components/issue/issue-unmap-item.js
@@ -151,7 +151,7 @@ export default canComponent.extend({
     showNoRelationshipError() {
       const issueTitle = this.attr('issueInstance.title');
       const targetTitle = this.attr('target.title');
-      const targetType = this.attr('target').class.title_singular;
+      const targetType = this.attr('target').constructor.title_singular;
 
       notifier('error',
         `Unmapping cannot be performed.

--- a/src/ggrc-client/js/components/issue/tests/issue-unmap-item_spec.js
+++ b/src/ggrc-client/js/components/issue/tests/issue-unmap-item_spec.js
@@ -4,13 +4,14 @@
 */
 
 import canMap from 'can-map';
-import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import {getComponentVM, makeFakeInstance} from '../../../../js_specs/spec_helpers';
 import Component from '../issue-unmap-item';
 import * as QueryAPI from '../../../plugins/utils/query-api-utils';
 import * as CurrentPageUtils from '../../../plugins/utils/current-page-utils';
 import * as NotifiersUtils from '../../../plugins/utils/notifiers-utils';
 import Relationship from '../../../models/service-models/relationship';
 import * as businessModels from '../../../models/business-models';
+import Issue from '../../../models/business-models/issue';
 
 describe('issue-unmap-item component', () => {
   let viewModel;
@@ -343,32 +344,33 @@ describe('issue-unmap-item component', () => {
   });
 
   describe('showNoRelationshipError() method', () => {
-    const issueTitle = 'TEST_ISSUE_TITLE';
-    const targetType = 'TEST_TARGET_TYPE';
-    const targetTitle = 'TEST_TARGET_TITLE';
+    let sourceInstance;
+    let destinationInstance;
 
     beforeEach(() => {
-      viewModel.attr('source', {
+      sourceInstance = makeFakeInstance({model: Issue})({
         type: 'Issue',
-        title: issueTitle,
+        title: 'Issue_title',
       });
-      viewModel.attr('destination', {
-        type: targetType,
-        title: targetTitle,
-        'class': {
-          title_singular: targetType,
-        },
+      viewModel.attr('source', sourceInstance);
+
+      destinationInstance = makeFakeInstance({model: Issue})({
+        type: 'Target_type',
+        title: 'Target_title',
       });
+      viewModel.attr('destination', destinationInstance);
+
       spyOn(NotifiersUtils, 'notifier');
     });
 
     it('shows correct message', () => {
       viewModel.showNoRelationshipError();
 
+      const destinationType = destinationInstance.constructor.title_singular;
       expect(NotifiersUtils.notifier).toHaveBeenCalledWith('error',
         `Unmapping cannot be performed.
-        Please unmap Issue (${issueTitle})
-        from ${targetType} version (${targetTitle}),
+        Please unmap Issue (${sourceInstance.title})
+        from ${destinationType} version (${destinationInstance.title}),
         then mapping with original object will be automatically reverted.`);
     });
   });

--- a/src/ggrc-client/js/components/modal-wrappers/assessment-modal.js
+++ b/src/ggrc-client/js/components/modal-wrappers/assessment-modal.js
@@ -7,6 +7,7 @@ import canMap from 'can-map';
 import canComponent from 'can-component';
 import {
   toObject,
+  extendSnapshot,
 } from '../../plugins/utils/snapshot-utils';
 
 export default canComponent.extend({
@@ -20,14 +21,8 @@ export default canComponent.extend({
       return this.attr('instance').getRelatedObjects()
         .then((data) => {
           let snapshots = data.Snapshot.map((snapshot) => {
-            let object = toObject(snapshot);
-
-            snapshot.class = object.class;
-            snapshot.title = object.title;
-            snapshot.description = object.description;
-            snapshot.viewLink = object.originalLink;
-
-            return snapshot;
+            let snapshotObject = toObject(snapshot);
+            return extendSnapshot(snapshot, snapshotObject);
           });
 
           this.attr('mappedObjects', snapshots);

--- a/src/ggrc-client/js/components/modal-wrappers/tests/assessment-modal_spec.js
+++ b/src/ggrc-client/js/components/modal-wrappers/tests/assessment-modal_spec.js
@@ -18,7 +18,6 @@ describe('<assessment-modal/> component', () => {
     vm = getComponentVM(Component);
 
     spyOn(SnapshotUtils, 'toObject').and.returnValue({
-      'class': {},
       title: 'Foo',
       description: 'Bar',
       originalLink: 'Baz',

--- a/src/ggrc-client/js/components/object-cloner/object-cloner.js
+++ b/src/ggrc-client/js/components/object-cloner/object-cloner.js
@@ -32,7 +32,7 @@ export default canComponent.extend({
         modal_title: scope.attr('modalTitle'),
         modal_description: scope.attr('modalDescription'),
         content_view: GGRC.templates_path + '/' +
-          instance.class.root_collection + '/object_cloner.stache',
+          instance.constructor.root_collection + '/object_cloner.stache',
         modal_confirm: 'Clone',
         skip_refresh: true,
         button_view: GGRC.templates_path + '/modals/prompt_buttons.stache',

--- a/src/ggrc-client/js/components/object-list-item/comment-list-item.stache
+++ b/src/ggrc-client/js/components/object-list-item/comment-list-item.stache
@@ -38,7 +38,7 @@
     <div class="comment-object-item__text">
       <read-more
         text:from="commentText"
-        handleMarkdown:from="instance.class.isChangeableExternally">
+        handleMarkdown:from="instance.constructor.isChangeableExternally">
       </read-more>
     </div>
 </div>

--- a/src/ggrc-client/js/components/object-list-item/detailed-business-object-list-item.stache
+++ b/src/ggrc-client/js/components/object-list-item/detailed-business-object-list-item.stache
@@ -7,14 +7,14 @@
     <h6>Description</h6>
     <read-more
       text:from="itemData.description"
-      handleMarkdown:from="instance.class.isChangeableExternally">
+      handleMarkdown:from="instance.constructor.isChangeableExternally">
     </read-more>
 </div>
 <div class="mapped-object-info__item">
     <h6>Notes</h6>
     <read-more
       text:from="itemData.notes"
-      handleMarkdown:from="instance.class.isChangeableExternally">
+      handleMarkdown:from="instance.constructor.isChangeableExternally">
     </read-more>
 </div>
 <div class="mapped-object-info__attributes">

--- a/src/ggrc-client/js/components/page-header/page-header.js
+++ b/src/ggrc-client/js/components/page-header/page-header.js
@@ -97,7 +97,7 @@ let viewModel = canMap.extend({
     },
     model: {
       get() {
-        return this.attr('instance').class;
+        return this.attr('instance').constructor;
       },
     },
     instance: {

--- a/src/ggrc-client/js/components/related-objects/related-issues.stache
+++ b/src/ggrc-client/js/components/related-objects/related-issues.stache
@@ -34,7 +34,7 @@
                         <read-more
                           text:from="instance.description"
                           maxLinesNumber:from="2"
-                          handleMarkdown:from="instance.class.isChangeableExternally">
+                          handleMarkdown:from="instance.constructor.isChangeableExternally">
                         </read-more>
                     </div>
                 </div>

--- a/src/ggrc-client/js/components/related-objects/related-people-access-control.js
+++ b/src/ggrc-client/js/components/related-objects/related-people-access-control.js
@@ -172,7 +172,7 @@ export default canComponent.extend({
     },
     filterByIncludeExclude(includeRoles, excludeRoles) {
       const instance = this.attr('instance');
-      const objectRoles = getRolesForType(instance.class.model_singular);
+      const objectRoles = getRolesForType(instance.constructor.model_singular);
 
       return objectRoles.filter((item) => {
         return loIndexOf(includeRoles, item.name) > -1 &&
@@ -181,14 +181,14 @@ export default canComponent.extend({
     },
     filterByInclude(includeRoles) {
       const instance = this.attr('instance');
-      const objectRoles = getRolesForType(instance.class.model_singular);
+      const objectRoles = getRolesForType(instance.constructor.model_singular);
 
       return objectRoles.filter((item) =>
         loIndexOf(includeRoles, item.name) > -1);
     },
     filterByExclude(excludeRoles) {
       const instance = this.attr('instance');
-      const objectRoles = getRolesForType(instance.class.model_singular);
+      const objectRoles = getRolesForType(instance.constructor.model_singular);
 
       return objectRoles.filter((item) =>
         loIndexOf(excludeRoles, item.name) === -1);
@@ -206,7 +206,7 @@ export default canComponent.extend({
       } else if (excludeRoles.length) {
         roles = this.filterByExclude(excludeRoles);
       } else {
-        roles = getRolesForType(instance.class.model_singular);
+        roles = getRolesForType(instance.constructor.model_singular);
       }
 
       return roles;

--- a/src/ggrc-client/js/components/related-objects/tests/related-people-access-control_spec.js
+++ b/src/ggrc-client/js/components/related-objects/tests/related-people-access-control_spec.js
@@ -3,10 +3,10 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-import canMap from 'can-map';
 import Component from '../related-people-access-control';
-import {getComponentVM} from '../../../../js_specs/spec_helpers';
+import {getComponentVM, makeFakeInstance} from '../../../../js_specs/spec_helpers';
 import * as aclUtils from '../../../plugins/utils/acl-utils';
+import Control from '../../../models/business-models/control';
 
 describe('related-people-access-control component', function () {
   let viewModel;
@@ -112,11 +112,7 @@ describe('related-people-access-control component', function () {
     let getFilteredRolesMethod;
 
     beforeAll(function () {
-      instance = {
-        'class': {
-          model_singular: 'Control',
-        },
-      };
+      instance = makeFakeInstance({model: Control})();
     });
 
     beforeEach(function () {
@@ -176,11 +172,7 @@ describe('related-people-access-control component', function () {
     let instance;
 
     beforeAll(function () {
-      instance = new canMap({
-        'class': {
-          model_singular: 'Control',
-        },
-      });
+      instance = makeFakeInstance({model: Control})();
     });
 
     beforeEach(function () {
@@ -406,11 +398,7 @@ describe('related-people-access-control component', function () {
     ];
 
     beforeAll(function () {
-      instance = new canMap({
-        'class': {
-          model_singular: 'Control',
-        },
-      });
+      instance = makeFakeInstance({model: Control})();
     });
 
     beforeEach(function () {
@@ -542,11 +530,7 @@ describe('related-people-access-control component', function () {
     ];
 
     beforeAll(function () {
-      instance = new canMap({
-        'class': {
-          model_singular: 'Control',
-        },
-      });
+      instance = makeFakeInstance({model: Control})();
     });
 
     beforeEach(function () {

--- a/src/ggrc-client/js/components/tests/deferred-mapper_spec.js
+++ b/src/ggrc-client/js/components/tests/deferred-mapper_spec.js
@@ -516,7 +516,6 @@ describe('deferred-mapper component', function () {
         let snapshotObject = {
           title: 'title',
           description: 'description',
-          'class': 'class',
           originalLink: 'originalLink',
         };
         let item = {snapshotObject};
@@ -527,7 +526,6 @@ describe('deferred-mapper component', function () {
         let expected = jasmine.objectContaining({
           title: snapshotObject.title,
           description: snapshotObject.description,
-          'class': snapshotObject.class,
           viewLink: snapshotObject.originalLink,
         });
         expect(vm.attr('list').serialize()).toEqual([expected]);

--- a/src/ggrc-client/js/components/tree/templates/sub-tree-item.stache
+++ b/src/ggrc-client/js/components/tree/templates/sub-tree-item.stache
@@ -15,7 +15,7 @@
       {{#if isMega}}
         <i class="fa fa-bookmark mega-object-tree-view-icon"></i>
       {{/if}}
-      <i class="fa fa-{{instance.class.table_singular}}"></i>
+      <i class="fa fa-{{instance.constructor.table_singular}}"></i>
       {{title}}
     </span>
       <tree-item-status-for-workflow instance:from="instance"></tree-item-status-for-workflow>

--- a/src/ggrc-client/js/components/tree/templates/tree-item-actions.stache
+++ b/src/ggrc-client/js/components/tree/templates/tree-item-actions.stache
@@ -37,7 +37,7 @@
             {{^if isSnapshot}}
               <li>
                 <questionnaire-link instance:from="instance" showIcon:from="true">
-                  Open {{instance.class.title_singular}} in new frontend
+                  Open {{instance.constructor.title_singular}} in new frontend
                 </questionnaire-link>
               </li>
             {{/if}}
@@ -56,8 +56,8 @@
                 data-toggle="modal-ajax-form"
                 data-modal-reset="reset"
                 data-modal-class="modal-wide"
-                data-object-singular="{{instance.class.model_singular}}"
-                data-object-plural="{{instance.class.table_plural}}"
+                data-object-singular="{{instance.constructor.model_singular}}"
+                data-object-plural="{{instance.constructor.table_plural}}"
                 data-object-id="{{instance.id}}">
                 <i class="fa fa-pencil-square-o"></i>
                 Edit object

--- a/src/ggrc-client/js/components/tree/templates/tree-item-map.stache
+++ b/src/ggrc-client/js/components/tree/templates/tree-item-map.stache
@@ -9,7 +9,7 @@
       data-placement="left"
       data-toggle="unified-mapper"
       data-join-object-id="{{instance.id}}"
-      data-join-object-type="{{instance.class.model_singular}}"
+      data-join-object-type="{{instance.constructor.model_singular}}"
   >
     <i class="fa fa-code-fork"></i>
     {{title}}

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/cycle-task-group-object-task.stache
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/cycle-task-group-object-task.stache
@@ -124,7 +124,7 @@
                   data-toggle="unified-mapper"
                   data-is-refresh-counts-needed="false"
                   data-join-object-id="{{instance.id}}"
-                  data-join-object-type="{{instance.class.model_singular}}">
+                  data-join-object-type="{{instance.constructor.model_singular}}">
                   Map Objects
                 </a>
               {{/if}}
@@ -138,7 +138,7 @@
                 <div class="rtf-block">
                   <read-more
                     text:from="instance.description"
-                    handleMarkdown:from="instance.class.isChangeableExternally">
+                    handleMarkdown:from="instance.constructor.isChangeableExternally">
                   </read-more>
                 </div>
               {{/is}}

--- a/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/partials/three-dots-menu.stache
+++ b/src/ggrc-client/js/components/workflow/cycle-task-group-object-task/templates/partials/three-dots-menu.stache
@@ -5,7 +5,7 @@
 
 <three-dots-menu>
   <li>
-    <a href="javascript://" data-object-singular-override="Task for current Workflow Cycle" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="{{instance.class.model_singular}}" data-object-plural="{{instance.class.table_plural}}" data-object-id="{{instance.id}}">
+    <a href="javascript://" data-object-singular-override="Task for current Workflow Cycle" data-toggle="modal-ajax-form" data-modal-reset="reset" data-modal-class="modal-wide" data-object-singular="{{instance.constructor.model_singular}}" data-object-plural="{{instance.constructor.table_plural}}" data-object-id="{{instance.id}}">
       <i class="fa fa-pencil-square-o"></i>
       Edit Task
     </a>

--- a/src/ggrc-client/js/controllers/info_pin_controller.js
+++ b/src/ggrc-client/js/controllers/info_pin_controller.js
@@ -75,7 +75,7 @@ export default canControl.extend({
           instance: instance,
           isSnapshot: !!instance.snapshot || instance.isRevision,
           parentInstance: parentInstance,
-          model: instance.class,
+          model: instance.constructor,
           confirmEdit: confirmEdit,
           is_info_pin: true,
           options: options,
@@ -103,7 +103,7 @@ export default canControl.extend({
     let instance = opts.attr('instance');
     let options = this.findOptions(el);
     let populatedOpts = opts.attr('options');
-    let confirmEdit = instance.class.confirmEditModal || {};
+    let confirmEdit = instance.constructor.confirmEditModal || {};
     let view = getInstanceView(instance);
 
     if (populatedOpts && !options.attr('result')) {

--- a/src/ggrc-client/js/controllers/modals/modals_controller.js
+++ b/src/ggrc-client/js/controllers/modals/modals_controller.js
@@ -227,7 +227,7 @@ export default canControl.extend({
 
     dfd.then(function () {
       if (instance &&
-        exists(instance, 'class.is_custom_attributable') &&
+        exists(instance, 'constructor.is_custom_attributable') &&
         !(instance instanceof Assessment)) {
         return $.when(
           instance.load_custom_attribute_definitions &&

--- a/src/ggrc-client/js/models/business-models/document.js
+++ b/src/ggrc-client/js/models/business-models/document.js
@@ -81,7 +81,7 @@ export default Cacheable.extend({
   },
   kindTitle() {
     let value = this.attr('kind');
-    let title = loFind(this.class.kinds, {value}).title;
+    let title = loFind(this.constructor.kinds, {value}).title;
     return title;
   },
   save() {

--- a/src/ggrc-client/js/models/business-models/evidence.js
+++ b/src/ggrc-client/js/models/business-models/evidence.js
@@ -83,7 +83,7 @@ export default Cacheable.extend({
   },
   kindTitle() {
     let value = this.attr('kind');
-    let title = loFind(this.class.kinds, {value}).title;
+    let title = loFind(this.constructor.kinds, {value}).title;
     return title;
   },
 });

--- a/src/ggrc-client/js/models/cacheable.js
+++ b/src/ggrc-client/js/models/cacheable.js
@@ -483,7 +483,6 @@ export default canModel.extend({
       !isSnapshot(this)) {
       cache[this[idKey]] = this;
     }
-    this.attr('class', this.constructor);
     this.notifier = new PersistentNotifier();
 
     if (this.isCustomAttributable()) {

--- a/src/ggrc-client/js/models/mixins/issue-tracker.js
+++ b/src/ggrc-client/js/models/mixins/issue-tracker.js
@@ -31,8 +31,8 @@ export default Mixin.extend(
         this.attr('issue_tracker', new canMap({}));
       }
 
-      let config = this.class.buildIssueTrackerConfig
-        ? this.class.buildIssueTrackerConfig(this)
+      let config = this.constructor.buildIssueTrackerConfig
+        ? this.constructor.buildIssueTrackerConfig(this)
         : {enabled: false};
 
       issueTrackerUtils.initIssueTrackerObject(

--- a/src/ggrc-client/js/plugins/tests/acl-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/acl-utils_spec.js
@@ -4,14 +4,17 @@
 */
 
 import makeArray from 'can-util/js/make-array/make-array';
-import canMap from 'can-map';
 import {
   peopleWithRoleName,
 } from '../../plugins/utils/acl-utils';
+import {makeFakeInstance} from '../../../js_specs/spec_helpers';
+import Audit from '../../models/business-models/audit';
+import Policy from '../../models/business-models/policy';
 
 describe('ACL utils peopleWithRoleName() method', () => {
-  let instance;
   let origRoleList;
+  let acl;
+  let instance;
 
   beforeAll(() => {
     origRoleList = GGRC.access_control_roles;
@@ -23,14 +26,7 @@ describe('ACL utils peopleWithRoleName() method', () => {
       {id: 3, name: 'Role B', object_type: 'Audit'},
       {id: 2, name: 'Role B', object_type: 'Policy'},
     ];
-  });
-
-  afterAll(() => {
-    GGRC.access_control_roles = origRoleList;
-  });
-
-  beforeEach(() => {
-    const acl = [
+    acl = [
       {person: {id: 3}, ac_role_id: 1},
       {person: {id: 5}, ac_role_id: 3},
       {person: {id: 6}, ac_role_id: 9},
@@ -39,36 +35,44 @@ describe('ACL utils peopleWithRoleName() method', () => {
       {person: {id: 5}, ac_role_id: 2},
       {person: {id: 9}, ac_role_id: 9},
     ];
+  });
 
-    instance = new canMap({
-      id: 42,
-      type: 'Audit',
-      'class': {model_singular: 'Audit'},
-      access_control_list: acl,
-    });
+  afterAll(() => {
+    GGRC.access_control_roles = origRoleList;
   });
 
   it('returns users that have a role granted on a particular instance', () => {
+    instance = makeFakeInstance({model: Audit})({
+      id: 42,
+      type: 'Audit',
+      access_control_list: acl,
+    });
+
     const result = peopleWithRoleName(instance, 'Role B');
     expect(makeArray(result.map((person) => person.id).sort()))
       .toEqual([2, 5]);
-  }
-  );
+  });
 
   it('returns empty array if role name not found', () => {
+    instance = makeFakeInstance({model: Audit})({
+      id: 42,
+      type: 'Audit',
+      access_control_list: acl,
+    });
+
     const result = peopleWithRoleName(instance, 'Role X');
     expect(makeArray(result)).toEqual([]);
   });
 
   it('returns empty array if no users are granted a particular role', () => {
-    let result;
+    instance = makeFakeInstance({model: Policy})({
+      id: 43,
+      type: 'Policy',
+      access_control_list: acl,
+    });
 
-    instance.attr('type', 'Policy');
-    instance.attr('class.model_singular', 'Policy');
-
-    result = peopleWithRoleName(instance, 'Role A');
+    let result = peopleWithRoleName(instance, 'Role A');
 
     expect(makeArray(result)).toEqual([]);
-  }
-  );
+  });
 });

--- a/src/ggrc-client/js/plugins/tests/snapshot-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/snapshot-utils_spec.js
@@ -6,6 +6,7 @@
 import {makeFakeInstance} from '../../../js_specs/spec_helpers';
 import * as SnapshotUtils from '../utils/snapshot-utils';
 import Audit from '../../models/business-models/audit';
+import canMap from 'can-map';
 
 describe('SnapshotUtils', function () {
   describe('isSnapshotType() method', function () {
@@ -89,6 +90,51 @@ describe('SnapshotUtils', function () {
       let result = toObject(snapshot);
 
       expect(result.attr('updated_at')).toBe(snapshot.updated_at);
+    });
+  });
+
+  describe('extendSnapshot() method', function () {
+    let snapshot = {
+      title: 'title',
+      description: 'description',
+      originalLink: 'originalLink',
+      constructor: {},
+    };
+
+    let expected = jasmine.objectContaining({
+      title: snapshot.title,
+      description: snapshot.description,
+      viewLink: snapshot.originalLink,
+      constructor: snapshot.constructor,
+    });
+
+    let instance;
+    let result;
+
+    it('object should contain properties from snapshot ' +
+      'if object instance of Object', function () {
+      instance = {};
+
+      result = SnapshotUtils.extendSnapshot(
+        instance,
+        snapshot,
+      );
+
+      expect(result).toEqual(expected);
+      expect(result instanceof canMap).toBe(true);
+    });
+
+    it('returns object with properties from snapshot ' +
+      ' if object instance of canMap', function () {
+      instance = new canMap();
+
+      result = SnapshotUtils.extendSnapshot(
+        instance,
+        snapshot,
+      );
+
+      expect(result).toEqual(expected);
+      expect(result instanceof canMap).toBe(true);
     });
   });
 });

--- a/src/ggrc-client/js/plugins/utils/acl-utils.js
+++ b/src/ggrc-client/js/plugins/utils/acl-utils.js
@@ -69,7 +69,7 @@ function peopleWithRoleName(instance, roleName) {
   // get role ID by roleName
   modelRoles = loFilter(
     GGRC.access_control_roles,
-    {object_type: instance.class.model_singular, name: roleName});
+    {object_type: instance.constructor.model_singular, name: roleName});
 
   if (modelRoles.length === 0) {
     console.warn('peopleWithRole: role not found for instance type');

--- a/src/ggrc-client/js/plugins/utils/object-history-utils.js
+++ b/src/ggrc-client/js/plugins/utils/object-history-utils.js
@@ -182,7 +182,7 @@ const getInstanceView = (instance) => {
     return '';
   }
 
-  typeView = `${instance.class.table_plural}/info`;
+  typeView = `${instance.constructor.table_plural}/info`;
 
   if (typeView in GGRC.Templates) {
     view = `${GGRC.templates_path}/${typeView}.stache`;

--- a/src/ggrc-client/js/plugins/utils/snapshot-utils.js
+++ b/src/ggrc-client/js/plugins/utils/snapshot-utils.js
@@ -233,6 +233,26 @@ function getSnapshotsCounts(widgets, instance) {
     });
 }
 
+/**
+ * Extend object properties from snapshot properties
+ * @param {canMap | Object} object - Extendable object
+ * @param {canMap} snapshot - Snapshot object
+ * @return {canMap} Extended object
+ */
+function extendSnapshot(object, snapshot) {
+  const extendedObject = object instanceof canMap ? object : new canMap(object);
+
+  extendedObject.attr('title', snapshot.title);
+  extendedObject.attr('description', snapshot.description);
+  extendedObject.attr('viewLink', snapshot.originalLink);
+
+  // replace extended object constructor with snapshot constructor
+  // to save static properties from it
+  extendedObject.constructor = snapshot.constructor;
+
+  return extendedObject;
+}
+
 export {
   isSnapshot,
   isSnapshotParent,
@@ -246,4 +266,5 @@ export {
   isSnapshotType,
   getParentUrl,
   getSnapshotsCounts,
+  extendSnapshot,
 };

--- a/src/ggrc-client/js/templates/access_control_roles/modal_content.stache
+++ b/src/ggrc-client/js/templates/access_control_roles/modal_content.stache
@@ -14,7 +14,7 @@
         Role name
         <i class="fa fa-asterisk"></i>
         <i class="fa fa-question-circle" rel="tooltip"
-           title="Set a name for the {{class.title_singular}}."></i>
+           title="Set a name for the {{constructor.title_singular}}."></i>
       </label>
       <input-filter
         name:from="'name'"

--- a/src/ggrc-client/js/templates/access_control_roles/subtree.stache
+++ b/src/ggrc-client/js/templates/access_control_roles/subtree.stache
@@ -23,8 +23,8 @@
               href="javascript://"
               data-toggle="modal-ajax-form"
               data-modal-reset="reset"
-              data-object-singular="{{class.model_singular}}"
-              data-object-plural="{{class.table_plural}}"
+              data-object-singular="{{constructor.model_singular}}"
+              data-object-plural="{{constructor.table_plural}}"
               data-object-id="{{id}}"
               data-object-params='{
                 "parent_type": "{{parent_instance.model_singular}}"

--- a/src/ggrc-client/js/templates/assessment_templates/tree_add_item.stache
+++ b/src/ggrc-client/js/templates/assessment_templates/tree_add_item.stache
@@ -10,7 +10,7 @@
         on:refreshTree="loadItems()"
         objectType:from="model.model_singular"
         parentId:from="parent_instance.id"
-        parentType:from="parent_instance.class.model_singular">
+        parentType:from="parent_instance.constructor.model_singular">
         Create
       </assessment-template-clone-button>
     {{/if}}

--- a/src/ggrc-client/js/templates/assessments/assignable_extended_info.stache
+++ b/src/ggrc-client/js/templates/assessments/assignable_extended_info.stache
@@ -6,7 +6,7 @@
 {{#instance}}
   <div class="row-fluid">
     <div class="span12">
-      <a class="main-title {{class.category}} oneline" href="{{viewLink}}">
+      <a class="main-title {{constructor.category}} oneline" href="{{viewLink}}">
         {{title}}
       </a>
     </div>
@@ -58,7 +58,7 @@
   <div class="links">
     <div class="row-fluid">
       <div class="span12">
-        <a class="secondary oneline {{instance.class.category}}" href="{{instance.program.viewLink}}#audit/audit/{{id}}">
+        <a class="secondary oneline {{instance.constructor.category}}" href="{{instance.program.viewLink}}#audit/audit/{{id}}">
           View {{instance.title}}
         </a>
       </div>

--- a/src/ggrc-client/js/templates/assessments/header.stache
+++ b/src/ggrc-client/js/templates/assessments/header.stache
@@ -88,7 +88,7 @@ Copyright (C) 2019 Google Inc.
               <li>
                 <a href="{{instance.viewLink}}">
                   <i class="fa fa-long-arrow-right"></i>
-                  Open {{instance.class.title_singular}}
+                  Open {{instance.constructor.title_singular}}
                 </a>
               </li>
             {{/if}}

--- a/src/ggrc-client/js/templates/assessments/modal_content.stache
+++ b/src/ggrc-client/js/templates/assessments/modal_content.stache
@@ -146,7 +146,7 @@
                           <read-more
                             text:from="itemData.description"
                             maxLinesNumber:from="1"
-                            handleMarkdown:from="instance.class.isChangeableExternally">
+                            handleMarkdown:from="instance.constructor.isChangeableExternally">
                           </read-more>
                         </div>
                       </business-object-list-item>
@@ -174,7 +174,7 @@
                     data-deferred="true"
                     data-is-new="{{new_object_form}}"
                     data-join-object-id="{{instance.id}}"
-                    data-join-object-type="{{instance.class.model_singular}}"
+                    data-join-object-type="{{instance.constructor.model_singular}}"
                     tabindex="8"
                     data-snapshot-scope-id="{{instance.audit.id}}"
                     data-snapshot-scope-type="{{instance.audit.type}}"

--- a/src/ggrc-client/js/templates/audits/dropdown_menu.stache
+++ b/src/ggrc-client/js/templates/audits/dropdown_menu.stache
@@ -19,7 +19,7 @@
         <assessment-template-clone-button
           objectType:from="'AssessmentTemplate'"
           parentId:from="instance.id"
-          parentType:from="instance.class.model_singular">
+          parentType:from="instance.constructor.model_singular">
           <i class="fa fa-sliders"></i>
           Define Assessment template
         </assessment-template-clone-button>
@@ -28,7 +28,7 @@
   {{/if}}
 
   {{#is_allowed 'update' program context='for'}}
-    {{#if instance.class.is_clonable}}
+    {{#if instance.constructor.is_clonable}}
       {{#is_allowed 'update' instance context='for'}}
         <li>
           <object-cloner instance:from="instance"
@@ -83,7 +83,7 @@
       <li>
         <a href="{{instance.viewLink}}">
           <i class="fa fa-long-arrow-right"></i>
-          Open {{instance.class.title_singular}}
+          Open {{instance.constructor.title_singular}}
         </a>
       </li>
     {{/if}}

--- a/src/ggrc-client/js/templates/audits/extended_info.stache
+++ b/src/ggrc-client/js/templates/audits/extended_info.stache
@@ -6,7 +6,7 @@
 {{#instance}}
   <div class="row-fluid">
     <div class="span12">
-      <a class="main-title {{instance.class.category}} oneline" href="{{viewLink}}">
+      <a class="main-title {{instance.constructor.category}} oneline" href="{{viewLink}}">
         {{instance.title}}
       </a>
     </div>
@@ -88,7 +88,7 @@
     <div class="row-fluid">
       <div class="span6">
         <a class="secondary" href="{{viewLink}}">
-          View {{class.title_singular}}
+          View {{constructor.title_singular}}
         </a>
       </div>
     </div>

--- a/src/ggrc-client/js/templates/audits/info.stache
+++ b/src/ggrc-client/js/templates/audits/info.stache
@@ -48,7 +48,7 @@
               <div class="rtf-block">
                 <read-more
                   text:from="instance.description"
-                  handleMarkdown:from="instance.class.isChangeableExternally">
+                  handleMarkdown:from="instance.constructor.isChangeableExternally">
                 </read-more>
               </div>
             </div>

--- a/src/ggrc-client/js/templates/audits/search_result.stache
+++ b/src/ggrc-client/js/templates/audits/search_result.stache
@@ -4,7 +4,7 @@
 }}
 
 {{#each list}}
-<li class="{{class.category}}" data-model="true" {{canData 'model'}}>
+<li class="{{constructor.category}}" data-model="true" {{canData 'model'}}>
   <a href="{{viewLink}}" class="show-extended">
      <span class="lhs-item lhs-item-medium">
        {{title}}

--- a/src/ggrc-client/js/templates/audits/tree_add_item.stache
+++ b/src/ggrc-client/js/templates/audits/tree_add_item.stache
@@ -15,7 +15,7 @@
          data-object-singular="Audit"
          data-object-plural="audits"
          data-object-params='{
-           "{{parent_instance.class.table_singular}}": {
+           "{{parent_instance.constructor.table_singular}}": {
              "id" : {{parent_instance.id}},
              "type" : "{{parent_instance.type}}" 
            },
@@ -38,8 +38,8 @@
         data-toggle="unified-mapper"
         data-join-option-type="{{model.model_singular}}"
         data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.model_singular}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
+        data-join-object-type="{{parent_instance.constructor.model_singular}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.constructor.title_singular 'Object'}}"
       >
         Map
       </a>

--- a/src/ggrc-client/js/templates/base_objects/description.stache
+++ b/src/ggrc-client/js/templates/base_objects/description.stache
@@ -11,7 +11,7 @@
       <div class="rtf-block">
         <read-more
           text:from="description"
-          handleMarkdown:from="instance.class.isChangeableExternally">
+          handleMarkdown:from="instance.constructor.isChangeableExternally">
         </read-more>
       </div>
     </div>

--- a/src/ggrc-client/js/templates/base_objects/dropdown_menu.stache
+++ b/src/ggrc-client/js/templates/base_objects/dropdown_menu.stache
@@ -6,7 +6,7 @@
 <three-dots-menu>
     {{#is_allowed 'update' instance context='for'}}
       {{^if instance.archived}}
-        {{^if instance.class.isChangeableExternally}}
+        {{^if instance.constructor.isChangeableExternally}}
           {{^if instance.readonly}}
             {{> /static/templates/base_objects/edit_object_link.stache}}
           {{/if}}
@@ -62,23 +62,23 @@
         <li>
           <a href="{{instance.viewLink}}">
             <i class="fa fa-long-arrow-right"></i>
-            Open {{instance.class.title_singular}}
+            Open {{instance.constructor.title_singular}}
           </a>
         </li>
       {{/if}}
     {{/if}}
 
-    {{#if instance.class.isChangeableExternally}}
+    {{#if instance.constructor.isChangeableExternally}}
       <li>
         <questionnaire-link instance:from="instance" showIcon:from="true">
-          Open {{instance.class.title_singular}} in new frontend
+          Open {{instance.constructor.title_singular}} in new frontend
         </questionnaire-link>
       </li>
     {{/if}}
 
     {{#is_allowed 'delete' instance}}
       {{^if instance.archived}}
-        {{^if instance.class.isChangeableExternally}}
+        {{^if instance.constructor.isChangeableExternally}}
           {{^if instance.readonly}}
             <li>
               <a data-toggle="modal-ajax-deleteform"

--- a/src/ggrc-client/js/templates/base_objects/edit_object_link.stache
+++ b/src/ggrc-client/js/templates/base_objects/edit_object_link.stache
@@ -10,11 +10,11 @@
        data-toggle="modal-ajax-form"
        data-modal-reset="reset"
        data-modal-class="modal-wide"
-       data-object-singular="{{instance.class.model_singular}}"
-       data-object-plural="{{instance.class.table_plural}}"
+       data-object-singular="{{instance.constructor.model_singular}}"
+       data-object-plural="{{instance.constructor.table_plural}}"
        data-object-id="{{instance.id}}">
       <i class="fa fa-pencil-square-o"></i>
-      Edit {{instance.class.title_singular}}
+      Edit {{instance.constructor.title_singular}}
     </a>
   </li>
 {{/is_allowed}}

--- a/src/ggrc-client/js/templates/base_objects/extended_info.stache
+++ b/src/ggrc-client/js/templates/base_objects/extended_info.stache
@@ -6,8 +6,8 @@
 
   <div class="row-fluid">
     <div class="span12">
-      {{^if class.isChangeableExternally}}
-        <a class="main-title {{class.category}} oneline" href="{{viewLink}}">
+      {{^if constructor.isChangeableExternally}}
+        <a class="main-title {{constructor.category}} oneline" href="{{viewLink}}">
           {{title}}
         </a>
       {{else}}
@@ -62,18 +62,18 @@
 
   <div class="links">
     <div class="row-fluid">
-        {{^if class.isChangeableExternally}}
+        {{^if constructor.isChangeableExternally}}
           <div class="span6">
             <a class="secondary" href="{{viewLink}}">
-              View {{class.title_singular}}
+              View {{constructor.title_singular}}
             </a>
           </div>
         {{else}}
           <a class="secondary" href="{{viewLink}}">
-            Open Original {{class.title_singular}}
+            Open Original {{constructor.title_singular}}
           </a>
           <questionnaire-link instance:from="instance" cssClasses:from="'secondary'">
-            Open {{class.title_singular}} in new frontend
+            Open {{constructor.title_singular}} in new frontend
           </questionnaire-link>
         {{/if}}
     </div>

--- a/src/ggrc-client/js/templates/base_objects/info-pane-utility.stache
+++ b/src/ggrc-client/js/templates/base_objects/info-pane-utility.stache
@@ -13,7 +13,7 @@
             linkType:from="'review'"
             showIcon:from="true"
             viewType:from="'button'">
-            {{instance.class.title_singular}} Review Details
+            {{instance.constructor.title_singular}} Review Details
         </questionnaire-link>
     {{/if}}
     <show-related-assessments-button instance:from="instance" 

--- a/src/ggrc-client/js/templates/base_objects/mapper-item-description.stache
+++ b/src/ggrc-client/js/templates/base_objects/mapper-item-description.stache
@@ -42,7 +42,7 @@
     <read-more
       class="attr-value"
       text:from="item.description"
-      handleMarkdown:from="instance.class.isChangeableExternally">
+      handleMarkdown:from="instance.constructor.isChangeableExternally">
     </read-more>
   </div>
 </div>

--- a/src/ggrc-client/js/templates/base_objects/notes.stache
+++ b/src/ggrc-client/js/templates/base_objects/notes.stache
@@ -11,7 +11,7 @@
         <div class="rtf-block">
           <read-more
             text:from="notes"
-            handleMarkdown:from="instance.class.isChangeableExternally">
+            handleMarkdown:from="instance.constructor.isChangeableExternally">
           </read-more>
         </div>
       </div>

--- a/src/ggrc-client/js/templates/base_objects/test_plan.stache
+++ b/src/ggrc-client/js/templates/base_objects/test_plan.stache
@@ -11,7 +11,7 @@
         <div class="rtf-block">
           <read-more
             text:from="test_plan"
-            handleMarkdown:from="instance.class.isChangeableExternally">
+            handleMarkdown:from="instance.constructor.isChangeableExternally">
           </read-more>
         </div>
       </div>

--- a/src/ggrc-client/js/templates/base_objects/tree_add_item.stache
+++ b/src/ggrc-client/js/templates/base_objects/tree_add_item.stache
@@ -13,9 +13,9 @@
         data-toggle="unified-mapper"
         data-join-option-type="{{model.model_singular}}"
         data-join-object-id="{{parent_instance.id}}"
-        data-join-object-type="{{parent_instance.class.model_singular}}"
-        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.class.title_singular 'Object'}}"
-        {{#if parent_instance.class.isMegaObject}}
+        data-join-object-type="{{parent_instance.constructor.model_singular}}"
+        data-original-title="Map {{firstnonempty title_singular model.title_singular 'Object'}} to this {{firstnonempty parent_instance.constructor.title_singular 'Object'}}"
+        {{#if parent_instance.constructor.isMegaObject}}
           {{#is parent_instance.type model.model_singular}}
             data-mega-object="true"
             data-mega-object-widget="{{options.widgetId}}"

--- a/src/ggrc-client/js/templates/base_objects/view_link.stache
+++ b/src/ggrc-client/js/templates/base_objects/view_link.stache
@@ -7,7 +7,7 @@
   <li>
     <a href="{{instance.viewLink}}">
       <i class="fa fa-long-arrow-right"></i>
-      Open {{instance.class.title_singular}}
+      Open {{instance.constructor.title_singular}}
     </a>
   </li>
 {{/if}}

--- a/src/ggrc-client/js/templates/custom_attribute_definitions/subtree.stache
+++ b/src/ggrc-client/js/templates/custom_attribute_definitions/subtree.stache
@@ -16,7 +16,7 @@
     <td>
       <ul class="tree-action-list">
         <li>
-          <a href="javascript://" data-toggle="modal-ajax-form" data-modal-reset="reset" data-object-singular="{{class.model_singular}}" data-object-plural="{{class.table_plural}}" data-object-id="{{id}}">
+          <a href="javascript://" data-toggle="modal-ajax-form" data-modal-reset="reset" data-object-singular="{{constructor.model_singular}}" data-object-plural="{{constructor.table_plural}}" data-object-id="{{id}}">
             <i class="fa fa-pencil-square-o"></i>
             Edit
           </a>

--- a/src/ggrc-client/js/templates/custom_attributes/modal_content.stache
+++ b/src/ggrc-client/js/templates/custom_attributes/modal_content.stache
@@ -4,7 +4,7 @@
 }}
 
 
-{{#instance.class.is_custom_attributable}}
+{{#instance.constructor.is_custom_attributable}}
   {{^if_instance_of instance 'Assessment'}}
     <div class="ggrc-form">
       <gca-controls instance:from="instance"
@@ -12,4 +12,4 @@
       ></gca-controls>
     </div>
   {{/if_instance_of}}
-{{/instance.class.is_custom_attributable}}
+{{/instance.constructor.is_custom_attributable}}

--- a/src/ggrc-client/js/templates/cycle_task_group_object_tasks/modal_content.stache
+++ b/src/ggrc-client/js/templates/cycle_task_group_object_tasks/modal_content.stache
@@ -82,7 +82,7 @@
               data-toggle="unified-mapper"
               data-deferred="true"
               data-join-object-id="{{instance.id}}"
-              data-join-object-type="{{instance.class.model_singular}}"
+              data-join-object-type="{{instance.constructor.model_singular}}"
               tabindex="6">
               Map Objects
             </a>

--- a/src/ggrc-client/js/templates/cycle_task_groups/extended_info.stache
+++ b/src/ggrc-client/js/templates/cycle_task_groups/extended_info.stache
@@ -7,7 +7,7 @@
   <div class="row-fluid">
     <div class="span12">
       <object-loader path:from="instance.cycle">
-        <a class="main-title {{class.category}} oneline"
+        <a class="main-title {{constructor.category}} oneline"
            href="/workflows/{{loadedObject.workflow.id}}">
         {{title}}
       </a>

--- a/src/ggrc-client/js/templates/cycle_task_groups/info.stache
+++ b/src/ggrc-client/js/templates/cycle_task_groups/info.stache
@@ -34,11 +34,11 @@
       <div class="pane-content">
         <div class="row-fluid wrap-row">
           <div class="span12">
-            <h6>{{instance.class.title_singular}} description</h6>
+            <h6>{{instance.constructor.title_singular}} description</h6>
             <div class="rtf-block">
               <read-more
                 text:from="instance.description"
-                handleMarkdown:from="instance.class.isChangeableExternally">
+                handleMarkdown:from="instance.constructor.isChangeableExternally">
               </read-more>
             </div>
           </div>

--- a/src/ggrc-client/js/templates/cycles/info.stache
+++ b/src/ggrc-client/js/templates/cycles/info.stache
@@ -42,7 +42,7 @@
           <h6>Description</h6>
           <div class="rtf-block">
             <read-more text:from="instance.description"
-                       handleMarkdown:from="instance.class.isChangeableExternally">
+                       handleMarkdown:from="instance.constructor.isChangeableExternally">
             </read-more>
           </div>
         </div>

--- a/src/ggrc-client/js/templates/directives/autocomplete_result.stache
+++ b/src/ggrc-client/js/templates/directives/autocomplete_result.stache
@@ -7,7 +7,7 @@
   <li {{canData 'ui-autocomplete-item'}} class="ui-menu-item">
     <a
       href="javascript://" class='show-extended' {{canData 'model'}}>
-      <i class="fa fa-{{class.table_singular}} color"></i>
+      <i class="fa fa-{{constructor.table_singular}} color"></i>
       {{firstnonempty title name email}}
     </a>
   </li>

--- a/src/ggrc-client/js/templates/issues/remediation_plan.stache
+++ b/src/ggrc-client/js/templates/issues/remediation_plan.stache
@@ -11,7 +11,7 @@
             <div class="rtf-block">
               <read-more
                 text:from="test_plan"
-                handleMarkdown:from="instance.class.isChangeableExternally">
+                handleMarkdown:from="instance.constructor.isChangeableExternally">
               </read-more>
             </div>
         </div>

--- a/src/ggrc-client/js/templates/people/search_result.stache
+++ b/src/ggrc-client/js/templates/people/search_result.stache
@@ -4,7 +4,7 @@
 }}
 
 {{#each list}}
-<li class="{{class.category}}" data-model="true">
+<li class="{{constructor.category}}" data-model="true">
   <a href="{{viewLink}}">
     <div class="lhs-main-title">
       <span class="lhs-item lhs-item-long">

--- a/src/ggrc-client/js/templates/programs/info.stache
+++ b/src/ggrc-client/js/templates/programs/info.stache
@@ -18,10 +18,10 @@
               <div class="row-fluid wrap-row">
                 <div>
                   <custom-roles readOnly:from="instance.readOnlyProgramRoles"
-                                includeRoles:from="instance.class.programRoles"
+                                includeRoles:from="instance.constructor.programRoles"
                                 instance:from="instance">
                   </custom-roles>
-                  <custom-roles excludeRoles:from="instance.class.programRoles"
+                  <custom-roles excludeRoles:from="instance.constructor.programRoles"
                                 instance:from="instance">
                   </custom-roles>
                 </div>

--- a/src/ggrc-client/js/templates/programs/modal_content.stache
+++ b/src/ggrc-client/js/templates/programs/modal_content.stache
@@ -49,7 +49,7 @@
         <access-control-list-roles-helper
           instance:from="instance"
           isNewInstance:from="new_object_form"
-          orderOfRoles:from="instance.class.orderOfRoles">
+          orderOfRoles:from="instance.constructor.orderOfRoles">
         </access-control-list-roles-helper>
       {{/new_object_form}}
       {{^new_object_form}}
@@ -57,12 +57,12 @@
           instance:from="instance"
           isNewInstance:from="new_object_form"
           readOnly:from="instance.readOnlyProgramRoles"
-          includeRoles:from="instance.class.programRoles">
+          includeRoles:from="instance.constructor.programRoles">
         </access-control-list-roles-helper>
         <access-control-list-roles-helper
           instance:from="instance"
           isNewInstance:from="new_object_form"
-          excludeRoles:from="instance.class.programRoles">
+          excludeRoles:from="instance.constructor.programRoles">
         </access-control-list-roles-helper>
       {{/new_object_form}}
     </div>

--- a/src/ggrc-client/js/templates/programs/search_result.stache
+++ b/src/ggrc-client/js/templates/programs/search_result.stache
@@ -4,7 +4,7 @@
 }}
 
 {{#each list}}
-<li class="{{class.category}}" data-model="true" {{canData 'model'}}>
+<li class="{{constructor.category}}" data-model="true" {{canData 'model'}}>
   <a href="{{viewLink}}" class="show-extended">
     <div>
       <div class="lhs-main-title">

--- a/src/ggrc-client/js/templates/risks/info.stache
+++ b/src/ggrc-client/js/templates/risks/info.stache
@@ -24,7 +24,7 @@
                     <div class="rtf-block">
                       <read-more
                         text:from="description"
-                        handleMarkdown:from="instance.class.isChangeableExternally">
+                        handleMarkdown:from="instance.constructor.isChangeableExternally">
                       </read-more>
                     </div>
                   </proposable-attribute>
@@ -41,7 +41,7 @@
                     <div class="rtf-block">
                       <read-more
                         text:from="test_plan"
-                        handleMarkdown:from="instance.class.isChangeableExternally">
+                        handleMarkdown:from="instance.constructor.isChangeableExternally">
                       </read-more>
                     </div>
                   </proposable-attribute>
@@ -57,7 +57,7 @@
                   >
                     <read-more
                       text:from="risk_type"
-                      handleMarkdown:from="instance.class.isChangeableExternally">
+                      handleMarkdown:from="instance.constructor.isChangeableExternally">
                     </read-more>
                   </proposable-attribute>
                 </div>
@@ -72,7 +72,7 @@
                   >
                     <read-more
                       text:from="threat_source"
-                      handleMarkdown:from="instance.class.isChangeableExternally">
+                      handleMarkdown:from="instance.constructor.isChangeableExternally">
                     </read-more>
                   </proposable-attribute>
                 </div>
@@ -87,7 +87,7 @@
                   >
                     <read-more
                       text:from="threat_event"
-                      handleMarkdown:from="instance.class.isChangeableExternally">
+                      handleMarkdown:from="instance.constructor.isChangeableExternally">
                     </read-more>
                   </proposable-attribute>
                 </div>
@@ -102,7 +102,7 @@
                   >
                     <read-more
                       text:from="vulnerability"
-                      handleMarkdown:from="instance.class.isChangeableExternally">
+                      handleMarkdown:from="instance.constructor.isChangeableExternally">
                     </read-more>
                   </proposable-attribute>
                 </div>
@@ -118,7 +118,7 @@
                     <div class="rtf-block">
                       <read-more
                         text:from="notes"
-                        handleMarkdown:from="instance.class.isChangeableExternally">
+                        handleMarkdown:from="instance.constructor.isChangeableExternally">
                       </read-more>
                     </div>
                   </proposable-attribute>

--- a/src/ggrc-client/js/templates/snapshots/dropdown_menu.stache
+++ b/src/ggrc-client/js/templates/snapshots/dropdown_menu.stache
@@ -35,22 +35,22 @@
             {{#if instance.originalObjectDeleted}}
                 <a href="javascript:void(0)" class="disabled-original disabled">
                     <i class="fa fa-long-arrow-right"></i>
-                    Original {{instance.class.title_singular}} is deleted
+                    Original {{instance.constructor.title_singular}} is deleted
                 </a>
             {{else}}
                 <a href="{{instance.originalLink}}">
                     <i class="fa fa-long-arrow-right"></i>
-                    View original {{instance.class.title_singular}}
+                    View original {{instance.constructor.title_singular}}
                 </a>
             {{/if}}
         </li>
     {{/if}}
 
-    {{#if instance.class.isChangeableExternally}}
+    {{#if instance.constructor.isChangeableExternally}}
         {{^if instance.originalObjectDeleted}}
             <li>
                 <questionnaire-link instance:from="instance" showIcon:from="true">
-                    Open {{instance.class.title_singular}} in new frontend
+                    Open {{instance.constructor.title_singular}} in new frontend
                 </questionnaire-link>
             </li>
         {{/if}}

--- a/src/ggrc-client/js/templates/task_group_tasks/task_group_subtree.stache
+++ b/src/ggrc-client/js/templates/task_group_tasks/task_group_subtree.stache
@@ -12,13 +12,13 @@
 
     <div class="task_group_tasks__list-item-column">
         <div class="people-list roles attr-content">
-          <tree-people-with-role-list-field instance:from=".}" role:from="{class.tree_view_options.assigneeRoleName"/>
+          <tree-people-with-role-list-field instance:from=".}" role:from="{constructor.tree_view_options.assigneeRoleName"/>
         </div>
     </div>
 
     <div class="task_group_tasks__list-item-column">
         <div class="people-list roles attr-content">
-          <tree-people-with-role-list-field instance:from=".}" role:from="{class.tree_view_options.secondaryAssigneeRoleName"/>
+          <tree-people-with-role-list-field instance:from=".}" role:from="{constructor.tree_view_options.secondaryAssigneeRoleName"/>
         </div>
     </div>
 
@@ -39,8 +39,8 @@
         {{^is(workflow.status, "Inactive")}}
         <a class="btn btn-small btn-white" href="javascript://"
           data-toggle="modal-ajax-form" data-modal-reset="reset"
-          data-modal-class="modal-wide" data-object-singular="{{class.model_singular}}"
-          data-object-plural="{{class.table_plural}}" data-object-id="{{id}}"
+          data-modal-class="modal-wide" data-object-singular="{{constructor.model_singular}}"
+          data-object-plural="{{constructor.table_plural}}" data-object-id="{{id}}"
           data-object-params='{
             "modal_title": "Edit Task"
           }'>

--- a/src/ggrc-client/js/templates/workflows/extended_info.stache
+++ b/src/ggrc-client/js/templates/workflows/extended_info.stache
@@ -9,7 +9,7 @@
 {{#instance}}
   <div class="row-fluid">
     <div class="span12">
-      <a class="main-title {{class.category}} oneline" href="{{viewLink}}">
+      <a class="main-title {{constructor.category}} oneline" href="{{viewLink}}">
         {{title}}
       </a>
     </div>
@@ -37,7 +37,7 @@
     <div class="row-fluid">
       <div class="span12">
         <a class="secondary" href="{{viewLink}}">
-          View {{class.title_singular}}
+          View {{constructor.title_singular}}
         </a>
       </div>
     </div>

--- a/src/ggrc-client/js/templates/workflows/info.stache
+++ b/src/ggrc-client/js/templates/workflows/info.stache
@@ -99,7 +99,7 @@
                         <li>
                           <a href="{{instance.viewLink}}">
                             <i class="fa fa-long-arrow-right"></i>
-                            Open {{instance.class.title_singular}}
+                            Open {{instance.constructor.title_singular}}
                           </a>
                         </li>
                       {{/if}}
@@ -120,7 +120,7 @@
             <div class="rtf-block">
               <read-more
                 text:from="instance.description"
-                handleMarkdown:from="instance.class.isChangeableExternally">
+                handleMarkdown:from="instance.constructor.isChangeableExternally">
               </read-more>
             </div>
           </div>

--- a/src/ggrc-client/js/templates/workflows/search_result.stache
+++ b/src/ggrc-client/js/templates/workflows/search_result.stache
@@ -20,7 +20,7 @@
   </li>
 
   {{#each list}}
-    <li class="{{class.category}} {{firstnonempty status filter_params.Workflow.status}}" data-model="true" {{canData 'model'}}>
+    <li class="{{constructor.category}} {{firstnonempty status filter_params.Workflow.status}}" data-model="true" {{canData 'model'}}>
       <a href="{{viewLink}}" class="show-extended">
         <div class="lhs-main-title">
           <span class="lhs-item lhs-item-long">


### PR DESCRIPTION
# Issue description

 Replace `class` to `constructor` in templates and JS

# Steps to test the changes


# Solution description

In templates and JS files `class` and `constructor` are used. `class` is the reference to `constructor`. Replace `class` with `constructor` in templates and JS files for consistency. This improves readability.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".