### PR TITLE
GGRC-7427 Reduce number of queries during assessment generation with LCA

### DIFF
--- a/src/ggrc/access_control/roleable.py
+++ b/src/ggrc/access_control/roleable.py
@@ -338,3 +338,15 @@ class Roleable(object):
       )
       return
     acl.add_person(person)
+
+  def get_acl_with_role_name(self, ac_role_name):
+    """Get ACL with a given role name."""
+    acl = self.acr_name_acl_map.get(ac_role_name)
+    if not acl:
+      logger.warning(
+          "Trying to get invalid role by name %s to %s(%s)",
+          ac_role_name,
+          self.type,
+          self.id,
+      )
+    return acl

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -359,6 +359,21 @@ sa.event.listen(
     "before_delete",
     validators.validate_definition_type_ggrcq
 )
+sa.event.listen(
+    CustomAttributeDefinition,
+    "after_insert",
+    attributevalidator.invalidate_gca_cache,
+)
+sa.event.listen(
+    CustomAttributeDefinition,
+    "after_delete",
+    attributevalidator.invalidate_gca_cache,
+)
+sa.event.listen(
+    CustomAttributeDefinition,
+    "after_update",
+    attributevalidator.invalidate_gca_cache,
+)
 
 
 @memcache.cached

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -4,6 +4,7 @@
 """Custom attribute definition module"""
 
 import re
+
 import flask
 import sqlalchemy as sa
 from sqlalchemy import func

--- a/src/ggrc/models/mixins/__init__.py
+++ b/src/ggrc/models/mixins/__init__.py
@@ -62,9 +62,7 @@ class Titled(object):
 
     return value.strip()
 
-  @declared_attr
-  def title(cls):  # pylint: disable=no-self-argument
-    return deferred(db.Column(db.String, nullable=False), cls.__name__)
+  title = db.Column(db.String, nullable=False)
 
   @classmethod
   def indexed_query(cls):

--- a/src/ggrc/models/mixins/attributevalidator.py
+++ b/src/ggrc/models/mixins/attributevalidator.py
@@ -3,6 +3,8 @@
 
 """Attribute validatior"""
 
+import collections
+
 import flask
 import ggrc.models
 import ggrc.access_control
@@ -67,14 +69,31 @@ class AttributeValidator(object):
   @classmethod
   def _get_global_cad_names(cls, definition_type):
     """Get names of global cad for a given object"""
-    cad = ggrc.models.custom_attribute_definition.CustomAttributeDefinition
+    cad = ggrc.models.custom_attribute_definition
     definition_types = [definition_type]
     if definition_type == "assessment_template":
       definition_types.append("assessment")
-    if not getattr(flask.g, "global_cad_names", set()):
-      query = db.session.query(cad.title, cad.id).filter(
-          cad.definition_type.in_(definition_types),
-          cad.definition_id.is_(None)
+
+    if not hasattr(flask.g, "global_cad_names"):
+      flask.g.global_cad_names = collections.defaultdict(set)
+    if definition_type not in flask.g.global_cad_names:
+      query = db.session.query(
+          cad.CustomAttributeDefinition.title,
+          cad.CustomAttributeDefinition.id,
+      ).filter(
+          cad.CustomAttributeDefinition.definition_type.in_(definition_types),
+          cad.CustomAttributeDefinition.definition_id.is_(None),
       )
-      flask.g.global_cad_names = {name.lower(): id_ for name, id_ in query}
-    return flask.g.global_cad_names
+
+      flask.g.global_cad_names[definition_type] = {
+          name.lower(): id_ for name, id_ in query
+      }
+
+    return flask.g.global_cad_names[definition_type]
+
+
+def invalidate_gca_cache(mapper, content, target):
+  # pylint: disable=unused-argument
+  """Clear `global_cad_names` if GCA is created or update or deleted."""
+  if hasattr(flask.g, "global_cad_names"):
+    del flask.g.global_cad_names

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -1076,14 +1076,14 @@ class Resource(ModelView):
     return accumulator
 
   def _build_request_stub_cache(self, data):
+    """Query objects from `data` and store them in cache."""
     objects = self._gather_referenced_objects(data)
     flask.g.referenced_objects = {}
     for class_name, ids in objects.items():
-      class_ = getattr(ggrc.models, class_name, None)
-      if hasattr(class_, "query"):
-        flask.g.referenced_objects[class_] = {
-            obj.id: obj for obj in class_.query.filter(class_.id.in_(ids))
-        }
+      utils.referenced_objects.mark_to_cache(class_name, ids)
+    utils.referenced_objects.rewarm_cache(
+        undefer=True,
+    )
 
   def _check_post_create_options(self, body):
     """Do NOTHING by default"""

--- a/test/integration/external_app/test_export_risk.py
+++ b/test/integration/external_app/test_export_risk.py
@@ -47,7 +47,7 @@ class TestExportRisk(query_helper.WithQueryApi, TestCase):
       ).id
 
       cad_dropdown_id = factories.CustomAttributeDefinitionFactory(
-          title="multiselect_GCA",
+          title="dropdown_GCA",
           definition_type="risk",
           attribute_type="Dropdown",
           multi_choice_options="one,two,three,four,five"


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

During investigation of GGRC-5974 turned out that when generating 3000 assessments for 4 audits (750 assessments per 1 audit) with LCA and mapped objective some queries executed up to 60 000 times. 

# Steps to test the changes

1. Perform assessment autogeneration with snapshot and template having CADs;
2. Look at issued queries.

# Solution description

Solution contains following changes:

- LCA and ACP are now inserted in batches during assessment generation.

- Objects are now undeferred upon loading from request data.

- `_get_global_cad_names` is fixed so now it caches CADs that have already been queried.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
