### PR TITLE
GGRC-6529 Fixes assessment status when verifiers and map fields changed

### DIFF
--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -144,7 +144,8 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
       elif self.unmap and mapping:
         db.session.delete(mapping)
         signals.Restful.model_deleted.send(models.Relationship, obj=mapping)
-    db.session.flush(relationships)
+    if relationships:
+      db.session.flush(relationships)
     self.dry_run = True
 
   def get_value(self):

--- a/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
+++ b/src/ggrc/converters/handlers/snapshot_instance_column_handler.py
@@ -144,8 +144,7 @@ class SnapshotInstanceColumnHandler(MappingColumnHandler):
       elif self.unmap and mapping:
         db.session.delete(mapping)
         signals.Restful.model_deleted.send(models.Relationship, obj=mapping)
-    if relationships:
-      db.session.flush(relationships)
+    db.session.flush(relationships)
     self.dry_run = True
 
   def get_value(self):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Assessments status wasn't changed from IN REVIEW to IN PROGRESS if Verifiers were changed when it was updated via import with new  some data in map:any_field.
Example: map:objective versions

# Steps to test the changes

1. Create assessment
2. Add Objective to Assessment
3. Set assessment to the IN REVIEW state
4. Export Assessment
5. Set '--' into Verifiers field
6. Check if Objective slug existing in map:objective versions field
7. import assessment
8. Check assessment status and verifiers field

# Solution description

the cause of the problem was in sqlalchemy db.session.flush method:
1) src/ggrc/converters/handlers/snapshot_instance_column_handler.py here you can see that previously this method used to flush only data that were updated, but 
2) if empty data were received this method flushed everything in the session, and it leads to the problem
3) Problem was in the src/ggrc/access_control/roleable.py:Roleable.has_acr_acl_changed method when
inspecting access_control_people history didn't have any changes
4) Because of that src/ggrc/models/mixins/autostatuschangeable.py:AutoStatusChangeable.schedule_transition didn't reset the status to IN PROGRESS

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
