### PR TITLE
GGRC-7537 Switching between pages for Saved Search items works incorrect

### DIFF
--- a/src/ggrc-client/js/components/saved-search/saved-search-list/saved-search-list.js
+++ b/src/ggrc-client/js/components/saved-search/saved-search-list/saved-search-list.js
@@ -86,20 +86,10 @@ export default canComponent.extend({
         null :
         this.attr('objectType');
 
-      const paging = this.attr('searchesPaging');
       const searchType = this.attr('searchType');
-
-      const needToGoToPrevPage = (
-        paging.attr('current') > 1 &&
-        this.attr('searches.length') === 1
-      );
-
-      if (needToGoToPrevPage) {
-        paging.attr('current', paging.attr('current') - 1);
-      }
-
       this.attr('isLoading', true);
-      return SavedSearch.findBy(searchType, paging, type)
+
+      return SavedSearch.findBy(searchType, this.attr('searchesPaging'), type)
         .then(({total, values}) => {
           this.attr('searchesPaging.total', total);
 
@@ -113,7 +103,21 @@ export default canComponent.extend({
       event.stopPropagation();
 
       search.destroy().then(() => {
-        this.loadSavedSearches();
+        const paging = this.attr('searchesPaging');
+
+        const needToGoToPrevPage = (
+          paging.attr('current') > 1 &&
+          this.attr('searches.length') === 1
+        );
+
+        if (needToGoToPrevPage) {
+          // move to prev page when current page contains only one item (it was removed)
+          // "loadSavedSearches" will be
+          // triggered by "'{viewModel.searchesPaging} current'" handler
+          paging.attr('current', paging.attr('current') - 1);
+        } else {
+          this.loadSavedSearches();
+        }
       });
     },
     isSelectedSearch(search) {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Incorrect behaviour of saved searches paging 

# Steps to test the changes
Note: The issue is reproducible if only one Saved Search item is presented on the last page of the Saved Searches list.
1. Log in GGRC app and open Global Search pop-up
2. Create the list of saved searches with only one Saved Search item for example on the third page (you need to have 21 saved search items)
3. Go to the last Saved Searches page
4. Go back on on the previous page

_Actual result_: The first page with Saved Search items is displayed.
_Expected result_: The second page with Saved Search items is displayed

# Solution description

Move **decrease current page logic** to `removeSearch` handler

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
