### PR TITLE
GGRC-7021 Update checkout conditions for latest revision

### DIFF
--- a/src/ggrc-client/js/plugins/utils/snapshot-utils.js
+++ b/src/ggrc-client/js/plugins/utils/snapshot-utils.js
@@ -97,7 +97,7 @@ function toObject(instance) {
   });
   content.updated_at = instance.updated_at;
   content.canGetLatestRevision =
-    !instance.is_latest_revision &&
+    !instance.is_latest_revision && !instance.is_identical_revision &&
     isAllowedFor('update', {
       type: instance.child_type,
       id: instance.child_id}) &&

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -27,6 +27,7 @@ from ggrc.models.mixins import with_last_assessment_date
 from ggrc.models.mixins.synchronizable import Synchronizable
 from ggrc.utils import benchmark
 from ggrc.utils import errors
+from ggrc.utils import referenced_objects
 from ggrc.utils.revisions_diff import builder as revisions_diff
 
 
@@ -143,7 +144,9 @@ class Snapshot(rest_handable.WithDeleteHandable,
   @builder.simple_property
   def is_identical_revision(self):
     """Flag if the snapshot has the identical revision."""
+    instance = referenced_objects.get(self.child_type, self.child_id)
     return self.revisions and revisions_diff.is_identical_revision(
+        instance,
         self.revision.content,
         self.revisions[-1].content
     )

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -27,6 +27,7 @@ from ggrc.models.mixins import with_last_assessment_date
 from ggrc.models.mixins.synchronizable import Synchronizable
 from ggrc.utils import benchmark
 from ggrc.utils import errors
+from ggrc.utils.revisions_diff import builder as revisions_diff
 
 
 class Snapshot(rest_handable.WithDeleteHandable,
@@ -142,7 +143,10 @@ class Snapshot(rest_handable.WithDeleteHandable,
   @builder.simple_property
   def is_identical_revision(self):
     """Flag if the snapshot has the identical revision."""
-    return not any(self.revision.diff_with_current().values())
+    return self.revisions and revisions_diff.is_identical_revision(
+        self.revision.content,
+        self.revisions[-1].content
+    )
 
   @classmethod
   def eager_query(cls, **kwargs):

--- a/src/ggrc/models/snapshot.py
+++ b/src/ggrc/models/snapshot.py
@@ -59,6 +59,8 @@ class Snapshot(rest_handable.WithDeleteHandable,
       reflection.Attribute("original_object_deleted",
                            create=False,
                            update=False),
+      reflection.Attribute("is_identical_revision", create=False,
+                           update=False),
       reflection.Attribute("update_revision", read=False),
   )
 
@@ -136,6 +138,11 @@ class Snapshot(rest_handable.WithDeleteHandable,
         issubclass(inflector.get_model(self.child_type), Synchronizable)
     )
     return bool(deleted or external_deleted)
+
+  @builder.simple_property
+  def is_identical_revision(self):
+    """Flag if the snapshot has the identical revision."""
+    return not any(self.revision.diff_with_current().values())
 
   @classmethod
   def eager_query(cls, **kwargs):

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -327,6 +327,17 @@ def prepare(instance, content):
   )
 
 
+def is_identical_revision(context_1, context_2):
+  """Checks revisions contexts for identity."""
+  attr_to_exclude = 'updated_at'
+  for key, value in context_1.items():
+    if key == attr_to_exclude:
+      continue
+    if key in context_2 and context_2[key] != value:
+      return False
+  return True
+
+
 def prepare_content_full_diff(instance_meta_info, l_content, r_content):
   """Prepare diff between two revisions contents of same instance.
 

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -327,13 +327,32 @@ def prepare(instance, content):
   )
 
 
-def is_identical_revision(context_1, context_2):
+def is_identical_acr(instance, value_1, value_2):
+  """Checks acls for identity"""
+  meta = meta_info.MetaInfo(instance)
+  result = generate_acl_diff(meta.acrs, value_1, value_2)
+  return len(result) == 0
+
+
+def is_identical_revision(instance, context_1, context_2):
   """Checks revisions contexts for identity."""
   attr_to_exclude = 'updated_at'
+  attr_need_prepare = 'access_control_list'
+  context_1, context_2 = (context_1, context_2) if \
+      len(context_1.keys()) > len(context_2.keys()) else \
+      (context_2, context_1)
+
   for key, value in context_1.items():
     if key == attr_to_exclude:
       continue
-    if key in context_2 and context_2[key] != value:
+
+    if key not in context_2 and value:
+      return False
+    elif key == attr_need_prepare:
+      is_identical = is_identical_acr(instance, value, context_2.get(key, []))
+      if not is_identical:
+        return False
+    elif key in context_2 and context_2[key] != value:
       return False
   return True
 

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -386,10 +386,10 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
 
   @ddt.data(True, False)
   def test_latest_revision_delete_cad(self, is_add_cav):
-    """Test not creating new revision after deleting CAD.
+    """Test creating new revision after deleting CAD.
 
     In case of deleting CAD, snapshot attribute is_latest_revision
-    must be True
+    must be False
     """
     with factories.single_commit():
       objective = factories.ObjectiveFactory()
@@ -436,8 +436,7 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
 
     snapshot = models.Snapshot.query.filter().first()
 
-    self.assertTrue(snapshot.is_latest_revision or
-                    snapshot.is_identical_revision)
+    self.assertFalse(snapshot.is_latest_revision)
 
 
 class TestCADUpdate(TestCase):

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -386,10 +386,10 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
 
   @ddt.data(True, False)
   def test_latest_revision_delete_cad(self, is_add_cav):
-    """Test creating new revision after deleting CAD.
+    """Test not creating new revision after deleting CAD.
 
     In case of deleting CAD, snapshot attribute is_latest_revision
-    must be False
+    must be True
     """
     with factories.single_commit():
       objective = factories.ObjectiveFactory()
@@ -436,7 +436,8 @@ class TestCreateRevisionAfterDeleteCAD(TestCase):
 
     snapshot = models.Snapshot.query.filter().first()
 
-    self.assertEqual(snapshot.is_latest_revision, False)
+    self.assertTrue(snapshot.is_latest_revision or
+                    snapshot.is_identical_revision)
 
 
 class TestCADUpdate(TestCase):

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -348,8 +348,9 @@ class TestSnapshot(TestCase):
     self.assert200(response)
     self.assertEquals(1, response.json[0]["Snapshot"]["count"])
 
-  def test_comment_adding_revision(self):
-    """Test absence of snapshot after comment adding"""
+  # pylint: disable=invalid-name
+  def test_identity_revision_after_adding_comment(self):
+    """Test checks identity of revisions after adding comment"""
     with factories.single_commit():
       audit = factories.AuditFactory()
       standard = factories.StandardFactory()

--- a/test/integration/ggrc/models/test_snapshot.py
+++ b/test/integration/ggrc/models/test_snapshot.py
@@ -8,6 +8,7 @@ from ggrc.models import all_models
 from ggrc.snapshotter.rules import Types
 from integration.ggrc import TestCase, Api
 from integration.ggrc.models import factories
+from integration.ggrc import generator
 
 
 def get_snapshottable_models():
@@ -264,6 +265,7 @@ class TestSnapshot(TestCase):
   def setUp(self):
     super(TestSnapshot, self).setUp()
     self.api = Api()
+    self.generator = generator.ObjectGenerator()
 
   def test_search_by_reference_url(self):
     """Test search audit related snapshots of control type by reference_url"""
@@ -345,3 +347,31 @@ class TestSnapshot(TestCase):
     )
     self.assert200(response)
     self.assertEquals(1, response.json[0]["Snapshot"]["count"])
+
+  def test_comment_adding_revision(self):
+    """Test absence of snapshot after comment adding"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      standard = factories.StandardFactory()
+
+    snapshot = self._create_snapshots(audit, [standard])[0]
+    snapshot_id = snapshot.id
+    self.generator.generate_comment(standard, "", "some comment")
+
+    response = self.api.get(snapshot.__class__, snapshot_id)
+    self.assertStatus(response, 200)
+    self.assertTrue(response.json['snapshot']['is_identical_revision'])
+
+  def test_is_identical_revision(self):
+    """Test checks correctly work of is_identical_revision flag"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      standard = factories.StandardFactory()
+      standard_id = standard.id
+
+    snapshot = self._create_snapshots(audit, [standard])[0]
+    snapshot_id = snapshot.id
+    standard = all_models.Standard.query.get(standard_id)
+    self.api.put(standard, {"title": "Test standard 1"})
+    snapshot = all_models.Snapshot.query.get(snapshot_id)
+    self.assertFalse(snapshot.is_identical_revision)

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -10,6 +10,7 @@ import ddt
 import mock
 
 from ggrc.models import all_models
+from ggrc.utils.revisions_diff import builder as revisions_diff
 
 
 @ddt.ddt
@@ -376,3 +377,46 @@ class TestCheckPopulatedContent(unittest.TestCase):
 
       for acl in revision.content["access_control_list"]:
         self.assertIsNone(acl.get("parent_id"))
+
+  @ddt.data(
+      (
+          True,
+          {},
+          {}
+      ),
+      (
+          True,
+          {'key_1': 1, 'key_2': 2, 'key_3': 3},
+          {'key_1': 1, 'key_2': 2, 'key_3': 3}
+      ),
+      (
+          True,
+          {'key_1': 1, 'key_2': 2, 'key_3': None},
+          {'key_1': 1, 'key_2': 2}
+      ),
+      (
+          False,
+          {'key_1': 1, 'key_2': 2, 'key_3': 3},
+          {'key_1': 1, 'key_2': 2, 'key_3': 33}
+      ),
+      (
+          False,
+          {'key_1': 1, 'key_2': 2, 'key_3': 3},
+          {'key_1': 1, 'key_2': 2}
+      ),
+      (
+          False,
+          {'key_1': 1, 'key_2': 2},
+          {'key_1': 1, 'key_2': 2, 'key_3': 3},
+      ),
+
+  )
+  @ddt.unpack
+  def test_is_identical_revision(self, expected_result,
+                                 context_1,
+                                 context_2):
+    """Test checks work of is_identical_revision function"""
+    self.assertEqual(
+        revisions_diff.is_identical_revision(None, context_1, context_2),
+        expected_result
+    )


### PR DESCRIPTION
# Issue description

'Get the latest version ' link will appear for snapshots if you add a comment to the original object.

# Steps to test the changes

1 Have a program with mapped standard, audit
2 Add a comment to standard
3 Open Standard snapshot info panel on audit page and see that there is not 'Get the latest version ' link.

# Solution description

Added new snapshot flag 'is_identical_revision' that is responsibility for comparing 2 last revision

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".