### PR TITLE
GGRC-7536 Fixes evidence content in daily digest

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -160,6 +160,8 @@ def _get_displayed_updated_data(attr_name, new_val, old_val, definitions):
   definition = definitions.get(attr_name, None)
   updated_data = {}
   if new_val or old_val:
+    new_val = ','.join(new_val) if isinstance(new_val, list) else new_val
+    old_val = ','.join(old_val) if isinstance(old_val, list) else old_val
     if definition:
       updated_data[definition["display_name"].upper()] = (
           new_val,

--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -116,14 +116,14 @@ def _get_updated_roles(new_list, old_list, roles):
   return role_data
 
 
-def _get_updated_evidence(attr_name, new_val, old_val):
-  """Get difference between old and new evidence data"""
+def _get_updated_display_names(attr_name, new_val, old_val):
+  """Get difference between old and new display names data"""
   new_links = set()
   old_links = set()
   for val in new_val:
-    new_links.add(val.get("link", ""))
+    new_links.add(val.get("display_name", ""))
   for val in old_val:
-    old_links.add(val.get("link", ""))
+    old_links.add(val.get("display_name", ""))
   return (
       attr_name,
       list(new_links - old_links),
@@ -185,7 +185,7 @@ def _get_updated_fields(obj, created_at, definitions, roles):  # noqa: C901
   old_attrs = old_rev.content
 
   updated_roles = []
-  updated_evidence = []
+  updated_display_names = []
   for attr_name, new_val in new_attrs.iteritems():
     if attr_name in notifications.IGNORE_ATTRS:
       continue
@@ -199,8 +199,8 @@ def _get_updated_fields(obj, created_at, definitions, roles):  # noqa: C901
       if attr_name == "access_control_list":
         updated_roles = _get_updated_roles(new_val, old_val, roles)
         continue
-      if attr_name in ("evidences_url", "evidences_file"):
-        updated_evidence.append(_get_updated_evidence(
+      if attr_name in ("evidences_url", "evidences_file", "labels"):
+        updated_display_names.append(_get_updated_display_names(
             attr_name, new_val, old_val,
         ))
         continue
@@ -210,7 +210,7 @@ def _get_updated_fields(obj, created_at, definitions, roles):  # noqa: C901
     updated_data.update(
         _get_displayed_updated_data(attr_name, new_val, old_val, definitions)
     )
-  for attr_name, new_val, old_val in updated_evidence:
+  for attr_name, new_val, old_val in updated_display_names:
     updated_data.update(
         _get_displayed_updated_data(attr_name, new_val, old_val, definitions)
     )

--- a/test/integration/ggrc/notifications/test_assessment_notifications.py
+++ b/test/integration/ggrc/notifications/test_assessment_notifications.py
@@ -140,6 +140,38 @@ class TestAssessmentNotification(TestCase):
         ("test_description", "")
     )
 
+  def test_evidence_change_assmt(self):
+    """Test notification updated data when evidence values is changed"""
+    with factories.single_commit():
+      evidence_url = "test.com"
+      evidence_file = "test_gdrive.file"
+      evidence_1 = factories.EvidenceUrlFactory(link=evidence_url)
+      evidence_2 = factories.EvidenceFileFactory(link=evidence_file)
+    response = self.api.put(self.assessment, {
+        "actions": {"add_related": [
+            {
+                "id": evidence_1.id,
+                "type": "Evidence",
+            },
+            {
+                "id": evidence_2.id,
+                "type": "Evidence",
+            },
+        ]}
+    })
+    self.assert200(response)
+    notifs, notif_data = common.get_daily_notifications()
+    updated = notif_data["user@example.com"]["assessment_updated"]
+    self.assertEqual(len(notifs), 1)
+    self.assertEqual(
+        updated[self.assessment.id]["updated_data"]["EVIDENCE URL"],
+        ([evidence_url], [])
+    )
+    self.assertEqual(
+        updated[self.assessment.id]["updated_data"]["EVIDENCE FILE"],
+        ([evidence_file], [])
+    )
+
   def test_ca_change_by_import(self):
     """Test notification when custom attribute value is changed by import"""
 

--- a/test/integration/ggrc/notifications/test_assessment_notifications.py
+++ b/test/integration/ggrc/notifications/test_assessment_notifications.py
@@ -165,11 +165,11 @@ class TestAssessmentNotification(TestCase):
     self.assertEqual(len(notifs), 1)
     self.assertEqual(
         updated[self.assessment.id]["updated_data"]["EVIDENCE URL"],
-        ([evidence_url], [])
+        (evidence_url, "")
     )
     self.assertEqual(
         updated[self.assessment.id]["updated_data"]["EVIDENCE FILE"],
-        ([evidence_file], [])
+        (evidence_file, "")
     )
 
   def test_ca_change_by_import(self):
@@ -243,11 +243,11 @@ class TestAssessmentNotification(TestCase):
     self.assertEqual(len(notifs), 1)
     self.assertEqual(
         updated[self.assessment.id]["updated_data"]["PRIMARY CONTACTS"],
-        ([], ["user@example.com"])
+        ("", "user@example.com")
     )
     self.assertEqual(
         updated[self.assessment.id]["updated_data"]["SECONDARY CONTACTS"],
-        (["user@example.com"], [])
+        ("user@example.com", "")
     )
 
   def test_multiply_updates(self):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Layout of ATTRIBUTE / NEW VALUE / OLD VALUE is broken in _notifications/show_daily_digest.
- Evidence data shows the dictionary instead of link 
- header columns and content data is not similar as in design example [GGRC-6766](https://github.com/google/ggrc-core/pull/9664)  was shown

# Steps to test the changes

1. Login GGRC app as admin user
2. Update any assessment (add one more assignee)
3. Follow _notifications/show_daily_digest page
4. Find the assessment and look at the layout of ATTRIBUTE / NEW VALUE / OLD VALUE

# Solution description

- I added an additional if-statement for the EVIDENCE FILE and EVIDENCE URL fields
- returns link data from the EVIDENCE FILE and EVIDENCE URL fields

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
