### PR TITLE
GGRC-6263 Fix "Import failed due to unknown error." while importing a person and task group in one template

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -230,7 +230,7 @@ class ImportRowConverter(RowConverter):
     """
     value = self.get_value(attr_name)
     new_objects = self.block_converter.converter.new_objects[self.object_class]
-    if value in new_objects:
+    if value in new_objects and new_objects[value]:
       return new_objects[value]
     obj = self.get_object_by_key(attr_name)
     if value:

--- a/test/integration/ggrc_workflows/converters/test_import_task_group.py
+++ b/test/integration/ggrc_workflows/converters/test_import_task_group.py
@@ -93,6 +93,34 @@ class TestTaskGroupImport(WorkflowTestCase):
     task_group = all_models.TaskGroup.query.one()
     self.assertFalse(task_group.contact)
 
+  def test_import_of_tg_and_person_at_once(self):
+    """Test Task Group import failed when it's assignee is imported bellow."""
+    # pylint: disable=invalid-name
+    tg_data = collections.OrderedDict([
+        ("object_type", "TaskGroup"),
+        ("code", self.TG_SLUG),
+        ("workflow", self.WF_SLUG),
+        ("assignee", "unknownuser@example.com"),
+    ])
+    person_data = collections.OrderedDict([
+        ("object_type", "Person"),
+        ("name", "Unknown User"),
+        ("email", "unknownuser@example.com"),
+    ])
+    expected_errors = {
+        "Task Group": {
+            "row_errors": {
+                errors.NO_VALID_USERS_ERROR.format(
+                    line=3,
+                    column_name="Assignee",
+                )
+            }
+        }
+    }
+
+    response = self.import_data(tg_data, person_data)
+    self._check_csv_response(response, expected_errors)
+
   @ddt.data(
       (all_models.OrgGroup.__name__, "org group", True),
       (all_models.Vendor.__name__, "vendor", True),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If a Task Group is being imported with not existing user as an "Assignee" and in the next block this user is being imported, "Import failed due to unknown error" error is shown for Person block but it should import correctly.

# Steps to test the changes

1. Have any active wf in UI;
2. Import Task group and People into one Google sheet - (Task group should be displayed first in sheet);
3. Open Google sheet and fill out the required fields for Task group and New Person;
4. Set newly created person as Task group Assignee;
5. Save changes and Import it.

Expected result: For Task Group should be shown an error (due to unknown assignee) and there should not be any errors for Person.

# Solution description

Creating Task Group with unknown user as an assignee caused e-mail of this user be recorded into `converter.new_objects` dictionary as `{"email@example.com" : None}`. After that it was not flushed properly and during person import this caused application to think that this user is already created and needs only to be updated. And then application tried to set `email` attribute of this object (which is `None` because of corruption) to `email@example.com` which leads to an error.

To solve the issue `get_or_generate_object` is modified with new condition upon which a value from `converter.new_objects` should be returned.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
