### PR TITLE
GGRC-7582 Confirm user cannot restore Control's version

### DIFF
--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -808,7 +808,8 @@ class Requirements(InfoWidget):
 
 
 class Controls(page_mixins.WithAssignFolder,
-               page_mixins.WithDisabledProposals, InfoWidget):
+               page_mixins.WithDisabledProposals,
+               page_mixins.WithDisabledVersionHistory, InfoWidget):
   """Model for Control object Info pages and Info panels."""
   # pylint: disable=too-many-instance-attributes
   _locators = locator.WidgetInfoControl
@@ -982,7 +983,8 @@ class Markets(InfoWidget):
     super(Markets, self).__init__(driver)
 
 
-class Risks(page_mixins.WithDisabledProposals, InfoWidget):
+class Risks(page_mixins.WithDisabledProposals,
+            page_mixins.WithDisabledVersionHistory, InfoWidget):
   """Model for Risk object Info pages and Info panels."""
   _locators = locator.WidgetInfoRisk
 

--- a/test/selenium/src/lib/page/widget/page_mixins.py
+++ b/test/selenium/src/lib/page/widget/page_mixins.py
@@ -167,3 +167,18 @@ class WithProposals(WithDisabledProposals):
   def click_propose_changes(self):
     """Click on Propose Changes button."""
     self.propose_changes_btn.click()
+
+
+class WithDisabledVersionHistory(base.WithBrowser):
+  """A mixin for disabled objects pages with version history elements."""
+  # pylint: disable=invalid-name
+
+  @property
+  def version_history_tab_or_link_name(self):
+    """Returns a name of version history tab/link for active/disabled
+    objects."""
+    return "Version History"
+
+  def click_version_history(self):
+    """Click 'Version History' link or tab."""
+    self._browser.element(text=self.version_history_tab_or_link_name).click()

--- a/test/selenium/src/lib/page/widget/version_history.py
+++ b/test/selenium/src/lib/page/widget/version_history.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Version History."""
+# pylint: disable=too-few-public-methods
+from lib import base
+
+
+class VersionHistory(base.WithBrowser):
+  """Represents Version History element."""
+
+  def is_version_history_displayed(self):
+    """Returns whether Version History is displayed on page."""
+    return self._browser.element(tag_name="related-revisions").exists

--- a/test/selenium/src/lib/service/webui_facade.py
+++ b/test/selenium/src/lib/service/webui_facade.py
@@ -6,13 +6,13 @@ import copy
 import random
 import re
 
-from lib import url, users, base, browsers
+from lib import url, users, base, browsers, factory
 from lib.constants import objects, element
 from lib.entities import entities_factory
 from lib.page import dashboard
 from lib.page.modal import unified_mapper
 from lib.page.widget import (generic_widget, object_modal, import_page,
-                             related_proposals)
+                             related_proposals, version_history)
 from lib.service import (webui_service, rest_service, rest_facade,
                          admin_webui_service)
 from lib.utils import selenium_utils, ui_utils, string_utils
@@ -362,6 +362,25 @@ def soft_assert_cannot_view_proposals(info_page, soft_assert):
     soft_assert.expect(
         not related_proposals.RelatedProposals().are_proposals_displayed(),
         "Proposals should not be displayed in browser tab number {}.".
+        format(tab_num))
+
+
+def soft_assert_cannot_view_version_history(obj, soft_assert, selenium):
+  """Performs soft assertion that user cannot view Version History for disabled
+  object."""
+  info_page = factory.get_cls_webui_service(objects.get_plural(
+      obj.type))(selenium).open_info_page_of_obj(obj)
+  info_page.click_version_history()
+  soft_assert.expect(are_tabs_urls_equal(), "Tabs urls should be equal.")
+  soft_assert.expect(
+      info_page.version_history_tab_or_link_name
+      not in info_page.tabs.tab_names,
+      "'Version History' tab should not be displayed.")
+  for tab_num, tab in enumerate(browsers.get_browser().windows(), start=1):
+    tab.use()
+    soft_assert.expect(
+        not version_history.VersionHistory().is_version_history_displayed(),
+        "Version history should not be displayed in browser tab number {}.".
         format(tab_num))
 
 

--- a/test/selenium/src/tests/test_controls.py
+++ b/test/selenium/src/tests/test_controls.py
@@ -59,6 +59,13 @@ class TestControls(base.Test):
     webui_facade.soft_assert_cannot_view_proposals(info_page, soft_assert)
     soft_assert.assert_expectations()
 
+  def test_cannot_restore_disabled_object_version(self, control, soft_assert,
+                                                  selenium):
+    """Confirm that user cannot restore disabled object's version."""
+    webui_facade.soft_assert_cannot_view_version_history(
+        control, soft_assert, selenium)
+    soft_assert.assert_expectations()
+
   def test_user_cannot_add_person_to_custom_role(self, control,
                                                  controls_service):
     """Tests that user cannot add a person to custom Role."""


### PR DESCRIPTION

# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #9814 

# Issue description

Confirm user cannot restore Control's version

# Steps to test the changes


# Solution description


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
