### PR TITLE
GGRC-7614 Check review details button for controls

### DIFF
--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -863,6 +863,10 @@ class Controls(WithAssignFolder, InfoWidget):
             self.reference_urls.add_button,
             self.assign_folder_button] + list(self.inline_edit_controls)
 
+  def click_ctrl_review_details_btn(self):
+    """Click Control Review Details button."""
+    self._root.element(text="Control Review Details").click()
+
 
 class Objectives(InfoWidget):
   """Model for Objective object Info pages and Info panels."""

--- a/test/selenium/src/tests/test_controls.py
+++ b/test/selenium/src/tests/test_controls.py
@@ -103,3 +103,11 @@ class TestControls(base.Test):
         selenium).open_widget_of_mapped_objs(product_mapped_to_control)
     assert not widget.three_bbs.option_by_text("Unmap").exists, (
         "Unmap should not be available for scope objects.")
+
+  def test_review_details_for_disabled_obj(self, control, controls_service):
+    """Check that new browser tab is displayed after clicking Review
+    Details button for objects disabled in GGRC."""
+    controls_service.open_info_page_of_obj(
+        control).click_ctrl_review_details_btn()
+    old_tab, new_tab = browsers.get_browser().windows()
+    assert old_tab.url == new_tab.url


### PR DESCRIPTION

# Solution description

Check that new browser tab is displayed after clicking Review Details button for objects disabled in GGRC

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
