### PR TITLE
GGRC-7625 Check that buttons 'Mark Reviewed' and 'Request Review' are not displayed at Control Info page

### DIFF
--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -712,7 +712,7 @@ class AssessmentsService(BaseWebUiService):
 
 class ControlsService(SnapshotsWebUiService):
   """Class for Controls business layer's services objects."""
-  def __init__(self, driver, is_versions_widget=False):
+  def __init__(self, driver=None, is_versions_widget=False):
     super(ControlsService, self).__init__(
         driver, objects.CONTROLS, is_versions_widget)
 

--- a/test/selenium/src/tests/test_controls.py
+++ b/test/selenium/src/tests/test_controls.py
@@ -6,8 +6,8 @@
 import copy
 import pytest
 
-from lib import base, browsers, url
-from lib.constants import element
+from lib import base, browsers, factory, url
+from lib.constants import element, objects
 from lib.service import webui_service, webui_facade
 
 
@@ -123,3 +123,14 @@ class TestControls(base.Test):
         control).click_ctrl_review_details_btn()
     old_tab, new_tab = browsers.get_browser().windows()
     assert old_tab.url == new_tab.url
+
+  def test_deprecated_obj_review_buttons(self, control, soft_assert, selenium):
+    """Check that buttons 'Mark Reviewed' and 'Request Review' are not
+    displayed at Control Info page."""
+    info_page = factory.get_cls_webui_service(objects.get_plural(
+        control.type))().open_info_page_of_obj(control)
+    soft_assert.expect(not info_page.mark_reviewed_btn.exists,
+                       "There should be no 'Mark Reviewed' button.")
+    soft_assert.expect(not info_page.request_review_btn.exists,
+                       "There should be no 'Request Review button.")
+    soft_assert.assert_expectations()


### PR DESCRIPTION
# Solution description

Check that buttons 'Mark Reviewed' and 'Request Review' are not displayed at Control Info page

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
