### PR TITLE
GGRC-5265 Recipients field is set to invalid value for imported Documents

### DIFF
--- a/src/ggrc/migrations/versions/20190806_307953997c8b_modify_default_recipients_in_document.py
+++ b/src/ggrc/migrations/versions/20190806_307953997c8b_modify_default_recipients_in_document.py
@@ -1,0 +1,31 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Change recipients default value in documents
+
+Create Date: 2019-07-31 07:54:50.726753
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a6b61113e372'
+down_revision = 'f00343450894'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+        ALTER TABLE documents
+        MODIFY COLUMN `recipients`
+        VARCHAR (250) NOT NULL DEFAULT 'Admin'
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/migrations/versions/ggrcdev.sql
+++ b/src/ggrc/migrations/versions/ggrcdev.sql
@@ -1249,7 +1249,7 @@ CREATE TABLE `documents` (
   `gdrive_id` varchar(250) NOT NULL DEFAULT '',
   `slug` varchar(250) NOT NULL,
   `status` varchar(250) NOT NULL DEFAULT 'Active',
-  `recipients` varchar(250) DEFAULT NULL,
+  `recipients` varchar(250) NOT NULL DEFAULT 'Admin',
   `send_by_default` tinyint(1) NOT NULL DEFAULT '1',
   `last_deprecated_date` date DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/src/ggrc/models/document.py
+++ b/src/ggrc/models/document.py
@@ -41,6 +41,12 @@ class Document(Roleable, Relatable, mixins.Titled,
                          'Document')
   FILE = "FILE"
   REFERENCE_URL = "REFERENCE_URL"
+
+  recipients = db.Column(
+      db.String,
+      nullable=False,
+      default=u"Admin")
+
   VALID_DOCUMENT_KINDS = [FILE, REFERENCE_URL]
 
   START_STATE = 'Active'


### PR DESCRIPTION
# Issue description
1. Create object (e.g. objective) with reference url via import
2. Open the document created via import
3. Click Changelog tab
Actual result: "Recipients" is set to "Assignees, Creators, Verifiers"
Expected result: "Recipients" should be set to "Admin" like for control created via UI

It looks the same happens for other types of objects (e.g. Recipients in controls)

# Solution description
Modify recipients column in Document module with default value - Admin
Add tests with recipients validation on Import
Update default scheme configuration

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

