### PR TITLE
GGRC-8017, GGRC-7607 Hourly Issue Tracker sync job performance, Users are not populated in CC list after run cron job

### DIFF
--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -2270,15 +2270,15 @@ class AssessmentTrackerHandler(object):
       return False
 
     is_custom_fields_same, remove_fields = self.custom_fields_processing(
-        issue_payload.get("custom_fields", []),
-        issue_tracker_info.get("custom_fields", [])
+        issue_payload,
+        issue_tracker_info,
     )
     if remove_fields:
       issue_payload.pop("custom_fields", [])
 
-    is_css_same = self._is_ccs_same(
+    is_ccs_same = self._is_ccs_same(
         issue_payload,
-        issue_tracker_info
+        issue_tracker_info,
     )
 
     is_common_fields_same = self._is_common_fields_same(
@@ -2286,7 +2286,7 @@ class AssessmentTrackerHandler(object):
         issue_tracker_info
     )
 
-    return not all([is_css_same, is_common_fields_same, is_custom_fields_same])
+    return not all([is_ccs_same, is_common_fields_same, is_custom_fields_same])
 
   @staticmethod
   def _is_creation_mode(issue_obj, issue_id):
@@ -2467,28 +2467,35 @@ class AssessmentTrackerHandler(object):
     return True
 
   @staticmethod
-  def _is_ccs_same(ccs_payload, ccs_tracker):
-    """Check that CCs calculated and Issue Tracker same.
+  def _is_ccs_same(issue_payload, issue_tracker_info):
+    # type: (Dict[str, Any], Dict[str, Any]) -> bool
+    """Check that issue's CCS is the same in GGRC and Issue Tracker.
 
     Args:
-        ccs_payload: CCs calculated from ggrc.
-        ccs_tracker: CCs from Issue Tracker.
+        issue_payload (Dict[str, Any]): Issue information from GGRC.
+        issue_tracker_info (Dict[str, Any]): Issue information from
+          Issue Tracker.
 
     Returns:
         Boolean indicator for CCs validation
     """
-    ccs_payload = set(cc.strip() for cc in ccs_payload)
-    ccs_tracker = set(cc.strip() for cc in ccs_tracker)
+    ccs_ggrc_payload = issue_payload.get("ccs") or []
+    ccs_tracker_payload = issue_tracker_info.get("ccs") or []
 
-    return ccs_payload.issubset(ccs_tracker)
+    ccs_ggrc = set(cc.strip() for cc in ccs_ggrc_payload)
+    ccs_tracker = set(cc.strip() for cc in ccs_tracker_payload)
+
+    return ccs_ggrc.issubset(ccs_tracker)
 
   @staticmethod
   def _is_common_fields_same(issue_payload, issue_tracker_info):
-    """Check that common fields for Issue Tracker same.
+    # type: (Dict[str, Any], Dict[str, Any]) -> bool
+    """Check that issue's common fields are the same in GGRC and Issue Tracker.
 
     Args:
-        issue_payload: issue information on payload.
-        issue_tracker_info: issue information from Issue Tracker
+        issue_payload (Dict[str, Any]): Issue information from GGRC.
+        issue_tracker_info (Dict[str, Any]): Issue information from
+          Issue Tracker.
 
     Returns:
         Boolean indicator for common fields validation
@@ -2648,19 +2655,24 @@ class AssessmentTrackerHandler(object):
       )
 
   @staticmethod
-  def custom_fields_processing(custom_fields_payload, custom_fields_tracker):
-    """Check that custom fields for Issue Tracker same.
+  def custom_fields_processing(issue_payload, issue_tracker_info):
+    # type: (Dict[str, Any], Dict[str, Any]) -> bool
+    """Check that issue's custom fields are the same in GGRC and Issue Tracker.
 
     Args:
-        custom_fields_payload: custom fields on issue payload
-        custom_fields_tracker: custom fields from Issue Tracker
+        issue_payload (Dict[str, Any]): Issue information from GGRC.
+        issue_tracker_info (Dict[str, Any]): Issue information from
+          Issue Tracker.
 
     Returns:
-        Boolean indicator for custom fields validation
+        Boolean indicator for custom fields validation.
     """
-    if any(custom_fields_payload):
+    custom_fields_ggrc = issue_payload.get("custom_fields") or []
+    custom_fields_tracker = issue_tracker_info.get("custom_fields") or []
+
+    if any(custom_fields_ggrc):
       due_date_payload = datetime.datetime.strptime(
-          custom_fields_payload[0]["value"].strip(),
+          custom_fields_ggrc[0]["value"].strip(),
           "%Y-%m-%d"
       )
     else:

--- a/test/unit/ggrc/integrations/test_assessment_integration.py
+++ b/test/unit/ggrc/integrations/test_assessment_integration.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Unit tests for assessment integration helper methods."""
+# pylint: disable=protected-access,too-many-arguments
+
+import datetime
+import itertools
+import unittest
+
+from mock import patch
+import ddt
+
+from ggrc.integrations import constants as integration_constants
+from ggrc.models.hooks.issue_tracker import assessment_integration
+
+
+@ddt.ddt
+class AsmtIntegrationTest(unittest.TestCase):
+  """Test helper methods used in assessment integration with Issue Tracker."""
+
+  @ddt.data(
+      (["same@example.com"], ["same@example.com"], True),
+      (["same@example.com"], ["other@example.com"], False),
+  )
+  @ddt.unpack
+  def test_is_ccs_same(self, ccs_ggrc, ccs_tracker, same):
+    """Test _is_ccs_same works correctly."""
+    asmt_handler = assessment_integration.AssessmentTrackerHandler
+    payload_ggrc = {"ccs": ccs_ggrc}
+    payload_tracker = {"ccs": ccs_tracker}
+
+    self.assertEqual(
+        same,
+        asmt_handler._is_ccs_same(
+            payload_ggrc,
+            payload_tracker,
+        ),
+    )
+
+  @ddt.data(
+      (
+          {"due_date": datetime.date(2019, 8, 21)},
+          {"Due Date": "2019-08-21"},
+          True,
+      ),
+      (
+          {"due_date": datetime.date(2019, 8, 21)},
+          {"Due Date": "2019-08-22"},
+          False,
+      ),
+  )
+  @ddt.unpack
+  def test_is_custom_fields_same(self, custom_ggrc, custom_tracker, same):
+    """Test _is_common_fields_same works correctly."""
+    asmt_handler = assessment_integration.AssessmentTrackerHandler
+    custom_ggrc = asmt_handler._generate_custom_fields(custom_ggrc)
+    custom_tracker = [custom_tracker]
+    payload_ggrc = {"custom_fields": custom_ggrc}
+    payload_tracker = {"custom_fields": custom_tracker}
+
+    custom_fields_same, _ = asmt_handler.custom_fields_processing(
+        payload_ggrc,
+        payload_tracker,
+    )
+
+    self.assertEqual(same, custom_fields_same)
+
+  @ddt.data(
+      *[
+          ({field: value_ggrc}, {field: value_tracker}, same)
+          for field, (value_ggrc, value_tracker, same) in itertools.product(
+              integration_constants.COMMON_SYNCHRONIZATION_FIELDS,
+              [("same", "same", True), ("same", "other", False)],
+          )
+      ]
+  )
+  @ddt.unpack
+  def test_is_common_fields_same(self, payload_ggrc, payload_tracker, same):
+    """Test _is_common_fields_same works correctly."""
+    asmt_handler = assessment_integration.AssessmentTrackerHandler
+    self.assertEqual(
+        same,
+        asmt_handler._is_common_fields_same(
+            payload_ggrc,
+            payload_tracker,
+        ),
+    )
+
+  @patch.object(
+      assessment_integration.AssessmentTrackerHandler,
+      "_is_ccs_same",
+  )
+  @patch.object(
+      assessment_integration.AssessmentTrackerHandler,
+      "_is_common_fields_same",
+  )
+  @patch.object(
+      assessment_integration.AssessmentTrackerHandler,
+      "custom_fields_processing",
+  )
+  @ddt.data(
+      *[
+          (custom_same, common_same, ccs_same)
+          for custom_same, common_same, ccs_same in itertools.product(
+              [True, False],
+              repeat=3,
+          )
+      ]
+  )
+  @ddt.unpack
+  def test_is_need_sync(self, custom_same, common_same, ccs_same,
+                        custom_mock, common_mock, ccs_mock):
+    """Test _is_need_sync works correctly.
+
+    Test that assessment needs to be synced with Issue Tracker when either ccs,
+    common or custom fields differ.
+    """
+    asmt_handler = assessment_integration.AssessmentTrackerHandler()
+    custom_mock.return_value = (custom_same, True)
+    common_mock.return_value = common_same
+    ccs_mock.return_value = ccs_same
+    assessment_id = 0
+
+    self.assertEqual(
+        not all([custom_same, common_same, ccs_same]),
+        asmt_handler._is_need_sync(
+            assessment_id=assessment_id,
+            issue_payload={"status": "Not Started"},
+            issue_tracker_info={"status": "ASSIGNED"}),
+    )


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Currently it takes about 20 minutes for hourly issue tracker sync job to run on ggrc-uat instance. It makes testing of all the cases of object synchronisation to take an unreasonably long amount of time.

This PR contains fixes that should lead to performance improvement of sync job.

# Steps to test the changes

1. Deploy this PR to GCP and import the last ggrc-uat dump;
2. Start hourly issue tracker sync job by performing `GET /hourly_issue_tracker_sync_endpoint` request;
3. Look in the browser's dev tools at time it took for request to finish and compare it with the results obtained on currently deployed ggrc-uat instance.

# Solution description

The bottleneck for issue tracker sync job is a syncronisation of Assessments. The problem is that each Assessment should be synced by `PUT` request to issue tracker, which can take up to 1.5 sec. Giving the number of Assessments on ggrc-uat, we end up with average duration about 20 min.

Whether the Assessment should be synced or not is decided based on `_is_need_sync` function, which compares fields of issue stored on GGRC and Issue Tracker sides. Among this fields is a `ccs` one. `ccs`s are compared by `_is_ccs_same` function. But the thing is, this method is used in a wrong way - **it expects to get a `ccs` values to compare, but the whole JSON representation of issue object was given instead**, which made `_is_need_sync` always produce `True` values. Which led to the situation when every Assessment was synced, even if there are no changes in it.

Solution includes:
-  Change of parameters passed to `_is_ccs_same` function. Now only `ccs` values are passed instead of the whole issue representation.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
