### PR TITLE
QUICK-FIX Fix linting issue about wrong datatype

### DIFF
--- a/src/ggrc/models/mixins/attributevalidator.py
+++ b/src/ggrc/models/mixins/attributevalidator.py
@@ -3,8 +3,6 @@
 
 """Attribute validatior"""
 
-import collections
-
 import flask
 import ggrc.models
 import ggrc.access_control
@@ -75,7 +73,7 @@ class AttributeValidator(object):
       definition_types.append("assessment")
 
     if not hasattr(flask.g, "global_cad_names"):
-      flask.g.global_cad_names = collections.defaultdict(set)
+      flask.g.global_cad_names = dict()
     if definition_type not in flask.g.global_cad_names:
       query = db.session.query(
           cad.CustomAttributeDefinition.title,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Linter warns about wrong default type, because later we assign `dict()` as value to this `defaultdict(set)`. Potentially it can lead to bug .
I don't see need for `defaultdict` at all. 

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
