### PR TITLE
GGRC-7675 Unify external CAD endpoint for Admin Panel

### DIFF
--- a/src/ggrc/models/mixins/attributevalidator.py
+++ b/src/ggrc/models/mixins/attributevalidator.py
@@ -68,7 +68,8 @@ class AttributeValidator(object):
   def _get_global_cad_names(cls, definition_type):
     """Get names of global cad for a given object"""
     model = ggrc.models.get_model(definition_type)
-    if issubclass(model, ggrc.models.mixins.ExternalCustomAttributable):
+    if model and issubclass(model,
+                            ggrc.models.mixins.ExternalCustomAttributable):
       cad = ggrc.models.all_models.ExternalCustomAttributeDefinition
       query_filter = []
     else:

--- a/src/ggrc/services/resources/external.py
+++ b/src/ggrc/services/resources/external.py
@@ -59,32 +59,6 @@ class ExternalResource(common.Resource):
 class ExternalCADResource(ExternalResource):
   """Resource handler for External Custom Attribute Definitions"""
 
-  def build_collection_representation(self, objs, extras=None):
-    """Mask external Custom attribute definitions for JSON response"""
-    resp = super(ExternalCADResource, self).build_collection_representation(
-        objs, extras
-    )
-    if "external_custom_attribute_definitions_collection" in resp:
-      col = resp.pop("external_custom_attribute_definitions_collection", {})
-      if "external_custom_attribute_definitions" in col:
-        col["custom_attribute_definitions"] = col.pop(
-            "external_custom_attribute_definitions"
-        )
-      resp["custom_attribute_definitions_collection"] = col
-    return resp
-
-  def object_for_json(self, obj, model_name=None, properties_to_include=None):
-    """Mask external Custom attribute definitions for JSON response"""
-    resp = super(ExternalCADResource, self).object_for_json(
-        obj, model_name, properties_to_include
-    )
-    if "external_custom_attribute_definition" in resp:
-      resp["custom_attribute_definition"] = resp.pop(
-          "external_custom_attribute_definition",
-          {}
-      )
-    return resp
-
   def delete(self, *args, **kwargs):
     """DELETE operation handler."""
     del args, kwargs

--- a/test/integration/external_app/test_ext_cad.py
+++ b/test/integration/external_app/test_ext_cad.py
@@ -303,5 +303,5 @@ class TestExternalGlobalCustomAttributes(ProductTestCase):
     self._run_cad_asserts(
         attribute_type,
         external_cad,
-        response_json["custom_attribute_definition"]
+        response_json["external_custom_attribute_definition"]
     )


### PR DESCRIPTION
# Issue description
Unify response for external CAD with representation by model

# Steps to test the changes
Add Admin panel for control/risk CAD
Open Network in browser
Response should be with "external_" prefix

For other CADs response should be without "external_"

# Solution description
Remove custom representation for external models

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
