### PR TITLE
GGRC-7434 Fix revision query performance

### DIFF
--- a/src/ggrc/query/builder.py
+++ b/src/ggrc/query/builder.py
@@ -209,7 +209,7 @@ class QueryHelper(object):
     return self.query
 
   @staticmethod
-  def _get_revision_type_query(model, permission_type):
+  def _get_revision_type_query(model, permission_type, filter_ids=None):
     """Filter model based on availability of related objects.
 
     This method is used only when quering revisions. In such case only
@@ -221,6 +221,9 @@ class QueryHelper(object):
     allowed_resources = permissions.all_resources(permission_type)
     if not allowed_resources:
       return sa.false()
+
+    if filter_ids:
+      allowed_resources = [i for i in allowed_resources if i[1] in filter_ids]
 
     return sa.or_(
         sa.tuple_(
@@ -244,7 +247,7 @@ class QueryHelper(object):
     )
 
   @staticmethod
-  def _get_type_query(model, permission_type):
+  def _get_type_query(model, permission_type, filter_ids=None):
     """Filter by contexts and resources
 
     Prepare query to filter models based on the available contexts and
@@ -259,7 +262,7 @@ class QueryHelper(object):
     if model.__name__ == "Revision":
       # Since revision contains all object data, query API should query only
       # revisions of objects user has right permission on.
-      return QueryHelper._get_revision_type_query(model, permission_type)
+      return QueryHelper._get_revision_type_query(model, permission_type, filter_ids)
 
     contexts, resources = permissions.get_context_resource(
         model_name=model.__name__, permission_type=permission_type
@@ -290,6 +293,49 @@ class QueryHelper(object):
 
     return objects
 
+  @staticmethod
+  def _get_revision_related_ids(revision):
+    """Get related objs ids for revision."""
+    return [revision.resource_id,
+            revision.source_id,
+            revision.destination_id,
+            revision.id]
+
+
+  def _get_revisions_related_ids(self, revisions):
+    """Get ids of all related objects for revisions"""
+    result = []
+    for revision in revisions:
+      result += self._get_revision_related_ids(revision)
+    return result
+
+  def _get_revision_query(self, object_class, expression, object_query):
+    """ Get query object for Revision"""
+    query = db.session.query(
+      object_class.id,
+      object_class.destination_id,
+      object_class.source_id,
+      object_class.resource_id,
+    )
+    with benchmark("Parse filter query: _get_ids > _build_expression"):
+      filter_expression = custom_operators.build_expression(
+          expression,
+          object_class,
+          object_class,
+          self.query
+      )
+      if filter_expression is not None:
+        query = query.filter(filter_expression)
+    related_objects_ids = self._get_revisions_related_ids(query)
+    requested_permissions = object_query.get("permissions", "read")
+    with benchmark("Get permissions: _get_ids > _get_type_query"):
+      type_query = self._get_type_query(object_class,
+                                        requested_permissions,
+                                        related_objects_ids)
+      if type_query is not None:
+        query = query.filter(type_query)
+    return query
+
   def _get_ids(self, object_query):
     """Get a set of ids of objects described in the filters."""
 
@@ -301,27 +347,29 @@ class QueryHelper(object):
     object_class = inflector.get_model(object_name)
     if object_class is None:
       return set()
-    query = db.session.query(object_class.id)
-
     tgt_class = object_class
-    if object_name == "Snapshot":
-      child_type = self._get_snapshot_child_type(object_query)
-      tgt_class = getattr(models.all_models, child_type, object_class)
+    if object_name == "Revision":
+      query = self._get_revision_query(object_class, expression, object_query)
+    else:
+      query = db.session.query(object_class.id)
+      if object_name == "Snapshot":
+        child_type = self._get_snapshot_child_type(object_query)
+        tgt_class = getattr(models.all_models, child_type, object_class)
 
-    requested_permissions = object_query.get("permissions", "read")
-    with benchmark("Get permissions: _get_ids > _get_type_query"):
-      type_query = self._get_type_query(object_class, requested_permissions)
-      if type_query is not None:
-        query = query.filter(type_query)
-    with benchmark("Parse filter query: _get_ids > _build_expression"):
-      filter_expression = custom_operators.build_expression(
-          expression,
-          object_class,
-          tgt_class,
-          self.query
-      )
-      if filter_expression is not None:
-        query = query.filter(filter_expression)
+      requested_permissions = object_query.get("permissions", "read")
+      with benchmark("Get permissions: _get_ids > _get_type_query"):
+        type_query = self._get_type_query(object_class, requested_permissions)
+        if type_query is not None:
+          query = query.filter(type_query)
+      with benchmark("Parse filter query: _get_ids > _build_expression"):
+        filter_expression = custom_operators.build_expression(
+            expression,
+            object_class,
+            tgt_class,
+            self.query
+        )
+        if filter_expression is not None:
+          query = query.filter(filter_expression)
 
     if object_query.get("order_by"):
       with benchmark("Sorting: _get_ids > order_by"):


### PR DESCRIPTION
# Issue description

Assessment  'Change log' tab opens very long if current user has a lot of related objects (on QA about 2 minutes)

# Steps to test the changes

1. As admin user create a program, regulation, audit 
2. Open audit page and create assessment 
3. Assign Global Creator user as Auditor in Audit 
4. Log in as Global Creator user and open audit page 
5. Open Assessment Info panel and click on Change Log tab
6. See that tab opens fast

# Solution description

Before, we got all user allowed resources and next, we filtered all records by request ids. Now we get revisions by request ids and next we filter records by a list of allowed resources for current user.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
