### PR TITLE
GGRC-7480 If user attaches a file twice, file appears in the folder with the same title

### DIFF
--- a/test/unit/ggrc/gdrive/__init__.py
+++ b/test/unit/ggrc/gdrive/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/unit/ggrc/gdrive/test_gdrive_utils.py
+++ b/test/unit/ggrc/gdrive/test_gdrive_utils.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Tests for GDrive utils."""
+
+import unittest
+
+from ggrc.gdrive.file_actions import _generate_new_file_name
+
+
+class TestGDriveUtils(unittest.TestCase):
+  """Test for GDrive utils"""
+
+  def test_generate_new_file_name(self):
+    """Test test_generate_new_file_name method"""
+    folder_id = '123abc'
+    expected = "File name (2)"
+    files_list = [{"parents": [folder_id], "name": "File name"},
+                  {"parents": [folder_id], "name": "File name (1)"}]
+    actual = _generate_new_file_name(files_list=files_list,
+                                     original_name="File name",
+                                     folder_id=folder_id)
+    self.assertEqual(expected, actual)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If user attaches a file twice, file appears in the folder with the same title

# Steps to test the changes

1. Log in ggrc app and open any audit
2. Attach folder to audit
3. Create assessment and attach evidence file to this assessment from GDrive
4. Attach the same file once again
4. Open Gdrive and open the folder
Actual Result: If user attaches a file twice, file appears in the folder with the same title
Expected Result: Evidence attached to assessment twice should not have the same title in audit folder. File should be named differently (such as (1) or (2) after the file name.

# Solution description

Check if file already exists in folder and rename original file

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
