### PR TITLE
GGRC-6491 2 WF cycles created during WF activation if client date < server date

### DIFF
--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -188,12 +188,14 @@ def is_external_app_user():
 
 
 def get_user_date():
-  """Get current user timezone and prepare users current date
+  """
+    Get current user timezone from HTTP request
+    and prepare users current date
 
   Returns:
       datetime.date()
   """
-  user_tz_offset = int(request.headers['x-usertimezoneoffset']) / 60
+  user_tz_offset = int(request.headers.get('x-usertimezoneoffset', 0)) / 60
   user_date = (datetime.datetime.now() + datetime.timedelta(
       hours=user_tz_offset)).date()
   return user_date

--- a/src/ggrc/login/__init__.py
+++ b/src/ggrc/login/__init__.py
@@ -7,6 +7,7 @@ Provides basic login and session management using Flask-Login with various
 backends
 """
 
+import datetime
 import json
 import logging
 import re
@@ -184,3 +185,15 @@ def is_external_app_user():
 
   from ggrc.utils.user_generator import is_app_2_app_user_email
   return is_app_2_app_user_email(user.email)
+
+
+def get_user_date():
+  """Get current user timezone and prepare users current date
+
+  Returns:
+      datetime.date()
+  """
+  user_tz_offset = int(request.headers['x-usertimezoneoffset']) / 60
+  user_date = (datetime.datetime.now() + datetime.timedelta(
+      hours=user_tz_offset)).date()
+  return user_date

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -11,7 +11,6 @@ from ggrc import builder
 from ggrc import db
 from ggrc import rbac
 from ggrc import settings
-from ggrc.login import get_user_date
 from ggrc.fulltext import attributes
 from ggrc.fulltext import mixin as ft_mixin
 from ggrc.models import context
@@ -257,7 +256,3 @@ class Person(customattributable.CustomAttributable,
     sorted_roles = sorted(unique_roles,
                           key=lambda x: role_hierarchy.get(x, -1))
     return sorted_roles[0]
-
-  @property
-  def user_date(self):
-    return get_user_date()

--- a/src/ggrc/models/person.py
+++ b/src/ggrc/models/person.py
@@ -11,6 +11,7 @@ from ggrc import builder
 from ggrc import db
 from ggrc import rbac
 from ggrc import settings
+from ggrc.login import get_user_date
 from ggrc.fulltext import attributes
 from ggrc.fulltext import mixin as ft_mixin
 from ggrc.models import context
@@ -256,3 +257,7 @@ class Person(customattributable.CustomAttributable,
     sorted_roles = sorted(unique_roles,
                           key=lambda x: role_hierarchy.get(x, -1))
     return sorted_roles[0]
+
+  @property
+  def user_date(self):
+    return get_user_date()

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -13,7 +13,7 @@ from flask import Blueprint
 from sqlalchemy import inspect, orm
 
 from ggrc import db
-from ggrc.login import get_current_user
+from ggrc.login import get_current_user, get_user_date
 from ggrc.models import all_models
 from ggrc.models.relationship import Relationship
 from ggrc.rbac.permissions import is_allowed_update
@@ -202,13 +202,14 @@ def build_cycles(workflow, cycle=None, user=None):
   user: User isntance (optional). User who will be the creator of the cycles.
   """
   user = user or get_current_user()
+  request_user_date = get_user_date()
   if not workflow.next_cycle_start_date:
     workflow.next_cycle_start_date = workflow.calc_next_adjusted_date(
         workflow.min_task_start_date)
   if cycle:
     build_cycle(workflow, cycle, user)
   if workflow.unit and workflow.repeat_every:
-    while workflow.next_cycle_start_date <= user.user_date:
+    while workflow.next_cycle_start_date <= request_user_date:
       build_cycle(workflow, current_user=user)
 
 

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -208,7 +208,7 @@ def build_cycles(workflow, cycle=None, user=None):
   if cycle:
     build_cycle(workflow, cycle, user)
   if workflow.unit and workflow.repeat_every:
-    while workflow.next_cycle_start_date <= date.today():
+    while workflow.next_cycle_start_date <= user.user_date:
       build_cycle(workflow, current_user=user)
 
 

--- a/test/integration/ggrc/api_helper.py
+++ b/test/integration/ggrc/api_helper.py
@@ -54,7 +54,8 @@ class Api(object):
     self.client.get("/login")
     self.resource = Resource()
     self.headers = {'Content-Type': 'application/json',
-                    "X-Requested-By": "GGRC"
+                    "X-Requested-By": "GGRC",
+                    'X-usertimezoneoffset': '120'
                     }
     self.user_headers = {}
     self.person_name = None

--- a/test/selenium/src/lib/service/rest/session_pool.py
+++ b/test/selenium/src/lib/service/rest/session_pool.py
@@ -6,7 +6,7 @@ import json
 import requests
 
 from lib import url as url_module
-
+from lib.utils import date_utils
 
 BASIC_HEADERS = {"X-Requested-By": "GGRC",
                  "Content-Type": "application/json",
@@ -47,6 +47,8 @@ def create_session(user, is_external=False):
     session.headers["X-ggrc-user"] = json.dumps(session.headers["X-ggrc-user"])
   else:
     session.headers = copy.deepcopy(BASIC_HEADERS)
+    session.headers["x-usertimezoneoffset"] = (
+        date_utils.user_timezone_offset_min_str())
     _set_login_cookie(session, user)
   return session
 

--- a/test/selenium/src/lib/utils/date_utils.py
+++ b/test/selenium/src/lib/utils/date_utils.py
@@ -2,6 +2,7 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Date utils."""
 import datetime
+import time
 
 from dateutil import tz
 
@@ -87,3 +88,14 @@ def iso8601_to_ui_str_with_zone(iso8601_str):
    (mm/dd/yyyy hh:mm:ss AM/PM) format."""
   return datetime.datetime.strftime(
       iso8601_to_local_datetime(iso8601_str), "%m/%d/%Y %I:%M:%S %p")
+
+
+def user_timezone_offset():
+  """Returns user timezone offset in seconds."""
+  return (time.mktime(datetime.datetime.now().timetuple()) -
+          time.mktime(datetime.datetime.utcnow().timetuple()))
+
+
+def user_timezone_offset_min_str():
+  """Returns user timezone offset in minutes in string."""
+  return str(int(user_timezone_offset() / 60))


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

2 WF cycles created during WF activation if client date < server date

# Steps to test the changes

Pre-condition: client time < server time (like example from 17 to 24 in LA in browser, from 00 to 8 in London)
1. Create repeat on WF that repeats every weekday
2. Create task w/start date today
3. Click activate button
4. Go to Active cycles tab

# Solution description

Currently FE application convert datetime objects to UTC time and send it to BE.
In this fact BE doesn't know about local user time(date).
Was added method that collect user's time zone to calculate user's time(date) for cycles generating.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
