### PR TITLE
GGRC-3939 Add Tip message for Assessment Type

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -198,7 +198,30 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
     out_json = super(Assessment, self).log_json()
     out_json["folder"] = self.folder
     return out_json
-
+  ASSESSMENT_TYPE_OPTIONS = ("AccessGroup",
+                             "AccountBalance",
+                             "Contract",
+                             "Control",
+                             "DataAsset",
+                             "Facility",
+                             "Market",
+                             "Objective",
+                             "OrgGroup",
+                             "Policy",
+                             "Process",
+                             "Product",
+                             "Regulation",
+                             "Requirement",
+                             "Standard",
+                             "System",
+                             "Vendor",
+                             "Risk",
+                             "TechnologyEnvironment",
+                             "Threat",
+                             "Metric",
+                             "ProductGroup",
+                             "KeyReport"
+                             )
   _aliases = {
       "owners": None,
       "assessment_template": {
@@ -210,6 +233,8 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
       "assessment_type": {
           "display_name": "Assessment Type",
           "mandatory": False,
+          "description": "Options are:\n{}".format(
+              '\n'.join(ASSESSMENT_TYPE_OPTIONS)),
       },
       "design": "Conclusion: Design",
       "operationally": "Conclusion: Operation",

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2019 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
-
+"""Tests exported csv files"""
 from os.path import abspath, dirname, join
 
 import collections
@@ -36,6 +36,7 @@ class TestExportEmptyTemplate(TestCase):
     }
 
   def test_basic_policy_template(self):
+    """Tests for basic policy templates."""
     data = {
         "export_to": "csv",
         "objects": [{"object_name": "Policy", "fields": "all"}]
@@ -48,6 +49,7 @@ class TestExportEmptyTemplate(TestCase):
     self.assertIn("Policy", response.data)
 
   def test_multiple_empty_objects(self):
+    """Tests for multiple empty objects"""
     data = {
         "export_to": "csv",
         "objects": [
@@ -125,7 +127,6 @@ class TestExportEmptyTemplate(TestCase):
   @ddt.data("Assessment", "Issue")
   def test_delete_tip_in_export_csv(self, model):
     """Tests if delete column has tip message in export file for {}"""
-
     data = {
         "export_to": "csv",
         "objects": [
@@ -134,8 +135,20 @@ class TestExportEmptyTemplate(TestCase):
     }
     response = self.client.post("/_service/export_csv",
                                 data=dumps(data), headers=self.headers)
-
     self.assertIn("Allowed value is:\nYes", response.data)
+
+  def test_assessment_type_tip(self):
+    """Tests if Assessment type column has tip message in export file for {}"""
+    data = {
+        "export_to": "csv",
+        "objects": [
+            {"object_name": "Assessment", "fields": "all"},
+        ],
+    }
+    response = self.client.post("/_service/export_csv",
+                                data=dumps(data), headers=self.headers)
+    self.assertIn("Options are:\n{}".format('\n'.join(
+        all_models.Assessment.ASSESSMENT_TYPE_OPTIONS)), response.data)
 
 
 @ddt.ddt
@@ -282,6 +295,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_program_audit_relevant_query(self):
+    """Test program audit relevant query"""
     response = self._import_file("data_for_export_testing_program_audit.csv")
     self._check_csv_response(response, {})
     data = [{  # should return just program prog-1
@@ -403,6 +417,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(title, response.data, "'{}' was found".format(title))
 
   def test_multiple_relevant_query(self):
+    """Test multiple relevant query"""
     response = self._import_file(
         "data_for_export_testing_program_policy_contract.csv")
     self._check_csv_response(response, {})
@@ -435,6 +450,7 @@ class TestExportSingleObject(TestCase):
         self.assertNotIn(",Cat ipsum {},".format(i), response.data)
 
   def test_query_all_aliases(self):
+    """Tests query for all aliases"""
     def rhs(model, attr):
       attr = getattr(model, attr, None)
       if attr is not None and hasattr(attr, "_query_clause_element"):
@@ -462,11 +478,11 @@ class TestExportSingleObject(TestCase):
         if field is None:
           continue
         try:
-          field = field["display_name"] if type(field) is dict else field
+          field = field["display_name"] if isinstance(field, dict) else field
           res = self.export_csv(data(model, attr, field))
           self.assertEqual(res.status_code, 200)
-        except Exception as e:
-          failed.add((model, attr, field, e))
+        except Exception as err:
+          failed.add((model, attr, field, err))
     self.assertEqual(sorted(failed), [])
 
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Assessment Type Column doesn't have tip message in csv template.

# Steps to test the changes
 1.Log into GGRC app.
 2.Goto Export page.
 3.Select the Object Type (which have Assessment Type as field) and export the csv file.
Open the excel and check for the Assessment Type column , here you can see the tip message
"Options are:
AccessGroup
AccountBalance
Contract
Control
DataAsset
Facility
Market
Objective
OrgGroup
Policy
Process
Product
Regulation
Requirement
Standard
System
Vendor
Risk
TechnologyEnvironment
Threat
Metric
ProductGroup
KeyReport" above the Assessment Type column.

# Solution description

A variable **ASSESSMENT_TYPE_OPTIONS**  is added to the class Assessment in ggrc/models/assessments.py and updated \_aliases variable as per requirement.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
