### PR TITLE
GGRC-7695 Send correct response on request with empty CAD id

### DIFF
--- a/src/ggrc/models/external_custom_attribute_definition.py
+++ b/src/ggrc/models/external_custom_attribute_definition.py
@@ -3,10 +3,12 @@
 
 """External Custom attribute definition module"""
 
+from sqlalchemy.orm import validates
 from sqlalchemy.sql.schema import UniqueConstraint
 
 from ggrc import db
 from ggrc.models import reflection
+from ggrc.models import exceptions
 from ggrc.models.custom_attribute_definition \
     import CustomAttributeDefinitionBase
 
@@ -61,6 +63,15 @@ class ExternalCustomAttributeDefinition(CustomAttributeDefinitionBase):
                            update=False),
       *_include_links
   )
+
+  @validates("id")
+  def validate_cad_id(self, _, value):
+    """Validates external CAD id."""
+    # pylint: disable=no-self-use
+    if value is None:
+      raise exceptions.ValidationError("id for the CAD is not specified.")
+
+    return value
 
   @property
   def definition_attr(self):

--- a/test/integration/external_app/test_ext_cad.py
+++ b/test/integration/external_app/test_ext_cad.py
@@ -266,6 +266,26 @@ class TestExternalGlobalCustomAttributes(ProductTestCase):
     self._run_cad_asserts(attribute_type, ex_cad, attribute_payload)
 
   @ddt.data("Text", "Rich Text", "Date", "Dropdown", "Multiselect")
+  def test_create_cad_wh_id(self, attribute_type):
+    """Test create CAD without id."""
+    attribute_payload = self._get_payload(attribute_type)
+    attribute_payload.pop("id")
+
+    payload = [
+        {
+            "external_custom_attribute_definition": attribute_payload,
+        }
+    ]
+
+    response = self.api.post(
+        all_models.ExternalCustomAttributeDefinition,
+        data=payload
+    )
+
+    self.assertEqual(response.status_code, 400)
+    self.assertIn("id for the CAD is not specified.", response.data)
+
+  @ddt.data("Text", "Rich Text", "Date", "Dropdown", "Multiselect")
   def test_update_custom_attribute(self, attribute_type):
     """Test for update external CAD validation."""
     external_cad = factories.ExternalCustomAttributeDefinitionFactory(
@@ -287,6 +307,29 @@ class TestExternalGlobalCustomAttributes(ProductTestCase):
     self.assertEqual(response.status_code, 200)
     ex_cad = all_models.ExternalCustomAttributeDefinition.eager_query().first()
     self._run_cad_asserts(attribute_type, ex_cad, attribute_payload)
+
+  @ddt.data("Text", "Rich Text", "Date", "Dropdown", "Multiselect")
+  def test_update_cad_wh_id(self, attribute_type):
+    """Test update CAD without id."""
+    external_cad = factories.ExternalCustomAttributeDefinitionFactory(
+        title="GCA example",
+        definition_type="control",
+    )
+    attribute_payload = self._get_payload(attribute_type)
+    attribute_payload.pop("id")
+
+    payload = {
+        "external_custom_attribute_definition": attribute_payload,
+    }
+
+    response = self.api.put(
+        all_models.ExternalCustomAttributeDefinition,
+        obj_id=external_cad.id,
+        data=payload
+    )
+
+    self.assertEqual(response.status_code, 400)
+    self.assertIn("id for the CAD is not specified.", response.data)
 
   @ddt.data("Text", "Rich Text", "Date", "Dropdown", "Multiselect")
   def test_get_custom_attribute(self, attribute_type):


### PR DESCRIPTION
# Issue description
Request with empty id for create/update CAD from external service raise 500 error

# Steps to test the changes
Send request for create/update CAD from external service without id.
Response should be: 400 Bad Request - id for the CAD is not specified.

# Solution description
Add validates method for external CAD model

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

