### PR TITLE
GGRC-4048 Forbid to edit GCA after creation

### DIFF
--- a/src/ggrc-client/js/templates/custom_attribute_definitions/modal_content.stache
+++ b/src/ggrc-client/js/templates/custom_attribute_definitions/modal_content.stache
@@ -21,7 +21,8 @@
         class="input-filter input-block-level"
         placeholder="Enter Title"
         tabindex="1"
-        autofocus>
+        autofocus
+        {{^if new_object_form}}disabled{{/if}}>
       {{#instance.computed_errors.title}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.title}}
     </div>
     <div class="span4">
@@ -31,7 +32,8 @@
         <i class="fa fa-question-circle" rel="tooltip" title="Choose the type of attribute to create."></i>
       </label>
         <dropdown-component optionsList:from="attributeTypes"
-                            name:bind="instance.attribute_type">
+                            name:bind="instance.attribute_type"
+                            {{^if new_object_form}}isDisabled:from="true"{{/if}}>
         </dropdown-component>
     </div>
     {{^is(instance.definition_type, "assessment")}}
@@ -100,7 +102,8 @@
         {{/instance.computed_errors.multi_choice_options}}
         <input type="text" class="input-block-level"
                name="multi_choice_options" value="{{multi_choice_options}}"
-               placeholder="Enter possible values" tabindex="4">
+               placeholder="Enter possible values" tabindex="4"
+               {{^if new_object_form}}disabled{{/if}}>
       </div>
     </div>
     <div class="row-fluid">
@@ -142,7 +145,8 @@
         {{/instance.computed_errors.multi_choice_options}}
         <input type="text" class="input-block-level"
                name="multi_choice_options" value="{{multi_choice_options}}"
-               placeholder="Enter possible values" tabindex="4">
+               placeholder="Enter possible values" tabindex="4"
+               {{^if new_object_form}}disabled{{/if}}>
       </div>
     </div>
     <div class='row-fluid'>

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -239,8 +239,6 @@ class CustomAttributeDefinition(CustomAttributeDefinitionBase):
   _include_links = [
       'definition_type',
       'definition_id',
-      'attribute_type',
-      'multi_choice_options',
       'multi_choice_mandatory',
       'mandatory',
       'helptext',
@@ -252,6 +250,9 @@ class CustomAttributeDefinition(CustomAttributeDefinitionBase):
                            read=True,
                            create=False,
                            update=False),
+      reflection.Attribute("title", update=False),
+      reflection.Attribute("attribute_type", update=False),
+      reflection.Attribute("multi_choice_options", update=False),
       *_include_links)
 
   @property

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -303,86 +303,6 @@ def _merge_errors(create_errors, update_errors):
   return errors
 
 
-def _get_revisions_by_type(resource_type):
-  """Get all revision according the resource type
-
-  Args:
-    resource_type: Resource type of revision that yields further
-  Yields:
-    Revision that according the resource_type
-  """
-  query = models.Revision.query.filter(
-      models.Revision.resource_type == resource_type)
-
-  for chunk in ggrc_utils.generate_query_chunks(query):
-    for obj in chunk.all():
-      yield obj
-
-
-def _is_cad_definition_type(cad, object_type):
-  """Check if cad is right one by checking definition type
-
-  Args:
-    cad: CAD that we check
-    object_type: Type of object of cad which is expected
-  Return:
-    True if cad is exist and definition type of cad which is expected
-    else False
-  """
-  definition_type = ggrc_utils.underscore_from_camelcase(object_type)
-  return cad and cad.definition_type == definition_type
-
-
-def _refresh_cads_title(revision_id, revision_content):
-  # pylint: disable=protected-access
-  """Update cad title in revision
-
-  Args:
-    revision_id: Id of revision in table that will be updated
-    revision_content: Content of revision that will be refresh current content
-  """
-  models.Revision.query.filter(
-      models.Revision.id == revision_id).update(
-      {models.Revision._content: revision_content})
-
-
-def _get_modified_revision_content(cad, resource_type):
-  # pylint: disable=protected-access
-  """Modify revision cad json for updating the cad title for revisions
-
-  Args:
-    cad: A modified cad whose title rewrites to the revision
-  Yields:
-    Id of revision that will be updated with revision_content
-    revision content itself
-  """
-  cad_id, cad_title = cad.id, cad.title
-
-  for rev in _get_revisions_by_type(resource_type):
-    revision_content, revision_id = rev._content, rev.id
-    revision_cads = revision_content["custom_attribute_definitions"]
-
-    for revision_cad in revision_cads:
-      if revision_cad["id"] == cad_id:
-        revision_cad["title"] = cad_title
-        yield revision_id, revision_content
-        break
-
-
-def refresh_program_cads_title(cad):
-  """Refresh cads title in Program revisions when cad title is modified
-
-  Args:
-    cad: A modified cad
-  """
-  resource_type = "Program"
-
-  if _is_cad_definition_type(cad, resource_type):
-    for revision_id, revision_content in _get_modified_revision_content(
-            cad, resource_type):
-      _refresh_cads_title(revision_id, revision_content)
-
-
 @app.route("/_background_tasks/update_cad_related_objects", methods=["POST"])
 @background_task.queued_task
 @helpers.without_sqlalchemy_cache
@@ -400,8 +320,6 @@ def update_cad_related_objects(task):
   query = db.session.query(model
                            if task.parameters.get("need_revisions")
                            else model.id)
-  if event.action == "PUT":
-    refresh_program_cads_title(cad)
   objects_count = len(query.all())
   handled_objects = 0
   for chunk in ggrc_utils.generate_query_chunks(query):

--- a/test/integration/ggrc/proposal/api/test_cads.py
+++ b/test/integration/ggrc/proposal/api/test_cads.py
@@ -41,28 +41,6 @@ class TestCADProposalsApi(base.BaseTestProposalApi):
                      program.proposals[0].content["custom_attribute_values"])
     self.assertEqual(1, len(program.comments))
 
-  def test_change_cad_title(self):
-    """Test program revision after changing CAD's title."""
-    # pylint: disable=protected-access
-    new_title = "new title"
-    with factories.single_commit():
-      program = factories.ProgramFactory(title="1")
-      cad = factories.CustomAttributeDefinitionFactory(
-          definition_type="program")
-      factories.CustomAttributeValueFactory(
-          custom_attribute=cad,
-          attributable=program,
-          attribute_value="text")
-
-    self.api.put(cad, {"title": new_title})
-
-    revision = all_models.Revision.query.filter(
-        all_models.Revision.resource_type == "Program").order_by(
-        all_models.Revision.id.desc()).first()
-    self.assertEqual(
-        revision._content['custom_attribute_definitions'][0]['title'],
-        new_title)
-
   @ddt.data(
       ("1", "1", None),
       ("0", "0", None),

--- a/test/integration/ggrc/services/test_query/test_cad_reindex.py
+++ b/test/integration/ggrc/services/test_query/test_cad_reindex.py
@@ -76,40 +76,6 @@ class TestCADReindex(query_helper.WithQueryApi, ggrc.TestCase):
 
   @ddt.data(
       ("assessment", "Checkbox", "no"),
-      ("assessment", "Text", ""),
-      ("audit", "Checkbox", "no"),
-      ("audit", "Text", ""),
-  )
-  @ddt.unpack
-  def test_reindex_cad_edit(self, definition_type, attribute_type, value):
-    """Test reindex after CAD editing"""
-    model_name = cad.get_inflector_model_name_dict()[definition_type]
-    model_id = factories.get_model_factory(model_name)().id
-    expected = [model_id]
-    title = "test_title %s %s" % (definition_type, attribute_type)
-    cad_model = models.all_models.CustomAttributeDefinition
-    response = self.api.post(cad_model, [
-        self._create_cad_body(
-            title, attribute_type, definition_type, model_name
-        )
-    ])
-    self.assert200(response)
-
-    cad_obj = db.session.query(cad_model).filter_by(title=title).first()
-    title_edited = "%s_edited" % title
-    self.api.put(cad_obj, {"title": title_edited})
-    self.assert200(response)
-
-    ids = self.simple_query(
-        model_name,
-        expression=[title_edited, "=", value],
-        type_="ids",
-        field="ids"
-    )
-    self.assertItemsEqual(ids, expected)
-
-  @ddt.data(
-      ("assessment", "Checkbox", "no"),
       ("assessment", "Multiselect", ""),
       ("assessment", "Text", ""),
       ("audit", "Checkbox", "no"),

--- a/test/selenium/src/lib/page/widget/widget_base.py
+++ b/test/selenium/src/lib/page/widget/widget_base.py
@@ -55,7 +55,7 @@ class CustomAttributesItemContent(base.Component):
     selenium_utils.wait_until_not_present(
         self._driver, self._locators.TREE_SPINNER_CSS)
     self.add_btn.click()
-    return CustomAttributeModal(self._driver)
+    return AddCustomAttributeModal(self._driver)
 
   def open_edit_ca_modal(self, index):
     """Click 'Edit' button to open edit modal for Custom Attribute from list
@@ -68,24 +68,20 @@ class CustomAttributesItemContent(base.Component):
     """
     self._browser.links(text="Edit")[index].click()
     selenium_utils.wait_for_js_to_load(self._driver)
-    return CustomAttributeModal()
+    return EditCustomAttributeModal()
 
 
-class CustomAttributeModal(object_modal.BaseFormModal):
-  """Custom attribute modal."""
+class EditCustomAttributeModal(object_modal.BaseFormModal):
+  """Custom attribute edit modal."""
 
   def __init__(self, driver=None):
-    super(CustomAttributeModal, self).__init__(driver)
-    self._fields = ["title", "attribute_type", "mandatory", "helptext",
-                    "placeholder", "multi_choice_options"]
-
-  def set_attribute_type(self, value):
-    """Sets attribute type dropdown with value."""
-    self._root.element(tag_name="dropdown-component").select().select(value)
-
-  def set_title(self, title):
-    """Sets title field with value."""
-    self._root.text_field(name="title").set(title)
+    super(EditCustomAttributeModal, self).__init__(driver)
+    self.title_field = self._root.text_field(name="title")
+    self.attribute_type_field = self._root.element(
+        tag_name="dropdown-component").select()
+    self.multi_choice_options_field = self._root.text_field(
+        name="multi_choice_options")
+    self._fields = ["mandatory", "helptext", "placeholder"]
 
   def set_helptext(self, value):
     """Sets helptext field with value."""
@@ -94,10 +90,6 @@ class CustomAttributeModal(object_modal.BaseFormModal):
   def set_placeholder(self, value):
     """Sets placeholder field with value."""
     self._root.text_field(name="placeholder").set(value)
-
-  def set_multi_choice_options(self, value):
-    """Sets multi choice options field with value."""
-    self._root.text_field(name="multi_choice_options").set(value)
 
   def set_mandatory(self, value):
     """Sets mandatory checkbox according to the value."""
@@ -110,6 +102,27 @@ class CustomAttributeModal(object_modal.BaseFormModal):
     data.update({"attribute_type": self._root.select().value,
                  "mandatory": self._root.checkbox().is_set})
     return data
+
+
+class AddCustomAttributeModal(EditCustomAttributeModal):
+  """Custom attribute creation modal."""
+
+  def __init__(self, driver=None):
+    super(AddCustomAttributeModal, self).__init__(driver)
+    self._fields = ["title", "attribute_type", "mandatory", "helptext",
+                    "placeholder", "multi_choice_options"]
+
+  def set_attribute_type(self, value):
+    """Sets attribute type dropdown with value."""
+    self.attribute_type_field.select(value)
+
+  def set_title(self, title):
+    """Sets title field with value."""
+    self.title_field.set(title)
+
+  def set_multi_choice_options(self, value):
+    """Sets multi choice options field with value."""
+    self.multi_choice_options_field.set(value)
 
 
 class DynamicTreeToggle(base.Toggle):

--- a/test/selenium/src/lib/service/webui_facade.py
+++ b/test/selenium/src/lib/service/webui_facade.py
@@ -12,7 +12,7 @@ from lib.entities import entities_factory
 from lib.page import dashboard
 from lib.page.modal import unified_mapper
 from lib.page.widget import (generic_widget, object_modal, import_page,
-                             related_proposals, version_history)
+                             related_proposals, version_history, widget_base)
 from lib.service import (webui_service, rest_service, rest_facade,
                          admin_webui_service)
 from lib.utils import selenium_utils, ui_utils, string_utils
@@ -316,7 +316,7 @@ def get_available_templates_list():
   return page.open_download_template_modal().available_templates_list
 
 
-def edit_gca(selenium, old_ca_type, new_ca_type):
+def edit_gca(selenium, ca_type):
   """Create Global Custom attribute via rest api and edit it via web ui.
 
   Returns:
@@ -324,12 +324,12 @@ def edit_gca(selenium, old_ca_type, new_ca_type):
   """
   new_ca = rest_facade.create_gcad(definition_type=objects.get_singular(
       random.choice(objects.OBJS_SUPPORTING_MANDATORY_CA)),
-      attribute_type=old_ca_type, mandatory=True)
-  expected_ca = entities_factory.CustomAttributeDefinitionsFactory().create(
-      attribute_type=new_ca_type, definition_type=new_ca.definition_type,
-      helptext=element.Common.TITLE_EDITED_PART, mandatory=False)
-  if new_ca_type in (element.AdminWidgetCustomAttributes.TEXT,
-                     element.AdminWidgetCustomAttributes.RICH_TEXT):
+      attribute_type=ca_type, mandatory=True)
+  expected_ca = copy.deepcopy(new_ca)
+  expected_ca.update_attrs(helptext=element.Common.TITLE_EDITED_PART,
+                           mandatory=False)
+  if ca_type in (element.AdminWidgetCustomAttributes.TEXT,
+                 element.AdminWidgetCustomAttributes.RICH_TEXT):
     expected_ca.update_attrs(placeholder=element.Common.TITLE_EDITED_PART)
   actual_ca = admin_webui_service.CustomAttributeWebUiService(
       selenium).edit_custom_attribute(new_ca, expected_ca)
@@ -411,6 +411,21 @@ def export_objects(path_to_export_dir, obj_type, src_obj=None,
   widget = (ui_service.open_widget_of_mapped_objs(src_obj) if src_obj
             else ui_service.open_obj_dashboard_tab())
   return ui_service.exported_objs_via_tree_view(path_to_export_dir, widget)
+
+
+def soft_assert_gca_fields_disabled_for_editing(soft_assert, ca_type):
+  """Soft assert that following fields are disabled in 'Edit Custom Attribute
+  Definition' modal: 'Title', 'Attribute type', 'Possible values'.
+  """
+  modal = widget_base.EditCustomAttributeModal()
+  soft_assert.expect(not modal.title_field.enabled,
+                     "'Title' field should be disabled.")
+  soft_assert.expect(not modal.attribute_type_field.enabled,
+                     "'Attribute type' field should be disabled.")
+  if ca_type in (element.AdminWidgetCustomAttributes.MULTISELECT,
+                 element.AdminWidgetCustomAttributes.DROPDOWN):
+    soft_assert.expect(not modal.multi_choice_options_field.enabled,
+                       "'Possible values' field should be disabled.")
 
 
 def soft_assert_techenv_mapped_to_programs(

--- a/test/selenium/src/tests/test_admin_dashboard_page.py
+++ b/test/selenium/src/tests/test_admin_dashboard_page.py
@@ -14,7 +14,7 @@ import pytest
 
 from lib import base, constants, url, users
 from lib.constants import element, messages, objects, roles
-from lib.entities import entities_factory
+from lib.entities import entities_factory, entity
 from lib.page import dashboard
 from lib.service import admin_webui_service, rest_facade, webui_facade
 from lib.utils import date_utils, selenium_utils, string_utils
@@ -348,23 +348,14 @@ class TestCAAdministration(base.Test):
                                 "multi_choice_options")
 
   @pytest.mark.parametrize(
-      'old_ca_type, new_ca_type',
-      [(element.AdminWidgetCustomAttributes.TEXT,
-        element.AdminWidgetCustomAttributes.RICH_TEXT),
-       (element.AdminWidgetCustomAttributes.TEXT,
-        element.AdminWidgetCustomAttributes.DATE),
-       (element.AdminWidgetCustomAttributes.TEXT,
-        element.AdminWidgetCustomAttributes.CHECKBOX),
-       (element.AdminWidgetCustomAttributes.TEXT,
-        element.AdminWidgetCustomAttributes.MULTISELECT),
-       (element.AdminWidgetCustomAttributes.TEXT,
-        element.AdminWidgetCustomAttributes.DROPDOWN),
-       (element.AdminWidgetCustomAttributes.RICH_TEXT,
-        element.AdminWidgetCustomAttributes.TEXT)]
-  )
-  def test_destructive_edit_global_ca(
-      self, old_ca_type, new_ca_type, selenium
-  ):
-    """Check that Global Custom Attributes can be edited."""
-    ca_data = webui_facade.edit_gca(selenium, old_ca_type, new_ca_type)
-    self.general_equal_assert(ca_data["expected_ca"], ca_data["actual_ca"])
+      'ca_type', element.AdminWidgetCustomAttributes.ALL_GCA_TYPES)
+  def test_destructive_edit_global_ca(self, ca_type, soft_assert, selenium):
+    """Check that Global Custom Attributes can be edited and 'Title',
+    'Attribute type' and 'Possible values' are disabled for editing."""
+    ca_data = webui_facade.edit_gca(selenium, ca_type)
+    webui_facade.soft_assert_gca_fields_disabled_for_editing(soft_assert,
+                                                             ca_type)
+    soft_assert.assert_expectations()
+    self.general_equal_assert(
+        ca_data["expected_ca"], ca_data["actual_ca"], 'modified_by',
+        *entity.Representation.tree_view_attrs_to_exclude)

--- a/test/unit/ggrc/models/test_custom_attribute_definition.py
+++ b/test/unit/ggrc/models/test_custom_attribute_definition.py
@@ -5,9 +5,8 @@
 
 import unittest
 import ddt
-from mock import MagicMock, Mock, patch
+from mock import MagicMock
 
-from ggrc import views
 from ggrc.models import all_models
 from ggrc.access_control import role as acr
 
@@ -36,53 +35,3 @@ class TestCustomAttributeDefinition(unittest.TestCase):
     """Test if raises if title invalid"""
     with self.assertRaises(ValueError):
       self.cad.validate_title("title", title)
-
-
-@ddt.ddt
-class TestCustomAttributeDefinitionViews(unittest.TestCase):
-  # pylint: disable=protected-access
-  """Test cads title modification functions in ggrc.views.__init__"""
-  @ddt.data(
-      (True, "program", "person", False),
-      (True, "program", "program", False),
-      (False, "program", "person", False),
-      (False, "program", "program", True),
-  )
-  @ddt.unpack
-  def test_is_cad_definition(self, is_none, definition_type,
-                             expected_definition_type, expected):
-    """Test _is_cad_definition function"""
-    cad = None if is_none else Mock()
-    if cad:
-      cad.definition_type = definition_type
-
-    result = bool(views._is_cad_definition_type(cad, expected_definition_type))
-    self.assertEqual(result, expected)
-
-  @ddt.data(
-      (1, 1, [(None, {'custom_attribute_definitions': [
-          {
-              'id': 1,
-              'title': 'new title'
-          }]})]),
-      (1, 2, []),
-  )
-  @ddt.unpack
-  def test_modify_revision_content(self, cad_id, expected_cad_id, expected):
-    """Test _get_modified_revision_content function"""
-    cad = Mock(id=cad_id, title="new title")
-    content = {
-        "custom_attribute_definitions": [{
-            "id": expected_cad_id,
-            "title": "title"
-        }]
-    }
-
-    obj = Mock(resource_type="Program")
-    revision = all_models.Revision(obj, MagicMock(),
-                                   MagicMock(), content)
-
-    with patch("ggrc.views._get_revisions_by_type", return_value=[revision]):
-      result = [c for c in views._get_modified_revision_content(
-          cad, revision.resource_type)]
-      self.assertEqual(result, expected)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

We need to make not-editable the following fields of Custom 

- Attribute title 
- Attribute 
- Possible values (for Dropdowns and Multiselect) 

The following fields of Custom Attributes should be editable:

- Inline Help 
- Placeholder 
- Mandatory 

 

# Steps to test the changes

1. Open Admin dashboard.
2. Create a Custom Attribute for Program, click "save".
Expected result: no Edit button is displayed for the Custom Attribute.
Actual result: Edit button is displayed for the Custom Attribute, it is possible to change its title and type.

# Solution description

Change access for fields to non-editable in `CustomAttributeDefinition` model. Also, change it dynamically for `multi_choice_options` depending on `attribute_type`. Fix template according these improvements.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
