### PR TITLE
GGRC-7202 Confirmation popup is not displayed if Assessment moves to IN progress

### DIFF
--- a/src/ggrc-client/js/components/related-objects/templates/related-assessments.stache
+++ b/src/ggrc-client/js/components/related-objects/templates/related-assessments.stache
@@ -8,10 +8,17 @@
   {{#if needReuse}}
     {{#is_allowed 'update' baseInstance context='for'}}
       {{#unless instance.archived}}
-        <button type="button"
-                class="btn btn-small btn-green grid-data__toolbar-item"
-                on:el:click="reuseSelected()"
-                {{#if unableToReuse}}disabled{{/if}}>Reuse</button>
+        <confirm-edit-action class="grid-data__toolbar-item"
+                              on:setEditMode="reuseSelected()"
+                              on:setInProgress="setInProgressState()"
+                              instance:from="instance">
+          <button type="button"
+                  class="btn btn-small btn-green"
+                  on:el:click="confirmEdit()"
+                  {{#if unableToReuse}}disabled{{/if}}>
+            Reuse
+          </button>
+        </confirm-edit-action>
       {{/unless}}
     {{/is_allowed}}
   {{/if}}


### PR DESCRIPTION

# Issue description 
Does not appear popup of conformation moving Assessment to "In Progress".

# Steps to test the changes 
1. Create 2 Assessments and map one Control 
2. Open the first Assessment and add several evidence 
3. Open the second Assessment and Complete it 
4. Open Related Assessments tab for second Assessment 
5. Select Evidence for reusing and click Reuse button  
**Actual result**: Evidence are reused. Assessment remains in Completed status  
**Expected result**: Confirmation popup appears. If user confirms Assessment status is changed to In Progress and evidence attaches.

# Solution description 
Add appearing popup of conformation moving Assessment to "In Progress" after click on "Reuse".

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".