### PR TITLE
GGRC-7669 Fix error when exporting assessments linked to object from trie view

### DIFF
--- a/src/ggrc/migrations/versions/20190902_7542f6d44eaa_fix_null_resource_slugs_in_revisions.py
+++ b/src/ggrc/migrations/versions/20190902_7542f6d44eaa_fix_null_resource_slugs_in_revisions.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Fix NULL resource slugs in revisions.
+
+Create Date: 2019-09-02 11:58:15.663744
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import json
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+from ggrc.models import all_models
+from ggrc.models import mixins
+
+
+# revision identifiers, used by Alembic.
+revision = "7542f6d44eaa"
+down_revision = "10b40b26d571"
+
+
+logger = logging.getLogger(__name__)
+
+
+def gather_slugged_models():
+  """Gather models that have `slug` column."""
+  return [
+      model for model in all_models.all_models
+      if issubclass(model, mixins.Slugged)
+  ]
+
+
+def get_objs_with_broken_revisions(slugged_model, connection):
+  """Get resource (ID, slug) pairs from broken revisions of specific type."""
+  sql = """
+      SELECT rev.id, rev.resource_id, rev.content
+        FROM revisions AS rev
+       WHERE rev.resource_type = '{slugged_type}'
+         AND rev.resource_slug IS NULL;
+  """.format(
+      slugged_type=slugged_model.__name__,
+  )
+
+  resource_id_slug_map = {}
+  fail_to_fix_revisions = []
+  query_result = connection.execute(sa.text(sql)).fetchall()
+  for revision_id, resource_id, content, in query_result:
+    content = json.loads(content)
+    resource_slug = content.get("slug")
+    if not resource_slug:
+      fail_to_fix_revisions.append(revision_id)
+    else:
+      resource_id_slug_map[resource_id] = resource_slug
+
+  if fail_to_fix_revisions:
+    logger.warning(
+        "Failed to fix following revisions - no slug in content. %s",
+        fail_to_fix_revisions,
+    )
+
+  return resource_id_slug_map
+
+
+def update_resource_slug_value(slugged_model, id_slug_map, connection):
+  """Set `resource_slug` to right value for `slugged_model`'s revisions."""
+  logger.info(
+      "Fixing %s revisions. %s revisions will be affected.",
+      slugged_model.__name__,
+      len(id_slug_map),
+  )
+
+  sql = """
+      UPDATE revisions AS rev
+         SET rev.resource_slug = :resource_slug
+       WHERE rev.resource_type = '{slugged_type}'
+         AND rev.resource_id = {slugged_id};
+  """
+  for obj_id, obj_slug in id_slug_map.iteritems():
+    query = sa.text(
+        sql.format(slugged_type=slugged_model.__name__, slugged_id=obj_id)
+    )
+    connection.execute(query, resource_slug=obj_slug)
+
+
+def fix_null_resource_slug_in_revs(connection):
+  """Set correct `resource_slug` for slugged objects if it is `NULL`."""
+  for model in gather_slugged_models():
+    id_slug_map = get_objs_with_broken_revisions(model, connection)
+    update_resource_slug_value(model, id_slug_map, connection)
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  connection = op.get_bind()
+  fix_null_resource_slug_in_revs(
+      connection,
+  )
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/utils/objects_cache.py
+++ b/src/ggrc/utils/objects_cache.py
@@ -3,6 +3,7 @@
 
 """Functionality for caching db data for GGRC objects."""
 from collections import defaultdict
+import logging
 
 import sqlalchemy as sa
 
@@ -10,6 +11,9 @@ from ggrc import db
 from ggrc.models import all_models
 from ggrc.utils import benchmark
 from ggrc.utils import helpers
+
+
+logger = logging.getLogger(__name__)
 
 
 @helpers.cached
@@ -93,5 +97,14 @@ def related_snapshot_slugs_cache(obj_class, obj_ids):
     ).fetchall()
 
     for object_id, snapshot_obj_type, snapshot_obj_slug in mapped_revs:
+      if not snapshot_obj_slug:
+        logger.warning(
+            "Snapshot for object %s with ID=%s contains invalid object slug. "
+            "The value will be ignored.",
+            snapshot_obj_type,
+            object_id,
+        )
+        continue
       snapshots[object_id][snapshot_obj_type].add(snapshot_obj_slug)
+
     return snapshots


### PR DESCRIPTION
# Dependencies

- [x] This PR is `on hold` until SQL query results from PROD instance are provided.

<!--
- [ ] GGRC-1234
- [ ] #1234
-->
# Issue description

Export fails when trying to export assessments some object is linked to from trie view. The following error appears: `"Your Export job failed due to a server error. Please restart the export again. Sorry for the inconveniences."`

But when exporting assessments linked to object from export page, everything works fine.

# Steps to test the changes

Changes could be reproduced on PROD instances only due to corrupted data. To reproduce changes locally some manual changing of data in DB is needed:

1. Login in GGRC;
2. Create program, audit;
3. Map control to audit;
4. Create assessment and map control to it;
5. Look in the DB for snapshot of control from step 4;
6. Find revision specified in snapshot and set `resource_slug` to `NULL`;
7. Click on mapped snapshot on UI and select "View original Control" option;
8. Go to "Assessments" tab;
9. Select "Export Assessments" from three dots menu;
10. Go on "Export" page and see that export has failed due to unknown server error.

# Solution description

Solution consists of a migration which updates `resource_slug` for revisions with appropriate value take from revision's content.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->