### PR TITLE
GGRC-3939 Update the Assessment type options

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -196,31 +196,29 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
     out_json = super(Assessment, self).log_json()
     out_json["folder"] = self.folder
     return out_json
-  ASSESSMENT_TYPE_OPTIONS = ("AccessGroup",
-                             "AccountBalance",
-                             "Contract",
-                             "Control",
-                             "DataAsset",
-                             "Facility",
-                             "Market",
-                             "Objective",
-                             "OrgGroup",
-                             "Policy",
-                             "Process",
-                             "Product",
-                             "Regulation",
-                             "Requirement",
-                             "Standard",
-                             "System",
-                             "Vendor",
-                             "Risk",
-                             "TechnologyEnvironment",
-                             "Threat",
-                             "Metric",
-                             "ProductGroup",
-                             "KeyReport"
+  ASSESSMENT_TYPE_OPTIONS = ("Access Groups",
+                             "Account Balances",
+                             "Data Assets",
+                             "Facilities",
+                             "Key Reports",
+                             "Markets",
+                             "Org Groups",
+                             "Processes",
+                             "Product Groups",
+                             "Products",
+                             "Systems",
+                             "Technology Environments",
+                             "Vendors",
+                             "Contracts",
+                             "Controls",
+                             "Objectives",
+                             "Policies",
+                             "Regulations",
+                             "Requirements",
+                             "Risks",
+                             "Standards",
+                             "Threats",
                              )
-
   _aliases = {
       "owners": None,
       "assessment_template": {
@@ -232,7 +230,7 @@ class Assessment(Assignable, statusable.Statusable, AuditRelationship,
       "assessment_type": {
           "display_name": "Assessment Type",
           "mandatory": False,
-          "description": "Options are:\n{}".format(
+          "description": "Allowed values are:\n{}".format(
               '\n'.join(ASSESSMENT_TYPE_OPTIONS)),
       },
       "design": {

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -224,7 +224,7 @@ class TestExportEmptyTemplate(TestCase):
     }
     response = self.client.post("/_service/export_csv",
                                 data=dumps(data), headers=self.headers)
-    self.assertIn("Options are:\n{}".format('\n'.join(
+    self.assertIn("Allowed values are:\n{}".format('\n'.join(
         all_models.Assessment.ASSESSMENT_TYPE_OPTIONS)), response.data)
 
   def test_role_tip(self):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Assessment Type Column doesn't have tip correct message in csv template.

# Steps to test the changes

1.Log into GGRC app.
2.Goto Export page.
3.Select the Object Type (which have Assessment Type as field) and export the csv file.
Open the excel and check for the Assessment Type column , here you can see the tip message
"Allowed values are:
Access Groups
Account Balances
Data Assets
Facilities
Key Reports
Markets
Org Groups
Processes
Product Groups
Products
Systems
Technology Environments
Vendors
Contracts
Controls
Objectives
Policies
Regulations
Requirements
Risks
Standards
Threats"

# Solution description

Updated variable *ASSESSMENT_TYPE_OPTIONS* is added to the class Assessment in ggrc/models/assessments.py 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
