### PR TITLE
GGRC-7604 Incorrect behavior of dropdown filter

### DIFF
--- a/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
@@ -234,6 +234,16 @@ describe('tree-status-filter component', () => {
         router.attr('widget', 'test1');
         viewModel.attr('disabled', false);
       });
+
+      it('when newStatuses is not defined', () => {
+        viewModel.attr('filterStates', [
+          {value: 'A', checked: true},
+          {value: 'B', checked: true},
+        ]);
+        newStatuses = null;
+        router.attr('widget', 'test1');
+        viewModel.attr('disabled', false);
+      });
     });
   });
 

--- a/src/ggrc-client/js/components/tree/tree-status-filter.js
+++ b/src/ggrc-client/js/components/tree/tree-status-filter.js
@@ -143,11 +143,15 @@ export default canComponent.extend({
       }
     },
     '{viewModel.router} state'([router], event, newStatuses) {
+      // ignore empty "state" query param
+      if (!newStatuses) {
+        return;
+      }
+
       let isCurrent = this.viewModel.attr('widgetId') === router.attr('widget');
       let isEnabled = !this.viewModel.attr('disabled');
 
       let currentStates = this.viewModel.attr('currentStates');
-      newStatuses = newStatuses || this.viewModel.attr('allStates');
       let isChanged =
         loDifference(currentStates, newStatuses).length ||
         loDifference(newStatuses, currentStates).length;


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

States resets to default after tab switching

# Steps to test the changes

1. Log in GGRC as admin user
2. Open All objects / My Work page
3. Set dropdown filter for Standards: Active
4. Set dropdown filter for Regulations: Draft
5. Set dropdown filter for Requirements: Deprecated
6. Click on Regulations tab: Filter switched to Active/Draft/Deprecated (incorrect)
7. Click on Standards tab twice: Filter switched to Active/Draft/Deprecated (incorrect)
_Actual Result_: Filter settings are incorrect while switching objects tabs
_Expected Result_: Filter settings should be saved while switching objects tabs.

# Solution description

Ignore empty "state" query param

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
