### PR TITLE
GGRC-6532 Notification emails aren't sent after Issue Tracker Issue create / update via import

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -3,12 +3,11 @@
 
 """Base objects for csv file converters."""
 
+import collections
 import logging
-from collections import defaultdict
 
-import sqlalchemy as sa
-from flask import g
 from google.appengine.ext import deferred
+import sqlalchemy as sa
 
 from ggrc import db
 from ggrc import login
@@ -33,7 +32,7 @@ class BaseConverter(object):
   """Base class for csv converters."""
   # pylint: disable=too-few-public-methods
   def __init__(self, ie_job):
-    self.new_objects = defaultdict(structures.CaseInsensitiveDict)
+    self.new_objects = collections.defaultdict(structures.CaseInsensitiveDict)
     self.shared_state = {}
     self.response_data = []
     self.cache_manager = cache_utils.get_cache_manager()
@@ -100,7 +99,7 @@ class ImportConverter(BaseConverter):
   ]
 
   def __init__(self, ie_job, dry_run=True, csv_data=None):
-    self.user = getattr(g, '_current_user', None)
+    self.user = login.get_current_user()
     self.dry_run = dry_run
     self.csv_data = csv_data or []
     self.indexer = get_indexer()

--- a/src/ggrc/integrations/issuetracker_bulk_sync.py
+++ b/src/ggrc/integrations/issuetracker_bulk_sync.py
@@ -87,6 +87,7 @@ class IssueTrackerBulkCreator(object):
 
     filename = request_data.get("mail_data", {}).get("filename", '')
     recipient = request_data.get("mail_data", {}).get("user_email", '')
+    recipient = recipient or getattr(login.get_current_user(), "email", "")
 
     try:
       issuetracked_info = []


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There aren't any notifications regarding Issue Tracker Issues when they are created / updated via import. Upon import two different types of emails should be sent - one when tickets are created during import and one when they are updated.

# Steps to test the changes

**Version alexl-6532  is deployed to ggrc-test, changes could be checked there.**

### Scenario I:
1. Create Audit with Issue Tracker turned ON;
2. Create some Assessments (with Issue Tracker turned ON) via import for Audit from previous step;
3. Check that corresponding tickets are created in Issue Tracker.

**Expected result:**
Email `Ticket generation status` is sent after background job finishes.

### Scenario II:
1. Create Audit with Issue Tracker turned ON;
2. Create some Assessments (with Issue Tracker turned ON)  in Audit from step 1.
2. Update created Assessments via import;
3. Check that corresponding tickets are updated in Issue Tracker.

**Expected result:**
Email `Ticket update status` is sent after background job finishes.

# Solution description

Solution includes changes in `ImportConverter` and in `IssueTrackerBulkCreator.sync_issuetracker`.

* `ImportConverter`: user in `__init__` is taken from `login.get_current_user()` instead of `flask.g._current_user`

* `IssueTrackerBulkCreator.sync_issuetracker`: recipient for email is taken from `login.get_current_user()` if isn't present in request data passed to method.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
