### PR TITLE
GGRC-7780 GCAs are not synced in some Control objects

### DIFF
--- a/src/ggrc/models/custom_attribute_value.py
+++ b/src/ggrc/models/custom_attribute_value.py
@@ -108,7 +108,7 @@ class CustomAttributeValueBase(base.ContextRBAC,
     """Validate dropdown option."""
     valid_options = set(self.custom_attribute.multi_choice_options.split(","))
     if self.attribute_value:
-      self.attribute_value = self.attribute_value.strip()
+      self.attribute_value = str(self.attribute_value).strip()
       if self.attribute_value not in valid_options:
         raise ValueError("Invalid custom attribute dropdown option: {v}, "
                          "expected one of {l}"

--- a/test/unit/ggrc/models/test_custom_attribute_value.py
+++ b/test/unit/ggrc/models/test_custom_attribute_value.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Test Custom Attribute Value validation."""
+
+import unittest
+
+import ddt
+import mock
+
+from ggrc.models import custom_attribute_value
+
+
+@ddt.ddt
+class TestCustomAttributeValue(unittest.TestCase):
+  """Test Custom Attribute Value validation."""
+
+  def setUp(self):
+    self.cav = custom_attribute_value.CustomAttributeValueBase()
+
+  def test_validate_dropdown(self):
+    """Test for validate dropdown function."""
+    # pylint: disable=protected-access
+    self.cav.custom_attribute = mock.MagicMock()
+    self.cav.custom_attribute.multi_choice_options = "1, 2, 3"
+    self.cav.attribute_value = 1
+
+    self.cav._validate_dropdown()


### PR DESCRIPTION
# Issue description
Sync for control/risk with dropdown GCA crashed if value was added

# Steps to test the changes
Update control/risk on GGRCQ side with integer value for GCA

# Solution description
Update validator with casting integer to string


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

