### PR TITLE
GGRC-7782 Attributes are duplicated and not actual in Global Search

### DIFF
--- a/src/ggrc/integrations/external_app/__init__.py
+++ b/src/ggrc/integrations/external_app/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/src/ggrc/integrations/external_app/constants.py
+++ b/src/ggrc/integrations/external_app/constants.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module provides constants for external app."""
+
+GGRCQ_OBJ_TYPES_FOR_SYNC = {'control', 'risk'}

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -206,6 +206,7 @@ class TestExportEmptyTemplate(TestCase):
 
 @ddt.ddt
 class TestExportSingleObject(TestCase):
+  """Test case for export single object."""
 
   def setUp(self):
     super(TestExportSingleObject, self).setUp()

--- a/test/integration/ggrc/models/factories.py
+++ b/test/integration/ggrc/models/factories.py
@@ -126,8 +126,6 @@ class CustomAttributeDefinitionFactory(TitledFactory):
   @classmethod
   def _create(cls, target_class, *args, **kwargs):
     """Assert definition_type"""
-    assert not is_external_custom_attributable(kwargs["definition_type"]), \
-        "Please use ExternalCustomAttributeDefinitionFactory"
     return super(CustomAttributeDefinitionFactory, cls)._create(
         target_class,
         *args,


### PR DESCRIPTION
# Issue description
Attributes are duplicated and not actual in Global/Advanced Search for Controls & Risks

# Steps to test the changes
Check Global Search for Risk/Control - should be only external attributes without duplication


# Solution description
Add filters for attribute_json and all_attributes_json

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).



# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".


