### PR TITLE
GGRC-4549 Fix to show pending notifications

### DIFF
--- a/src/ggrc/contributions.py
+++ b/src/ggrc/contributions.py
@@ -68,5 +68,5 @@ def contributed_notifications():
   return {
       "Assessment": data_handlers.get_assignable_data,
       "Comment": data_handlers.get_comment_data,
-      "Review": lambda x, _: {}
+      "Review": lambda *x, **_: {}
   }

--- a/src/ggrc/templates/notifications/view_pending_digest.html
+++ b/src/ggrc/templates/notifications/view_pending_digest.html
@@ -22,5 +22,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
   {% endfor %}
   <hr>
-
+  <!--temporary demonstration of how to use total
+  count notification in a template-->
+  <p> total count {{total_count}}</p>
 {% endblock %}


### PR DESCRIPTION
# Dependencies

_This PR should be tested on GAE thus it is on hold until the issue with BCID is resolved._

# Issue description

HTTP response for getting pending notifications are too large.

# Steps to test the changes

1 Install any DB dump
2 Login to the system as superadmin
3 Open notification pending page on the link: localhost:8080/_notifications/show_pending
4 See that request is too large.

# Solution description

Fix endpoint for getting pending notifications

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
