### PR TITLE
GGRC-6361 Add optional description field for evidence URL/File

### DIFF
--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
@@ -36,6 +36,7 @@ import '../../related-objects/related-assessments';
 import '../../related-objects/related-issues';
 import '../../issue-tracker/issue-tracker-switcher';
 import './ticket-id-checker';
+import '../../item-edit-control/item-edit-control';
 import '../../object-list-item/editable-document-object-list-item';
 import '../../object-state-toolbar/object-state-toolbar';
 import '../../loading/loading-status';

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
@@ -98,20 +98,27 @@
                                 Evidence file
                             </div>
                             <object-list items:from="files" emptyMessage:from="noItemsText">
-                                <editable-document-object-list-item document:from="{.}">
-                                  <confirm-edit-action
-                                      on:setEditMode="removeRelatedItem(document, 'files')"
-                                      on:setInProgress="setInProgressState()"
-                                      isEditIconDenied:from="isEditDenied"
-                                      instance:from="instance"
-                                      onStateChangeDfd:from="onStateChangeDfd">
-                                          <a on:el:click="confirmEdit()">
-                                              <action-toolbar-control>
-                                                <i class="fa fa-trash"></i>
-                                              </action-toolbar-control>
-                                          </a>
-                                  </confirm-edit-action>
-                                </editable-document-object-list-item>
+                                <item-edit-control document:from="{.}"
+                                    propName:from="'notes'"
+                                    value:from="notes"
+                                    instance:from="instance"
+                                    placeholder="Add optional description"
+                                    isEditIconDenied:from="isEditDenied"
+                                    on:removeItem="removeRelatedItem(scope.event.payload, 'files')">
+                                  <a class="item-edit-control__content__link"
+                                     href="{{normalizeLink link}}"
+                                     target="_blank"
+                                     rel="tooltip"
+                                     data-original-title="{{title}}">
+                                    {{title}}
+                                  </a>
+                                  {{#unless editMode}}
+                                    <div class="object-list__item__description">
+                                      {{notes}}
+                                    </div>
+                                  {{/unless}}
+                                  <span class="date">{{localize_date created_at}}</span>
+                                </item-edit-control>
                             </object-list>
                             <confirm-edit-action
                                         on:setInProgress="setInProgressState()"
@@ -130,38 +137,47 @@
                                 Evidence URL
                             </div>
                             <object-list items:from="urls" emptyMessage:from="noItemsText">
-                                <editable-document-object-list-item document:from="{.}">
-                                    <confirm-edit-action
-                                        on:setEditMode="removeRelatedItem(document, 'urls')"
-                                        on:setInProgress="setInProgressState()"
-                                        isEditIconDenied:from="isEditDenied"
-                                        instance:from="instance"
-                                        onStateChangeDfd:from="onStateChangeDfd">
-                                            <a on:el:click="confirmEdit">
-                                                <action-toolbar-control>
-                                                    <i class="fa fa-trash"></i>
-                                                </action-toolbar-control>
-                                            </a>
-                                    </confirm-edit-action>
-                                </editable-document-object-list-item>
-                            </object-list>
+                              <item-edit-control document:from="{.}"
+                                    propName:from="'notes'"
+                                    value:from="notes"
+                                    instance:from="instance"
+                                    placeholder="Add optional description"
+                                    isEditIconDenied:from="isEditDenied"
+                                    on:removeItem="removeRelatedItem(scope.event.payload, 'urls')">
+                                  <a class="item-edit-control__content__link"
+                                     href="{{normalizeLink link}}"
+                                     target="_blank"
+                                     rel="tooltip"
+                                     data-original-title="{{title}}">
+                                    {{title}}
+                                  </a>
+                                  {{#unless editMode}}
+                                    <div class="object-list__item__description">
+                                      {{notes}}
+                                    </div>
+                                  {{/unless}}
+                                  <span class="date">{{localize_date created_at}}</span>
+                              </item-edit-control>
+                          </object-list>
                           {{#unless isEditDenied}}
                             {{#if urlsEditMode}}
                                 <create-url
                                     context:from="instance.context"
                                     on:setEditMode="setUrlEditMode(false)">
                                     <form class="create-form">
-                                        <fieldset class="create-form__layout">
-                                            <input value:bind="value" class="create-form__input" type="text" placeholder="Add URL" spellcheck="false" autocomplete="false">
-                                            <div class="create-form__controls">
-                                                <button type="button" class="create-form__confirm" on:el:click="create">
-                                                    <i class="fa fa-check"></i>
-                                                </button>
-                                                <button type="button" class="create-form__cancel" on:el:click="clear">
-                                                    <i class="fa fa-times"></i>
-                                                </button>
-                                            </div>
-                                        </fieldset>
+                                      <div class="item-edit-control">
+                                        <div class="item-edit-control__content">
+                                          <input value:bind="value" class="create-form__input" type="text" placeholder="Add URL" spellcheck="false" autocomplete="false">
+                                         </div>
+                                         <div class="create-form__controls">
+                                           <button type="button" class="create-form__confirm" on:el:click="create">
+                                               <i class="fa fa-check"></i>
+                                           </button>
+                                           <button type="button" class="create-form__cancel" on:el:click="clear">
+                                               <i class="fa fa-times"></i>
+                                           </button>
+                                         </div>
+                                      </div>
                                     </form>
                                 </create-url>
                             {{else}}

--- a/src/ggrc-client/js/components/assessment/info-pane/create-url.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/create-url.js
@@ -51,5 +51,8 @@ export default canComponent.extend({
           });
         });
     },
+    clear: function () {
+      this.dispatch({type: 'setEditMode'});
+    },
   }),
 });

--- a/src/ggrc-client/js/components/item-edit-control/item-edit-control.js
+++ b/src/ggrc-client/js/components/item-edit-control/item-edit-control.js
@@ -1,0 +1,88 @@
+/*
+    Copyright (C) 2019 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+*/
+
+import canStache from 'can-stache';
+import canMap from 'can-map';
+import canComponent from 'can-component';
+import template from './item-edit-control.stache';
+import {notifier} from '../../plugins/utils/notifiers-utils';
+import * as businessModels from '../../models/business-models';
+
+export default canComponent.extend({
+  tag: 'item-edit-control',
+  view: canStache(template),
+  leakScope: true,
+  viewModel: canMap.extend({
+    instance: {},
+    editMode: false,
+    value: '',
+    document: {},
+    placeholder: '',
+    propName: '',
+    isEditIconDenied: false,
+    context: {
+      value: null,
+    },
+    setEditMode: function () {
+      this.attr('editMode', true);
+    },
+    save: function () {
+      const oldValue = this.attr('value');
+      let value = this.attr('context.value');
+
+      this.attr('editMode', false);
+
+      if (typeof value === 'string') {
+        value = value.trim();
+      }
+
+      if (oldValue === value) {
+        return;
+      }
+
+      this.updateItem(value);
+    },
+    cancel: function () {
+      const value = this.attr('value');
+      this.attr('editMode', false);
+      this.attr('context.value', value);
+    },
+    updateContext: function () {
+      const value = this.attr('value');
+      this.attr('context.value', value);
+    },
+    fieldValueChanged: function (args) {
+      this.attr('context.value', args.value);
+    },
+    remove: function (document) {
+      this.dispatch({
+        type: 'removeItem',
+        payload: document,
+      });
+    },
+    async updateItem(value) {
+      const document = this.attr('document');
+      const model = businessModels[document.type];
+      try {
+        const object = await model.findOne({id: document.id});
+        object[this.attr('propName')] = value;
+        await model.update(object.id, object);
+        this.attr('value', value);
+      } catch (err) {
+        notifier('error', 'Unable to update.');
+      }
+    },
+  }),
+  events: {
+    init: function () {
+      this.viewModel.updateContext();
+    },
+    '{viewModel} value': function () {
+      if (!this.viewModel.attr('editMode')) {
+        this.viewModel.updateContext();
+      }
+    },
+  },
+});

--- a/src/ggrc-client/js/components/item-edit-control/item-edit-control.stache
+++ b/src/ggrc-client/js/components/item-edit-control/item-edit-control.stache
@@ -1,0 +1,46 @@
+{{!
+    Copyright (C) 2019 Google Inc.
+    Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+}}
+
+{{#if editMode}}
+<div class="item-edit-control">
+  <div class="document-object-item item-edit-control__content">
+    <div class="document-object-item__body">
+      <content></content>
+      <text-form-field value:from="value"
+          placeholder:from="placeholder"
+          on:valueChanged="fieldValueChanged(scope.event)">
+      </text-form-field>
+    </div>
+  </div>
+  <div class="create-form__controls">
+    <button href="javascript://" type="button" class="create-form__confirm" on:el:click="save()">
+      <i class="fa fa-check"></i>
+    </button>
+    <button type="button" class="create-form__cancel" on:el:click="cancel()">
+      <i class="fa fa-times"></i>
+    </button>
+  </div>
+</div>
+{{else}}
+<div class="action-toolbar action-toolbar-align">
+  <div class="action-toolbar__item-control-content">
+    <div class="document-object-item">
+      <div class="document-object-item__body">
+        <content></content>
+      </div>
+    </div>
+  </div>
+  <div class="action-toolbar__controls">
+    {{#unless isEditIconDenied}}
+      <action-toolbar-control on:el:click="setEditMode(scope.event)">
+        <i class="fa fa-pencil-square-o"></i>
+      </action-toolbar-control>
+      <action-toolbar-control on:el:click="remove(document)">
+        <i class="fa fa-trash"></i>
+      </action-toolbar-control>
+    {{/unless}}
+  </div>
+</div>
+{{/if}}

--- a/src/ggrc-client/js/components/object-list-item/editable-document-object-list-item.stache
+++ b/src/ggrc-client/js/components/object-list-item/editable-document-object-list-item.stache
@@ -3,7 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div class="action-toolbar">
+<div class="action-toolbar action-toolbar-align">
     <div class="action-toolbar__content-item">
       <document-object-list-item instance:from="document"></document-object-list-item>
     </div>

--- a/src/ggrc-client/js/components/related-objects/templates/related-urls.stache
+++ b/src/ggrc-client/js/components/related-objects/templates/related-urls.stache
@@ -7,6 +7,29 @@
   <content/>
   <div class="related-urls__list">
     <object-list items:bind="urls" emptyMessage:from="emptyMessage" showMore:from="showMore">
+      {{#is(modelType, "Evidence")}}
+        <item-edit-control document:bind="{.}"
+                         propName:from="'notes'"
+                         value:bind="notes"
+                         instance:from="instance"
+                         placeholder="Add optional description"
+                         isEditIconDenied:from="isEditDenied"
+                         on:removeItem=removeUrl(%context)>
+          <a class="item-edit-control__content__link"
+             href="{{normalizeLink link}}"
+             target="_blank"
+             rel="tooltip"
+             data-original-title="{{title}}">
+            {{title}}
+          </a>
+          {{#unless editMode}}
+            <div class="object-list__item__description">
+              {{notes}}
+            </div>
+          {{/unless}}
+          <span class="date">{{localize_date created_at}}</span>
+        </item-edit-control>
+      {{else}}
       <div class="action-toolbar">
         <document-object-list-item
           instance:from="{.}">
@@ -23,28 +46,32 @@
           </div>
         {{/if}}
       </div>
+      {{/is}}
     </object-list>
   </div>
   {{#if canAddUrl}}
     {{#if isFormVisible}}
       <form class="related-urls__create create-form">
-        <fieldset class="create-form__layout"
-          {{#if isDisabled}}disabled{{/if}}>
-          <input el:value:bind="value"
-          class="create-form__input"
-          type="text"
-          placeholder="Add URL"
-          spellcheck="false"
-          autocomplete="false">
-          <div class="create-form__controls">
-            <button type="submit" class="create-form__confirm" on:el:click="submitCreateUrlForm(value)">
-              <i class="fa fa-check"></i>
-            </button>
-            <button type="button" class="create-form__cancel" on:el:click="toggleFormVisibility(false)">
-              <i class="fa fa-times"></i>
-            </button>
-          </div>
-        </fieldset>
+        <div class="item-edit-control">
+          <fieldset {{#if isDisabled}}disabled{{/if}}>
+            <div class="item-edit-control__content">
+               <input el:value:bind="value"
+               class="create-form__input"
+               type="text"
+               placeholder="Add URL"
+               spellcheck="false"
+               autocomplete="false">
+            </div>
+            <div class="create-form__controls">
+              <button type="submit" class="create-form__confirm" on:el:click="submitCreateUrlForm(value)">
+                <i class="fa fa-check"></i>
+              </button>
+              <button type="button" class="create-form__cancel" on:el:click="toggleFormVisibility(false)">
+                <i class="fa fa-times"></i>
+              </button>
+            </div>
+          </fieldset>
+        </div>
       </form>
     {{else}}
       <button type="button"

--- a/src/ggrc-client/js/models/business-models/evidence.js
+++ b/src/ggrc-client/js/models/business-models/evidence.js
@@ -69,7 +69,9 @@ export default Cacheable.extend({
       {
         attr_title: 'Description',
         attr_name: 'description',
-      }],
+      },
+      {attr_title: 'Notes', attr_name: 'notes'},
+    ],
   },
 }, {
   define: {

--- a/src/ggrc-client/js/templates/audits/info.stache
+++ b/src/ggrc-client/js/templates/audits/info.stache
@@ -28,8 +28,8 @@
             </div>
             <div class="pane-header__toolbar">
               {{#if is_info_pin}}
-                <info-pin-buttons maximized:from="maximized" 
-                                  onChangeMaximizedState:from="@onChangeMaximizedState" 
+                <info-pin-buttons maximized:from="maximized"
+                                  onChangeMaximizedState:from="@onChangeMaximizedState"
                                   onClose:from="@onClose">
                 </info-pin-buttons>
               {{/if}}
@@ -70,7 +70,8 @@
                   isDisabled:from="isLoading"
                   isNotEditable:from="instance.archived"
                   on:createUrl="createRelatedDocument(scope.event.payload)"
-                  on:removeUrl="removeRelatedDocument(scope.event.payload)">
+                  on:removeUrl="removeRelatedDocument(scope.event.payload)"
+                  modelType:from="modelType">
                   <div class="related-urls__heading">
                     <h6 class="related-urls__title">Evidence URL</h6>
                   </div>

--- a/src/ggrc-client/js/templates/audits/modal_content.stache
+++ b/src/ggrc-client/js/templates/audits/modal_content.stache
@@ -164,10 +164,13 @@
           </div>
         </div>
       </div>
-      <div class="span3 hidable">
-        <ggrc-gdrive-folder-picker instance:from="instance" deferred:from="true" tabindex="13"></ggrc-gdrive-folder-picker>
+    </div>
+
+    <div class="row-fluid">
+      <div class="span4 hidable">
+          <ggrc-gdrive-folder-picker instance:from="instance" deferred:from="true" tabindex="13"></ggrc-gdrive-folder-picker>
       </div>
-      <div class="span3 hidable">
+      <div class="span4 hidable">
         <deferred-mapper
           instance:from="instance">
           <related-documents

--- a/src/ggrc-client/js/templates/evidence/info.stache
+++ b/src/ggrc-client/js/templates/evidence/info.stache
@@ -24,6 +24,18 @@
               </div>
 
               {{> /static/templates/base_objects/description.stache}}
+
+              <div class="row-fluid wrap-row">
+                <div class="span12">
+                  <div class="info-pane__section-title">Notes</div>
+                  {{#if instance.notes}}
+                    <div class="info-pane__text">{{instance.notes}}</div>
+                  {{else}}
+                    <span class="empty-message">None</span>
+                  {{/if}}
+                </div>
+              </div>
+
               {{> /static/templates/base_objects/contacts.stache}}
 
               <div class="row-fluid wrap-row">

--- a/src/ggrc-client/js/templates/evidence/modal_content.stache
+++ b/src/ggrc-client/js/templates/evidence/modal_content.stache
@@ -63,6 +63,20 @@
         <input disabled class="input-block-level" type="text" value:from="slug">
       </div>
     </div>
+
+    <div class="ggrc-form-item">
+      <div class="ggrc-form-item__row">
+        <label class="ggrc-form-item__label">
+          Notes
+        </label>
+        <input type="text"
+          id="form-field-notes"
+          placeholder="Enter Notes"
+          class="input-block-level"
+          el:value:bind="instance.notes">
+      </div>
+    </div>
+
   </form>
 </div>
 {{/instance}}

--- a/src/ggrc-client/styles/components/action-toolbar/_action-toolbar.scss
+++ b/src/ggrc-client/styles/components/action-toolbar/_action-toolbar.scss
@@ -46,4 +46,13 @@
     @extend %editable-control-item;
     margin: 0 0 0 8px;
   }
+
+  &__item-control-content {
+    min-width: 0;
+    max-width: 60%;
+  }
+}
+
+.action-toolbar-align{
+  align-items: flex-start;
 }

--- a/src/ggrc-client/styles/components/info-pane/_info-pane.scss
+++ b/src/ggrc-client/styles/components/info-pane/_info-pane.scss
@@ -14,6 +14,10 @@
     position: relative;
   }
 
+  &__text {
+    word-break: break-word;
+  }
+
   &__section {
     display: block;
     margin: 0 16px 16px 0;

--- a/src/ggrc-client/styles/components/mapped-objects/_mapped-objects.scss
+++ b/src/ggrc-client/styles/components/mapped-objects/_mapped-objects.scss
@@ -149,6 +149,42 @@
   }
 }
 
+.item-edit-control {
+  margin-bottom: 16px;
+  width: 60%;
+
+  &__content {
+    padding: 8px 10px;
+    background-color: $white;
+    border-radius: 2px 2px 0 2px;
+    border: 1px solid #ccc;
+    margin: 0;
+
+    &__link {
+      max-width: 100%;
+      font-style: italic;
+      font-size: 13px;
+      display: inline-block;
+      cursor: pointer;
+
+      @include text-overflow();
+    }
+
+    input {
+      box-sizing: border-box;
+      height: 28px;
+      margin: 0;
+      width: 100%;
+    }
+
+    .input-wrapper {
+      input {
+        margin: 4px 0 0;
+      }
+    }
+  }
+}
+
 .comment-object-item {
   display: block;
   margin: 0 16px 30px 0;
@@ -177,8 +213,8 @@
     flex-wrap: wrap;
 
     .comment-object-item__header-author {
-       display: flex;
-       margin-right: 6px;
+      display: flex;
+      margin-right: 6px;
 
       person-data {
         font-size: 11px;

--- a/src/ggrc-client/styles/components/object-list/_object-list.scss
+++ b/src/ggrc-client/styles/components/object-list/_object-list.scss
@@ -78,8 +78,12 @@ object-list {
     padding: 0;
     color: $text;
     min-width: 0;
+    &__description {
+      font-style: italic;
+      word-break: break-word;
+    }
   }
-
+  
   &__item-empty {
     color: #999;
     font-style: italic;

--- a/src/ggrc/migrations/versions/20190924_394f80f98f02_add_notes_column_to_evidence.py
+++ b/src/ggrc/migrations/versions/20190924_394f80f98f02_add_notes_column_to_evidence.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add notes column to evidence
+
+Create Date: 2019-09-24 08:33:07.944851
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '394f80f98f02'
+down_revision = '75ad21f0622b'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  op.execute("""
+      ALTER TABLE evidence
+        ADD notes TEXT NULL;
+  """)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/models/evidence.py
+++ b/src/ggrc/models/evidence.py
@@ -59,6 +59,8 @@ class Evidence(Roleable, Relatable, mixins.Titled,
   description = deferred(db.Column(db.Text, nullable=False, default=u""),
                          "Evidence")
 
+  notes = deferred(db.Column(db.Text, nullable=True), "Notes")
+
   # Override from Commentable mixin (can be removed after GGRC-5192)
   send_by_default = db.Column(db.Boolean, nullable=False, default=True)
 
@@ -72,6 +74,7 @@ class Evidence(Roleable, Relatable, mixins.Titled,
       reflection.Attribute("parent_obj", read=False, update=False),
       reflection.Attribute('archived', create=False, update=False),
       reflection.Attribute('is_uploaded', read=False, update=False),
+      "notes",
   )
 
   _fulltext_attrs = [

--- a/test/integration/ggrc/models/test_evidence.py
+++ b/test/integration/ggrc/models/test_evidence.py
@@ -103,6 +103,27 @@ class TestEvidence(TestCase):
                      'Expected options are `URL`, `FILE`"',
                      resp.data)
 
+  def test_change_evidence_put(self):
+    """Test change evidence notes via put request"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory(audit=audit)
+      evidence = factories.EvidenceFactory(
+          title='Test title',
+          kind=all_models.Evidence.URL,
+          description='',
+          source_gdrive_id='gdrive_file_id',
+          parent_obj={
+              'id': assessment.id,
+              'type': 'Assessment'
+          }
+      )
+      evidence_id = evidence.id
+    resp = self.api.put(evidence, {"notes": "test_notes"})
+    self.assert200(resp)
+    evidence = all_models.Evidence.query.get(evidence_id)
+    self.assertEqual(evidence.notes, "test_notes")
+
   @mock.patch('ggrc.gdrive.file_actions.process_gdrive_file',
               dummy_gdrive_response)
   def test_get_parent_obj_audit_type(self):

--- a/test/selenium/src/lib/element/page_elements.py
+++ b/test/selenium/src/lib/element/page_elements.py
@@ -187,7 +187,8 @@ class AssessmentEvidenceUrls(object):
 
   def get_urls(self):
     """Get urls"""
-    return [el.text for el in self._root.elements(class_name="link")]
+    return [el.text for el in self._root.elements(
+        class_name="item-edit-control__content__link")]
 
 
 class CommentArea(object):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

What   is the problem / issue?   
Although we can use the Response/Comment field to add comments, I believe it   would be easier to have a dedicated field for small comments (ex: "See   section x.y" or "Go to page x")       
What is the impact if it is not fixed / implemented? 
(Quantify the impact,   eg, # of hours)   Minor confusion could occur when adding multiple links/files.

Solution to be implemented:
AC1: Add on Evidence file and evidence url INFO PAGE / INFO PANE/ EDIT EVIDENCE POPUP additional field named 'Notes'. Field type 'Text'
AC2: Add on Assessments/Audits INFO PANE / INFO PAGE / EDIT POPUPs near added Evidence URL/file an 'Edit' icon.
AC3: On 'Edit' icon click a popover with text field, Approve and Cancel buttons should appear.
AC4: After adding a text to popover and clicking 'Approve' a text should appear under 'Evidence file/URL'.
AC5:  After adding a text to popover and clicking 'Cancel' a text should NOT appear under 'Evidence file/URL'.

# Steps to test the changes

1. Open any Assessment/Audit.
2. Click Add Evidence Url/Attach Evidence File.
3. After adding/attaching click 'Edit' icon near the url/file.
4. Verify that a popover with text field, Approve and Cancel buttons are shown. |
5. Enter any notes and click 'Approve'. 
6. Verify that notes appears under url/file. 
7. Verify that notes fields is shown on the Evidence Info. 

# Solution description
FE:
1. Added on Evidence file and evidence url INFO PAGE / INFO PANE/ EDIT EVIDENCE POPUP additional field named 'Notes'. Field type 'Text'
2. Added on Assessments/Audits INFO PANE / INFO PAGE / EDIT POPUPs near added Evidence URL/file an 'Edit' icon.
3. On 'Edit' icon click a popover with text field, Approve and Cancel buttons should appear.
4. After adding a text to popover and clicking 'Approve' a text should appear under 'Evidence file/URL'.
5. After adding a text to popover and clicking 'Cancel' a text should NOT appear under 'Evidence file/URL'.
6. Fixed 'Cancel' button on Add popup. 

BE:
1. Added Text null able field "notes" to Evidence class
2. Created migration for "notes"
# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
