### PR TITLE
GGRC-7486 Comparison window contains updates for GCA which should not be changed

### DIFF
--- a/src/ggrc/models/revision.py
+++ b/src/ggrc/models/revision.py
@@ -663,6 +663,10 @@ class Revision(before_flush_handleable.BeforeFlushHandleable,
     populated_content.update(self.populate_readonly())
     populated_content.update(self.populate_automappings())
 
+    populated_content["custom_attribute_definitions"] = sorted(
+        populated_content["custom_attribute_definitions"],
+        key=lambda x: x['id'])
+
     self.populate_requirements(populated_content)
     self.populate_options(populated_content)
     self.populate_review_status_display_name(populated_content)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Front-end expected that CADs will not change the order when we create new one CAD. So, new CADs should be always at the end of the list.

# Steps to test the changes

1. Log in ggrc app as admin user and open any audit
2. Map Facility object with GCA rich text to audit (snapshot Facility is created)
3. Go to Admin page and add any GCA (date) to Facility
4. Open Original Facility and fill GCA date
5. Open Facility snapshot on the audit page in treeView and open Comparison window by clicking 'Get the latest version' link
Actual Result: GCA rich text marked to be updated
Expected Result: No changes should be triggered for GCA rich text

# Solution description

Front end expected CADs sorted by creation. In a DB we have CADs sorted by title. We should update response format to the expected one.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
