### PR TITLE
GGRC-4249 User with changed role act as user with ex-role

### DIFF
--- a/src/ggrc-client/js/bootstrap/modal-ajax.js
+++ b/src/ggrc-client/js/bootstrap/modal-ajax.js
@@ -129,6 +129,7 @@ let handlers = {
     } else {
       instance = model.findInCacheById($trigger.attr('data-object-id'));
     }
+    const isNewInstance = !instance;
 
     objectParams = objectParams ? JSON.parse(objectParams) : {};
     extendNewInstance = extendNewInstance
@@ -209,25 +210,10 @@ let handlers = {
             return;
           }
         }
+        const promise =
+          isNewInstance ? refreshPermissions() : Promise.resolve();
 
-        refreshPermissions().then(function () {
-          let hiddenElement;
-          let tagName;
-
-          // 'is_allowed' helper rerenders an elements
-          // we should trigger event for hidden element
-          if (!$trigger.is(':visible') && option.uniqueId &&
-            $trigger.context) {
-            tagName = $trigger.context.tagName;
-
-            hiddenElement =
-              $(tagName + "[data-unique-id='" + option.uniqueId + "']");
-
-            if (hiddenElement) {
-              $trigger = hiddenElement;
-            }
-          }
-
+        promise.then(() => {
           $trigger.trigger(
             'modal:success', Array.prototype.slice.call(args, 1)
           );

--- a/src/ggrc-client/js/components/object-mapper/create-and-map.stache
+++ b/src/ggrc-client/js/components/object-mapper/create-and-map.stache
@@ -36,7 +36,6 @@
           data-modal-class="modal-wide"
           data-object-singular="{{destinationModel.model_singular}}"
           data-object-plural="{{destinationModel.table_plural}}"
-          data-unique-id="{{source.id}}"
           data-join-object-id="{{source.id}}">
 
           {{#if isMegaMapping}}

--- a/src/ggrc-client/js/plugins/utils/user-utils.js
+++ b/src/ggrc-client/js/plugins/utils/user-utils.js
@@ -74,10 +74,15 @@ function getUserObjectRoles(person) {
   return allRoleNames;
 }
 
+function getCurrentUser() {
+  return GGRC.current_user;
+}
+
 export {
   cacheCurrentUser,
   getPersonInfo,
   loadPersonProfile,
   getUserSystemRoles,
   getUserObjectRoles,
+  getCurrentUser,
 };


### PR DESCRIPTION
# Issue description
When we reassign role from Role A (for example, WF Admin) to Role B (for example, WF Member) then, if we did not refresh the page, we still have ability to make actions like for Role A (Admin). 

# Steps to test the changes 
1. Create some of this objects: assessment, wf, standard, regulation, requirement, objective, product, systems, metrics, technology env, product groups, proccesses, audit, access group, contract, data asset, document, evidence, facilities, key report, markets, org groups, policies, programs, projects, tasks, threats, vendors. 
2. Delete yourself from role 
**Actual Result**: You have ability to make actions like for role that was deleted. 
**Expected result**: Page should reload with new permisions. 
# Solution description 
Refresh the permissions after delete yourself on all objects with inline edit (assessment, wf, standard, regulation, requirement, objective, product, systems, metrics, technology env, product groups, proccesses, audit, access group, contract, data asset, document, evidence, facilities, key report, markets, org groups, policies, programs, projects, tasks, threats, vendors).
# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [x] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".