### PR TITLE
GGRC-7779 Add tooltip to the GCA attributes with long title

### DIFF
--- a/src/ggrc-client/js/components/gca-controls/gca-controls.stache
+++ b/src/ggrc-client/js/components/gca-controls/gca-controls.stache
@@ -6,12 +6,26 @@
 <div class="ggrc-form-item {{#isHidable .}}hidable{{/isHidable}}">
   <div class="ggrc-form-item__row {{#if_helpers '\n #if' validationState.hasGCAErrors '\n and #if' instance.computed_errors.custom_attribute_values}}field-failure{{/if_helpers}}">
     <div class="ggrc-form-item__field-header">
-      <label for="form-field-{{customAttributeId}}" class="form-label ggrc-form-item__label form-label__extended">
-        <span class="ggrc-form-item__label-text">{{title}}</span>
-        {{#if mandatory}}
-          <i class="fa fa-asterisk"></i>
-        {{/if}}
-      </label>
+      <tooltip-content
+        class="oneline"
+        placement:from="'bottom'"
+        content:from="title"
+      >
+        <label
+          for="form-field-{{customAttributeId}}"
+          class="form-label ggrc-form-item__label form-label__extended"
+        >
+          <span
+            class="ggrc-form-item__label-text"
+            data-trim-target="true"
+          >
+            {{title}}
+          </span>
+          {{#if mandatory}}
+            <i class="fa fa-asterisk"></i>
+          {{/if}}
+        </label>
+      </tooltip-content>
       <div class="ggrc-form-item__controls">
         {{#isHidable .}}
           <a class="field-hide" tabindex="-1">hide</a>

--- a/src/ggrc-client/js/templates/custom_attributes/info.stache
+++ b/src/ggrc-client/js/templates/custom_attributes/info.stache
@@ -28,12 +28,23 @@
               redirectionEnabled:from="redirectionEnabled"
               isEditIconDenied:from="isEditIconDenied"
               on:setEditModeInline="setEditModeInline(scope.event)">
-                <div class="info-pane__section-title {{#if mandatory}}form-label form-label__extended{{/if}}">
-                  {{title}}
-                  {{#if mandatory}}
-                    <i class="fa fa-asterisk"></i>
-                  {{/if}}
-                </div>
+                <tooltip-content
+                  class="single-line"
+                  placement:from="'bottom'"
+                  content:from="title"
+                >
+                  <div class="{{#if mandatory}}form-label form-label__extended{{/if}}">
+                    <div
+                      class="info-pane__section-title"
+                      data-trim-target="true"
+                    > 
+                      {{title}}
+                    </div>
+                    {{#if mandatory}}
+                      <i class="fa fa-asterisk"></i>
+                    {{/if}}
+                  </div>
+                </tooltip-content>
             </base-inline-control-title>
             {{#if helptext}}
               <div class="ggrc-form-item__small-text">


### PR DESCRIPTION
# Issue description
Add tooltip to the GCA attributes with long title.

# Steps to test the changes 
1. Login in GGRC app. 
2. Open Administration page. 
3. Add GCA attribute with long title e.g to the Objective.  
4. Open any Objective object and review created GCA. 
**Actual**: A part of the GCA's title is cut and there is no possibility to view all the title. 
**Expected**: Full GCA's title is be visible in toolltip.  

# Solution description 
Add tooltip when we hover over the title. 

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".