### PR TITLE
GGRC-7908 Add test checking mentioning person works if the first character is '+' or '@'

### DIFF
--- a/test/selenium/src/lib/constants/counters.py
+++ b/test/selenium/src/lib/constants/counters.py
@@ -10,3 +10,6 @@ BATCH_COUNT = 2
 
 # number of try operations
 TRY_COUNT = 2
+
+# max number of items in emails dropdown
+MAX_EMAILS_IN_DROPDOWN = 10

--- a/test/selenium/src/lib/constants/str_formats.py
+++ b/test/selenium/src/lib/constants/str_formats.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""String formats."""
+from lib.utils import string_utils
+
+MENTIONED_EMAIL = string_utils.Symbols.PLUS + "{email} "
+MAILTO = "mailto:{email}"

--- a/test/selenium/src/lib/ui/comments_ui_facade.py
+++ b/test/selenium/src/lib/ui/comments_ui_facade.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""UI facade for comment actions."""
+# pylint: disable=invalid-name
+from lib.constants import counters, str_formats
+from lib.service import webui_service
+from lib.utils import string_utils
+
+
+def soft_assert_max_emails_num(comments_panel, soft_assert):
+  """Soft assert max number of emails in dropdown is valid."""
+  soft_assert.expect(
+      comments_panel.emails_dropdown.number_of_items ==
+      counters.MAX_EMAILS_IN_DROPDOWN,
+      "There should be max {} items in dropdown".format(
+          counters.MAX_EMAILS_IN_DROPDOWN))
+
+
+def soft_assert_mentioning_format_in_input_field(
+    soft_assert, email, comments_panel
+):
+  """Soft assert selected email appears in input field with '+' sign before
+  it.
+  """
+  soft_assert.expect(comments_panel.input_field.text ==
+                     str_formats.MENTIONED_EMAIL.format(email=email),
+                     "Selected email should appear in comment field with '{}'"
+                     " sign before it".format(string_utils.Symbols.PLUS))
+
+
+def soft_assert_mentioning_format_in_comment(
+    comments_panel, soft_assert, email
+):
+  """Soft assert mentioned email appears in comment with '+' sign before it
+  and it is a link."""
+  soft_assert.expect(comments_panel.scopes[0].get('description') ==
+                     str_formats.MENTIONED_EMAIL.format(email=email).rstrip(),
+                     "Comment should be displayed under 'Comments' box")
+  soft_assert.expect(str_formats.MAILTO.format(email=email) in
+                     comments_panel.scopes[0].get('links'),
+                     "Added comment should be a link")
+
+
+def check_mentioning_on_asmt_comment_panel(
+    selenium, soft_assert, audit, assessment, first_symbol
+):
+  """Checks mentioning on assessment comment panel on info panel."""
+  comments_panel = (webui_service.AssessmentsService(selenium).
+                    open_info_panel_of_mapped_obj(
+                        src_obj=audit, obj=assessment).comments_panel)
+  comments_panel.call_email_dropdown(first_symbol)
+  soft_assert_max_emails_num(comments_panel, soft_assert)
+  mentioned_email = comments_panel.emails_dropdown.select_first_email()
+  soft_assert_mentioning_format_in_input_field(
+      soft_assert, mentioned_email, comments_panel)
+  comments_panel.click_add_button()
+  soft_assert_mentioning_format_in_comment(
+      comments_panel, soft_assert, mentioned_email)
+  soft_assert.assert_expectations()

--- a/test/selenium/src/lib/utils/string_utils.py
+++ b/test/selenium/src/lib/utils/string_utils.py
@@ -23,6 +23,8 @@ class Symbols(object):
   BACK_QUOTE = "`"
   BACKSLASH = "\\"
   PIPE = "|"
+  AT_SIGN = "@"
+  PLUS = "+"
 
   def __init__(self, additional_exclude=''):
     """Create symbols sets.

--- a/test/selenium/src/tests/test_mentioning_person.py
+++ b/test/selenium/src/tests/test_mentioning_person.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+"""Mentioning person smoke tests."""
+# pylint: disable=no-self-use
+# pylint: disable=too-many-arguments
+# pylint: disable=unused-argument
+# pylint: disable=invalid-name
+
+import pytest
+
+from lib.rest_facades import person_rest_facade
+from lib.ui import comments_ui_facade
+from lib.utils import string_utils
+
+
+class TestMentioningPerson(object):
+  """Tests of mentioning person."""
+
+  @pytest.fixture(scope="function")
+  def people(self):
+    """Creates 10 people."""
+    for _ in xrange(10):
+      person_rest_facade.create_person()
+
+  @pytest.mark.parametrize('first_symbol', [string_utils.Symbols.PLUS,
+                                            string_utils.Symbols.AT_SIGN])
+  def test_mentioning_on_asmt_comment_panel(
+      self, people, audit, assessment, selenium, first_symbol, soft_assert
+  ):
+    """Checks mentioning on assessment comment panel on info panel.
+
+    Preconditions:
+        - Program created via REST API.
+        - Audit created under Program via REST API.
+        - Assessment created under Audit via REST API.
+        - 10 People created via REST API.
+    """
+    comments_ui_facade.check_mentioning_on_asmt_comment_panel(
+        selenium, soft_assert, audit, assessment, first_symbol)


### PR DESCRIPTION

# Solution description

Add test checking mentioning person in comments box on assessment info page works if the first character is '+' or '@'.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

