### PR TITLE
GGRC-2686 Add reindex button and it's status info on admin page

### DIFF
--- a/src/ggrc/templates/maintenance/trigger.html
+++ b/src/ggrc/templates/maintenance/trigger.html
@@ -32,6 +32,11 @@
               <input type="submit" value="Run migrations">  Status : {{ migration_status }}
           </p>
       </form>
+      <form action='/maintenance/reindex' method='POST'>
+          <p>
+              <input type="submit" value="Run reindex">  Status : {{ reindex_status }}
+          </p>
+      </form>
     </div>
 
   </div>

--- a/test/integration/ggrc/maintenance/__init__.py
+++ b/test/integration/ggrc/maintenance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>

--- a/test/integration/ggrc/maintenance/test_maintenance.py
+++ b/test/integration/ggrc/maintenance/test_maintenance.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+
+"""Test for indexing of snapshotted objects"""
+
+import mock
+
+from ggrc import settings
+import ggrc.maintenance_views as maintenance_views
+from ggrc.maintenance import maintenance_app
+
+from integration.ggrc import TestCase
+
+
+class TestMaintenanceIntegration(TestCase):
+  """Test set for Maintenance app."""
+
+  def setUp(self):
+    self.client = maintenance_app.test_client()
+    super(TestMaintenanceIntegration, self).setUp()
+    self.init_taskqueue()
+
+  @mock.patch.object(settings, "APP_ENGINE", True, create=True)
+  def test_run_reindex(self):
+    """Reindex from Maintenance app"""
+    with maintenance_app.test_client() as client:
+      self.assertEqual(
+          maintenance_views.maintenance.get_latest_task_status("reindex"),
+          None)
+
+      response = client.post("/maintenance/reindex")
+      self.assertEqual(
+          response.status_code,
+          302)
+      latest_reindex = maintenance_views.maintenance \
+                                        .get_latest_task("reindex")
+      self.assertEqual(
+          maintenance_views.maintenance.get_latest_task_status("reindex"),
+          "Pending")
+
+      # Check if is it possible to trigger reindex once
+      # another one is running
+      client.post("/maintenance/reindex")
+      latest_reindex_to_check = maintenance_views.maintenance \
+                                                 .get_latest_task("reindex")
+      self.assertEqual(
+          latest_reindex.id,
+          latest_reindex_to_check.id)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Being logged in as an admin, there is a functionality implemented to trigger reindexing using /maintenance/index admin page. Additionally, last executed task status is shown with following states:
- "Not started" if reindex wasn't started
- "In progress" if reindex is ongoing
- "Finished" if reindex is finished

# Steps to test the changes

1.	Login in GGRC app as Admin 
2.	Open page <domain_name>/maintenance/index 
3.	There is a new button that triggers reindexing and label with last reindexing task result

# Solution description

There is a new endpoint provided "maintenance/reindex" to trigger reindex within maintenance module.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
