### PR TITLE
GGRC-7781/GGRC-7765 Fix import multiselect cad

### DIFF
--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -918,6 +918,62 @@ class TestAssessmentImport(TestCase):
         "text", assessment.custom_attribute_values[0].attribute_value
     )
 
+  def test_asmt_missing_mandatory_gca(self):
+    """"Import asmt with mandatory empty multiselect CAD"""
+    asmt_slug = "TestAssessment"
+    with factories.single_commit():
+      factories.CustomAttributeDefinitionFactory(
+          title="multiselect_GCA",
+          definition_type="assessment",
+          attribute_type="Multiselect",
+          multi_choice_options="1,2,3",
+          mandatory=True,
+      )
+      factories.AssessmentFactory(slug=asmt_slug)
+    response = self.import_data(OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code", asmt_slug),
+        ("multiselect_GCA", ""),
+    ]))
+    expected_response = {
+        "Assessment": {
+            "row_errors": {
+                errors.MISSING_VALUE_ERROR.format(
+                    column_name="multiselect_GCA",
+                    line=3
+                ),
+            },
+        },
+    }
+    self._check_csv_response(response, expected_response)
+
+  def test_asmt_with_multiselect_gca_diff_text(self):
+    """"Import asmt with mandatory diff case text multiselect CAD"""
+    asmt_slug = "TestAssessment"
+    with factories.single_commit():
+      factories.CustomAttributeDefinitionFactory(
+          title="multiselect_GCA",
+          definition_type="assessment",
+          attribute_type="Multiselect",
+          multi_choice_options="Option 1,Option 2,Option 3",
+      )
+
+      # create assessment with 1 CAV
+      asmt = factories.AssessmentFactory(slug=asmt_slug)
+      asmt_id = asmt.id
+    # update given assessment with empty GCA multiselect type
+    response = self.import_data(OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code", asmt_slug),
+        ("multiselect_GCA", "option 1"),
+    ]))
+    self._check_csv_response(response, {})
+    asmt = all_models.Assessment.query.get(asmt_id)
+    self.assertEquals(1, len(asmt.custom_attribute_values))
+    self.assertEquals(
+        "Option 1", asmt.custom_attribute_values[0].attribute_value
+    )
+
   @ddt.data(
       (
           factories.IssueFactory,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

During import Assessment template, mandatory GCAs are not validated on GGRC-QA instance

**Expected**: Error for each empty mandatory field should be shown on import page

**Note**: bug reproduced on multiselect GCA

# Steps to test the changes

1. Create audit
2. Create GCA mandatory multiselect
3. Open Import page
4. Download Assessment template
5. Add any Title, Audit code, Creator and Assignee
6. Leave multiselect GCA mandatory field:
- empty 
- put any value not represented in GCA choices
- put any valid value but with diff cases
7. Import assessment

# Solution description

1. Fixed `get_multiselect_values` method for parsing value
2. Added tests

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
