### PR TITLE
GGRC-7937 Skip custom attribute creation for not new assessment

### DIFF
--- a/src/ggrc/converters/handlers/assessment_template.py
+++ b/src/ggrc/converters/handlers/assessment_template.py
@@ -24,7 +24,7 @@ class AssessmentTemplateColumnHandler(handlers.MappingColumnHandler):
 
   def set_obj_attr(self):
     self.value = self.parse_item()
-    if not self.dry_run:
+    if not self.dry_run and self.row_converter.is_new:
       self.create_custom_attributes()
 
   def insert_object(self):

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -88,6 +88,31 @@ class TestAssessmentImport(TestCase):
     ]))
     self.assertEquals([], response[0]['row_warnings'])
 
+  def test_import_assessment_with_template(self):
+    """If assessment exist and import with template and lca"""
+
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assessment = factories.AssessmentFactory()
+      template = factories.AssessmentTemplateFactory()
+      factories.RelationshipFactory(source=audit,
+                                    destination=assessment)
+      factories.CustomAttributeDefinitionFactory(
+          title="Test LCA",
+          definition_type="assessment",
+          attribute_type="Text",
+          definition_id=assessment.id
+      )
+
+    response = self.import_data(OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", assessment.slug),
+        ("Template", template.slug),
+    ]))
+
+    self.assertEquals([], response[0]["row_warnings"])
+    self.assertEquals([], response[0]["row_errors"])
+
   def test_import_assessment_with_evidence_url_existing(self):
     """If url already mapped to assessment ignore it"""
     evidence_url = "test_gdrive_url"


### PR DESCRIPTION
Precondition:
Create an Audit
Create an assessment template with LCA-s in this Audit (Template 1)
Create an assessment template without LCA-s (Template 2)
Steps to reproduce:
1. Generate an Audit Assessment via template with LCA-s
2. Create the second Assessment via template without LCA-s
3. Export Assessments to google sheet 
4. Insert Template 1 code for two Assessments (in google sheet)
5. Import Assessments
Actual result:  'Import failed due to unknown error' displays while importing assessments with a template with LCA-s.
Expected: A warning should be displayed with the following text: