### PR TITLE
GGRC-7909 Fix complete assessmnet while import

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -504,23 +504,26 @@ class ImportRowConverter(RowConverter):
           modified_objects,
           self.block_converter.CACHE_EXPIRY_IMPORT,
       )
+      store_revision = True
       try:
         self.send_before_commit_signals(import_event)
       except StatusValidationError as exp:
         status_alias = self.headers.get("status", {}).get("display_name")
+        store_revision = False
         self.add_error(errors.VALIDATION_ERROR,
                        column_name=status_alias,
                        message=exp.message)
       db.session.commit_hooks_enable_flag.disable()
       db.session.commit()
-      self.block_converter.store_revision_ids(import_event)
+      if store_revision:
+        self.block_converter.store_revision_ids(import_event)
       cache_utils.update_memcache_after_commit(self.block_converter)
       update_snapshot_index(modified_objects)
     except exc.SQLAlchemyError as err:
       db.session.rollback()
       logger.exception("Import failed with: %s", err.message)
       self.block_converter.add_errors(errors.UNKNOWN_ERROR,
-                                      line=self.offset + 2)
+                                      line=self.block_converter.offset + 2)
     else:
       self.create_comment_notifications()
       self.send_comment_notifications()

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -241,6 +241,12 @@ NO_VERIFIER_WARNING = (u"Line {line}: Assessment without verifier cannot "
                        u"be moved to {status} state. "
                        u"The value will be ignored.")
 
+NO_REQUIRED_ANSWERS_WARNING = (u"Line {line}: Assessment status couldn't be "
+                               u"changed as some required info was not added "
+                               u"to answers. The column 'State' will "
+                               u"be skipped.")
+
+
 UNEXPECTED_ERROR = u"Unexpected error on import."
 
 EXTERNAL_MODEL_IMPORT_RESTRICTION = (u"Line {line}: Import for "

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -782,6 +782,37 @@ class TestAssessmentImport(TestCase):
     response = self.import_data(data)
     self._check_csv_response(response, {})
 
+  def test_import_complete_with_warnings(self):
+    """Test complete assessment with missing mandatory CAD comments."""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      asmnt = factories.AssessmentFactory(audit=audit)
+      factories.CustomAttributeDefinitionFactory(
+          title="CAD",
+          definition_type="assessment",
+          definition_id=asmnt.id,
+          attribute_type="Dropdown",
+          multi_choice_options="no,yes",
+          multi_choice_mandatory="0,1"
+      )
+    data = OrderedDict([
+        ("object_type", "Assessment"),
+        ("Code*", asmnt.slug),
+        ("Audit", audit.slug),
+        ("Title", "Test title"),
+        ("State", "Completed"),
+        ("CAD", "yes"),
+    ])
+    expected_response = {
+        "Assessment": {
+            "row_warnings": {
+                errors.NO_REQUIRED_ANSWERS_WARNING.format(line=3),
+            }
+        }
+    }
+    response = self.import_data(data)
+    self._check_csv_response(response, expected_response)
+
   def test_import_asmnt_rev_query_count(self):
     """Test only one revisions insert query should occur while importing."""
     with factories.single_commit():

--- a/test/integration/ggrc/converters/test_import_assessments.py
+++ b/test/integration/ggrc/converters/test_import_assessments.py
@@ -782,7 +782,7 @@ class TestAssessmentImport(TestCase):
     response = self.import_data(data)
     self._check_csv_response(response, {})
 
-  def test_import_complete_with_warnings(self):
+  def test_import_complete_missing_answers_warnings(self):
     """Test complete assessment with missing mandatory CAD comments."""
     with factories.single_commit():
       audit = factories.AuditFactory()

--- a/test/integration/ggrc/converters/test_import_audit.py
+++ b/test/integration/ggrc/converters/test_import_audit.py
@@ -164,8 +164,8 @@ class TestAuditImport(TestCase):
     ])
     expected_messages = {
         "Audit": {
-            "row_errors": {
-                errors.UNKNOWN_ERROR.format(line=7),
+            "block_errors": {
+                errors.UNKNOWN_ERROR.format(line=4),
             },
         },
         "Person": {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Error is shown on import of Assessment with status changed and filled LCA

# Steps to test the changes

1. Create assessment template with Dropdown LCA "TEST CAD" with values:
 - yes 'comment required'
 - no
2. Generate assessment with "TEST CAD"
3. Export assessment
4. Change "TEST CAD" value to 'yes' and Status to 'Complete'
5. Import changed filed

# Solution description

 - Added asmt validation in `secondary_check_assessment` with the logic same as in `_validate_assessment_done_state`
- Added bool checker in `commit_object` method when exception in `send_before_commit_signals` raise and DB rolled back
- Removed usage `self.offset` attribute in `ImportRowConverter` with the `self.block_converter.offset`

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
