### PR TITLE
RP: GGRC-7959/GGRC-7960 Restrict assignee permissions on Assessment pages/tabs

### DIFF
--- a/src/ggrc-client/js/components/add-tab-button/add-tab-button.js
+++ b/src/ggrc-client/js/components/add-tab-button/add-tab-button.js
@@ -34,6 +34,7 @@ const viewModel = canMap.extend({
         return !this.attr('isAuditInaccessibleAssessment')
           && isAllowedFor('update', instance)
           && !instance.attr('archived')
+          && !instance.attr('is_sox_restricted')
           && !isMyWork()
           && !isAllObjects()
           && this.attr('widgetList.length') > 0;

--- a/src/ggrc-client/js/components/assessment/controls-toolbar/assessment-controls-toolbar.stache
+++ b/src/ggrc-client/js/components/assessment/controls-toolbar/assessment-controls-toolbar.stache
@@ -3,11 +3,13 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<custom-attributes-actions
-  disabled:from="isInfoPaneSaving"
-  instance:from="instance"
-  formEditMode:bind="editMode">
-</custom-attributes-actions>
+{{^if_sox302_restricted instance}}
+  <custom-attributes-actions
+    disabled:from="isInfoPaneSaving"
+    instance:from="instance"
+    formEditMode:bind="editMode">
+  </custom-attributes-actions>
+{{/if_sox302_restricted}}
 <object-state-toolbar verifiers:from="verifiers"
                       instance:from="instance"
                       instanceState:from="currentState"

--- a/src/ggrc-client/js/components/assessment/controls-toolbar/assessment-controls-toolbar.stache
+++ b/src/ggrc-client/js/components/assessment/controls-toolbar/assessment-controls-toolbar.stache
@@ -3,13 +3,13 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-{{^if_sox302_restricted instance}}
+{{#unless instance.is_sox_restricted}}
   <custom-attributes-actions
     disabled:from="isInfoPaneSaving"
     instance:from="instance"
     formEditMode:bind="editMode">
   </custom-attributes-actions>
-{{/if_sox302_restricted}}
+{{/unless}}
 <object-state-toolbar verifiers:from="verifiers"
                       instance:from="instance"
                       instanceState:from="currentState"

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
@@ -209,6 +209,27 @@ export default canComponent.extend({
           return !!audit && isAllowedFor('read', audit);
         },
       },
+      isRestricted: {
+        get: function () {
+          return this.attr('isEditDenied')
+            || this.attr('instance.is_sox_restricted');
+        },
+      },
+      isSemiRestrictedOnStatus: {
+        get: function () {
+          const semiRestrictedStatuses = ['Deprecated', 'Completed'];
+          const isSemiRestrictedStatus = semiRestrictedStatuses
+            .includes(this.attr('instance.status'))
+            && this.attr('instance.is_sox_restricted');
+
+          return this.attr('isEditDenied') || isSemiRestrictedStatus;
+        },
+      },
+      isReuseNeeded: {
+        get: function () {
+          return !this.attr('isSemiRestrictedOnStatus');
+        },
+      },
       instance: {},
       isInfoPaneSaving: {
         get: function () {
@@ -225,6 +246,11 @@ export default canComponent.extend({
             this.attr('isAssessmentSaving');
         },
       },
+      noItemsText: {
+        get: function () {
+          return this.attr('isSemiRestrictedOnStatus') ? 'None' : '';
+        },
+      },
     },
     modal: {
       state: {
@@ -238,7 +264,6 @@ export default canComponent.extend({
     isAssessmentSaving: false,
     onStateChangeDfd: {},
     formState: {},
-    noItemsText: '',
     currentState: '',
     previousStatus: undefined,
     initialState: 'Not Started',
@@ -260,6 +285,15 @@ export default canComponent.extend({
     },
     setInProgressState: function () {
       this.onStateChange({state: 'In Progress', undo: false});
+    },
+    isReadOnlyAttribute: function (propName) {
+      const readOnlyAttributes = this.attr('instance.get_read_only_fields');
+      const isEditDenied = this.attr('isEditDenied');
+      if (readOnlyAttributes) {
+        const isReadOnly = [...readOnlyAttributes].includes(propName);
+        return isReadOnly || isEditDenied;
+      }
+      return isEditDenied;
     },
     getQuery: function (type, sortObj, additionalFilter) {
       let relevantFilters = [{

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.js
@@ -289,11 +289,8 @@ export default canComponent.extend({
     isReadOnlyAttribute: function (propName) {
       const readOnlyAttributes = this.attr('instance.get_read_only_fields');
       const isEditDenied = this.attr('isEditDenied');
-      if (readOnlyAttributes) {
-        const isReadOnly = [...readOnlyAttributes].includes(propName);
-        return isReadOnly || isEditDenied;
-      }
-      return isEditDenied;
+      const isReadOnly = [...readOnlyAttributes].includes(propName);
+      return isReadOnly || isEditDenied;
     },
     getQuery: function (type, sortObj, additionalFilter) {
       let relevantFilters = [{

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
@@ -54,7 +54,6 @@
                                                 <confirm-edit-action
                                                     on:setEditMode="openMapper()"
                                                     on:setInProgress="setInProgressState()"
-                                                    isEditIconDenied:from="isRestricted"
                                                     instance:from="instance"
                                                     onStateChangeDfd:from="onStateChangeDfd"
                                                     editMode:from="editMode">
@@ -174,7 +173,6 @@
                                 <confirm-edit-action
                                     on:setEditMode="setUrlEditMode(true)"
                                     on:setInProgress="setInProgressState()"
-                                    isEditIconDenied:from="isSemiRestrictedOnStatus"
                                     instance:from="instance"
                                     onStateChangeDfd:from="onStateChangeDfd">
                                         <button type="button" class="btn btn-small btn-gray"
@@ -367,7 +365,6 @@
                                                 <confirm-edit-action
                                                     on:setEditMode="openMapper()"
                                                     on:setInProgress="setInProgressState()"
-                                                    isEditIconDenied:from="isRestricted"
                                                     instance:from="instance"
                                                     onStateChangeDfd:from="onStateChangeDfd"
                                                     editMode:from="editMode">

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
@@ -24,7 +24,7 @@
                                 class="width-100"
                                 setInProgress:from="@setInProgressState"
                                 onStateChangeDfd:from="onStateChangeDfd"
-                                isEditIconDenied:from="isEditDenied"
+                                isEditIconDenied:from="isReadOnlyAttribute('test_plan')"
                                 value:from="instance.test_plan"
                                 instance:from="instance">
                                     <div class="info-pane__section-title">Assessment Procedure</div>
@@ -47,14 +47,14 @@
                                 {{assessmentTypeNamePlural}}
                             </div>
                             {{#if isAllowedToMap}}
-                                {{#unless isEditDenied}}
+                                {{#unless isRestricted}}
                                     <div class="action-toolbar__controls">
                                         <action-toolbar-control>
                                             <map-button-using-assessment-type instance:from="instance">
                                                 <confirm-edit-action
                                                     on:setEditMode="openMapper()"
                                                     on:setInProgress="setInProgressState()"
-                                                    isEditIconDenied:from="isEditDenied"
+                                                    isEditIconDenied:from="isRestricted"
                                                     instance:from="instance"
                                                     onStateChangeDfd:from="onStateChangeDfd"
                                                     editMode:from="editMode">
@@ -102,27 +102,31 @@
                                   <confirm-edit-action
                                       on:setEditMode="removeRelatedItem(document, 'files')"
                                       on:setInProgress="setInProgressState()"
-                                      isEditIconDenied:from="isEditDenied"
+                                      isEditIconDenied:from="isSemiRestrictedOnStatus"
                                       instance:from="instance"
                                       onStateChangeDfd:from="onStateChangeDfd">
-                                          <a on:el:click="confirmEdit()">
-                                              <action-toolbar-control>
-                                                <i class="fa fa-trash"></i>
-                                              </action-toolbar-control>
-                                          </a>
+                                         {{#unless isSemiRestrictedOnStatus}}
+                                            <a on:el:click="confirmEdit()">
+                                                <action-toolbar-control>
+                                                  <i class="fa fa-trash"></i>
+                                                </action-toolbar-control>
+                                            </a>
+                                          {{/unless}}
                                   </confirm-edit-action>
                                 </editable-document-object-list-item>
                             </object-list>
-                            <confirm-edit-action
-                                        on:setInProgress="setInProgressState()"
-                                        instance:from="instance"
-                                        onStateChangeDfd:from="onStateChangeDfd"
-                                        editMode:from="editMode">
-                            <attach-button
-                                        isAttachActionDisabled:from="isUpdatingFiles"
-                                        confirmationCallback:from="@confirmEdit"
-                                        instance:from="instance"></attach-button>
-                            </confirm-edit-action>
+                            {{#unless isSemiRestrictedOnStatus}}
+                              <confirm-edit-action
+                                          on:setInProgress="setInProgressState()"
+                                          instance:from="instance"
+                                          onStateChangeDfd:from="onStateChangeDfd"
+                                          editMode:from="editMode">
+                              <attach-button
+                                          isAttachActionDisabled:from="isUpdatingFiles"
+                                          confirmationCallback:from="@confirmEdit"
+                                          instance:from="instance"></attach-button>
+                              </confirm-edit-action>
+                            {{/unless}}
                         </div>
                         <div>
                             <div class="info-pane__section-title_spinnerable">
@@ -134,18 +138,20 @@
                                     <confirm-edit-action
                                         on:setEditMode="removeRelatedItem(document, 'urls')"
                                         on:setInProgress="setInProgressState()"
-                                        isEditIconDenied:from="isEditDenied"
+                                        isEditIconDenied:from="isSemiRestrictedOnStatus"
                                         instance:from="instance"
                                         onStateChangeDfd:from="onStateChangeDfd">
-                                            <a on:el:click="confirmEdit">
-                                                <action-toolbar-control>
-                                                    <i class="fa fa-trash"></i>
-                                                </action-toolbar-control>
-                                            </a>
+                                            {{#unless isSemiRestrictedOnStatus}}
+                                              <a on:el:click="confirmEdit">
+                                                  <action-toolbar-control>
+                                                      <i class="fa fa-trash"></i>
+                                                  </action-toolbar-control>
+                                              </a>
+                                            {{/unless}}
                                     </confirm-edit-action>
                                 </editable-document-object-list-item>
                             </object-list>
-                          {{#unless isEditDenied}}
+                          {{#unless isSemiRestrictedOnStatus}}
                             {{#if urlsEditMode}}
                                 <create-url
                                     context:from="instance.context"
@@ -168,7 +174,7 @@
                                 <confirm-edit-action
                                     on:setEditMode="setUrlEditMode(true)"
                                     on:setInProgress="setInProgressState()"
-                                    isEditIconDenied:from="isEditDenied"
+                                    isEditIconDenied:from="isSemiRestrictedOnStatus"
                                     instance:from="instance"
                                     onStateChangeDfd:from="onStateChangeDfd">
                                         <button type="button" class="btn btn-small btn-gray"
@@ -227,7 +233,8 @@
                       mainRoles:from="assessmentMainRoles"
                       deferredSave:from="deferredSave"
                       onStateChangeDfd:from="onStateChangeDfd"
-                      setInProgress:from="@setInProgressState">
+                      setInProgress:from="@setInProgressState"
+                      isReadonly:from="isRestricted">
                     </assessment-people>
                 </div>
             </div>
@@ -241,7 +248,7 @@
                          withReadMore:from="true"
                          setInProgress:from="@setInProgressState"
                          onStateChangeDfd:from="onStateChangeDfd"
-                         isEditIconDenied:from="isEditDenied"
+                         isEditIconDenied:from="isReadOnlyAttribute('start_date')"
                          value:from="instance.start_date"
                          instance:from="instance">
                              <div class="info-pane__section-title">Due Date</div>
@@ -255,7 +262,7 @@
                         propName:from="'labels'"
                         isConfirmationNeeded:from="false"
                         onStateChangeDfd:from="onStateChangeDfd"
-                        isEditIconDenied:from="isEditDenied"
+                        isEditIconDenied:from="isReadOnlyAttribute('labels')"
                         value:from="instance.labels"
                         instance:from="instance">
                             <div class="info-pane__section-title">Label</div>
@@ -298,7 +305,7 @@
             {{#instance}}
                 <related-assessments
                     instance:from="instance"
-                    needReuse:from="true"
+                    needReuse:from="isReuseNeeded"
                     on:reusableObjectsCreated="addReusableEvidence(scope.event)">
                 </related-assessments>
             {{/instance}}
@@ -320,11 +327,12 @@
               <div class="assessment-attributes-panel">
                 <custom-roles excludeRoles:from="assessmentMainRoles"
                     instance:from="instance"
-                    deferredSave:from="deferredSave">
+                    deferredSave:from="deferredSave"
+                    readOnly:from="isRestricted">
                 </custom-roles>
                 <assessment-custom-attributes on:onUpdateAttributes="saveGlobalAttributes(scope.event)"
                                               items:from="globalAttributes"
-                                              isEditDenied:from="isEditDenied"
+                                              isEditDenied:from="isRestricted"
                                               class="ggrc-form ggrc-form-multiple-columns">
                 </assessment-custom-attributes>
                 <div class="info-pane__section ggrc-form">
@@ -339,7 +347,7 @@
                                 setInProgress:from="@setInProgressState"
                                 onStateChangeDfd:from="onStateChangeDfd"
                                 dropdownOptionsGroups:from="objectTypes"
-                                isEditIconDenied:from="isEditDenied"
+                                isEditIconDenied:from="isReadOnlyAttribute('assessment_type')"
                                 value:from="instance.assessment_type"
                                 instance:from="instance">
                                     <div class="ggrc-form__title">Assessment Type</div>
@@ -352,14 +360,14 @@
                        <div class="action-toolbar">
                           <div class="action-toolbar__content-item">Related Information</div>
                             {{#if isAllowedToMap}}
-                                {{#unless isEditDenied}}
+                                {{#unless isRestricted}}
                                     <div class="action-toolbar__controls">
                                         <action-toolbar-control>
                                             <map-button-using-assessment-type instance:from="instance">
                                                 <confirm-edit-action
                                                     on:setEditMode="openMapper()"
                                                     on:setInProgress="setInProgressState()"
-                                                    isEditIconDenied:from="isEditDenied"
+                                                    isEditIconDenied:from="isRestricted"
                                                     instance:from="instance"
                                                     onStateChangeDfd:from="onStateChangeDfd"
                                                     editMode:from="editMode">
@@ -390,7 +398,7 @@
                         withReadMore:from="true"
                         setInProgress:from="@setInProgressState"
                         onStateChangeDfd:from="onStateChangeDfd"
-                        isEditIconDenied:from="isEditDenied"
+                        isEditIconDenied:from="isReadOnlyAttribute('description')"
                         value:from="instance.description"
                         instance:from="instance">
                             <div class="ggrc-form__title">Description</div>
@@ -406,7 +414,7 @@
                         withReadMore:from="true"
                         setInProgress:from="@setInProgressState"
                         onStateChangeDfd:from="onStateChangeDfd"
-                        isEditIconDenied:from="isEditDenied"
+                        isEditIconDenied:from="isReadOnlyAttribute('notes')"
                         value:from="instance.notes"
                         instance:from="instance">
                             <div class="ggrc-form__title">Notes</div>
@@ -425,7 +433,7 @@
                             setInProgress:from="@setInProgressState"
                             onStateChangeDfd:from="onStateChangeDfd"
                             dropdownOptions:from="model.conclusions"
-                            isEditIconDenied:from="isEditDenied"
+                            isEditIconDenied:from="isReadOnlyAttribute('design')"
                             value:from="instance.design"
                             instance:from="instance">
                                 <div>
@@ -445,7 +453,7 @@
                             setInProgress:from="@setInProgressState"
                             onStateChangeDfd:from="onStateChangeDfd"
                             dropdownOptions:from="model.conclusions"
-                            isEditIconDenied:from="isEditDenied"
+                            isEditIconDenied:from="isReadOnlyAttribute('operationally')"
                             value:from="instance.operationally"
                             instance:from="instance">
                                 <div>

--- a/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/templates/info-pane-issue-tracker-fields.stache
@@ -15,7 +15,7 @@
         on:valueChange="inlineDropdownValueChange(scope.event)">
         <inline-edit-control
           on:inlineSave="checkTicketId(scope.event)"
-          isEditIconDenied:from="isEditDenied"
+          isEditIconDenied:from="isRestricted"
           dropdownOptions:from="instance.constructor.issue_tracker_enable_options"
           instance:from="instance"
           value:from="issueTrackerEnabled"
@@ -65,7 +65,7 @@
       isConfirmationNeeded:from="false"
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
-      isEditIconDenied:from="isEditDenied"
+      isEditIconDenied:from="isRestricted"
       value:from="instance.issue_tracker.issue_id"
       mandatory:from="isTicketIdMandatory"
       instance:from="instance">
@@ -78,7 +78,7 @@
           </div>
           <div class="ggrc-form-item__small-text">
             <small>
-              {{#if isTicketIdMandatory}} 
+              {{#if isTicketIdMandatory}}
                 <em>You are not allowed to generate new ticket for Issues at statuses &quot;In Review&quot;, &quot;Completed (no verification)&quot;, &quot;Completed and Verified&quot; and &quot;Deprecated&quot;, only manual linking is allowed to perform. If you would like to keep the existing ticket linked to this issue do not edit this attribute. If you would like to link to a different ticket provide an existing ticket number.</em>
               {{else}}
                 <em>Please leave this empty for a new ticket to be generated and linked to this assessment. If you would like to link to an existing ticket please provide the ticket number.</em>
@@ -136,7 +136,7 @@
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
       dropdownOptions:from="instance.constructor.issue_tracker_priorities"
-      isEditIconDenied:from="isEditDenied"
+      isEditIconDenied:from="isRestricted"
       value:from="instance.issue_tracker.issue_priority"
       instance:from="instance">
         <div class="ggrc-form__title">Ticket Priority</div>
@@ -150,7 +150,7 @@
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
       dropdownOptions:from="instance.constructor.issue_tracker_severities"
-      isEditIconDenied:from="isEditDenied"
+      isEditIconDenied:from="isRestricted"
       value:from="instance.issue_tracker.issue_severity"
       instance:from="instance">
         <div class="ggrc-form__title">Ticket Severity</div>
@@ -165,7 +165,7 @@
       isConfirmationNeeded:from="false"
       setInProgress:from="@setInProgressState"
       onStateChangeDfd:from="onStateChangeDfd"
-      isEditIconDenied:from="isEditDenied"
+      isEditIconDenied:from="isRestricted"
       value:from="instance.issue_tracker.title"
       instance:from="instance">
         <div class="ggrc-form__title form-label form-label__extended">

--- a/src/ggrc-client/js/components/related-objects/related-issues.stache
+++ b/src/ggrc-client/js/components/related-objects/related-issues.stache
@@ -10,9 +10,9 @@
                      relatedItemsType:from="'Issue'">
         <div class="grid-data__toolbar flex-box">
             <tree-pagination paging:from="paging" class="grid-data__toolbar-item"></tree-pagination>
-            {{^if_edit_is_denied baseInstance}}
+            {{^is_edit_denied baseInstance}}
               <add-issue-button relatedInstance:from="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
-            {{/if_edit_is_denied}}
+            {{/is_edit_denied}}
         </div>
         <div class="grid-data-header flex-row flex-box">
             <div class="flex-size-2">

--- a/src/ggrc-client/js/components/related-objects/related-issues.stache
+++ b/src/ggrc-client/js/components/related-objects/related-issues.stache
@@ -10,9 +10,9 @@
                      relatedItemsType:from="'Issue'">
         <div class="grid-data__toolbar flex-box">
             <tree-pagination paging:from="paging" class="grid-data__toolbar-item"></tree-pagination>
-            {{^if baseInstance.archived}}
-                    <add-issue-button relatedInstance:from="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
-            {{/if}}
+            {{^if_edit_is_denied baseInstance}}
+              <add-issue-button relatedInstance:from="baseInstance" class="grid-data__toolbar-item"></add-issue-button>
+            {{/if_edit_is_denied}}
         </div>
         <div class="grid-data-header flex-row flex-box">
             <div class="flex-size-2">

--- a/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
+++ b/src/ggrc-client/js/components/related-objects/related-people-access-control-group.js
@@ -23,6 +23,7 @@ export default canComponent.extend({
           let canEdit = !this.attr('isReadonly') &&
             !isSnapshot(instance) &&
             !instance.attr('archived') &&
+            !instance.attr('is_sox_restricted') &&
             !this.attr('readOnly') &&
             !this.attr('updatableGroupId') &&
             (this.attr('isNewInstance') ||

--- a/src/ggrc-client/js/components/tree/tree-actions.js
+++ b/src/ggrc-client/js/components/tree/tree-actions.js
@@ -32,9 +32,10 @@ export default canComponent.extend({
       addItem: {
         type: String,
         get: function () {
-          return this.attr('options.objectVersion') ?
-            false :
-            this.attr('options').add_item_view ||
+          return (this.attr('options.objectVersion')
+            || this.attr('parentInstance.is_sox_restricted'))
+            ? false
+            : this.attr('options').add_item_view ||
             this.attr('model').tree_view_options.add_item_view ||
             'base_objects/tree_add_item';
         },

--- a/src/ggrc-client/js/components/tree/tree-item-actions.js
+++ b/src/ggrc-client/js/components/tree/tree-item-actions.js
@@ -55,9 +55,10 @@ const viewModel = canMap.extend({
         let type = instance.attr('type');
         let isSnapshot = this.attr('isSnapshot');
         let isArchived = instance.attr('archived');
+        let isRestricted = instance.attr('is_sox_restricted');
         let isInForbiddenList = forbiddenEditList.indexOf(type) > -1;
         return !isAllowedFor('update', instance) ||
-          (isSnapshot || isInForbiddenList || isArchived);
+          (isSnapshot || isInForbiddenList || isArchived || isRestricted);
       },
     },
     isAllowedToEdit: {

--- a/src/ggrc-client/js/components/unmap-button/unmap-dropdown-item.js
+++ b/src/ggrc-client/js/components/unmap-button/unmap-dropdown-item.js
@@ -62,7 +62,9 @@ export default canComponent.extend({
             && !(isAllObjects() || isMyWork())
             && options.attr('isDirectlyRelated')
             && !this.attr('denyIssueUnmap')
-            && !this.attr('denySnapshotUnmap');
+            && !this.attr('denySnapshotUnmap')
+            && !source.is_sox_restricted
+            && !destination.is_sox_restricted;
         },
       },
       isMappableExternally: {

--- a/src/ggrc-client/js/helpers.js
+++ b/src/ggrc-client/js/helpers.js
@@ -752,3 +752,20 @@ canStache.registerHelper('displayCount', (countObserver) => {
     return '(' + count + ')';
   }
 });
+
+canStache.registerHelper('if_sox302_restricted', function (instance, options) {
+  const isSox302Restricted = isFunction(instance)
+    ? instance().is_sox_restricted
+    : instance.is_sox_restricted;
+
+  return isSox302Restricted ? options.fn(this) : options.inverse(this);
+});
+
+canStache.registerHelper('if_edit_is_denied', (instance, options) => {
+  const source = isFunction(instance) ? instance(): instance;
+  const isEditDenied = source.archived || source.is_sox_restricted;
+
+  return isEditDenied
+    ? options.fn(options.context)
+    : options.inverse(options.context);
+});

--- a/src/ggrc-client/js/helpers.js
+++ b/src/ggrc-client/js/helpers.js
@@ -753,15 +753,7 @@ canStache.registerHelper('displayCount', (countObserver) => {
   }
 });
 
-canStache.registerHelper('if_sox302_restricted', function (instance, options) {
-  const isSox302Restricted = isFunction(instance)
-    ? instance().is_sox_restricted
-    : instance.is_sox_restricted;
-
-  return isSox302Restricted ? options.fn(this) : options.inverse(this);
-});
-
-canStache.registerHelper('if_edit_is_denied', (instance, options) => {
+canStache.registerHelper('is_edit_denied', (instance, options) => {
   const source = isFunction(instance) ? instance(): instance;
   const isEditDenied = source.archived || source.is_sox_restricted;
 

--- a/src/ggrc-client/js/models/business-models/assessment.js
+++ b/src/ggrc-client/js/models/business-models/assessment.js
@@ -43,6 +43,8 @@ export default Cacheable.extend({
     sox_302_enabled: false,
     send_by_default: true, // notifications when a comment is added
     recipients: 'Assignees,Creators,Verifiers', // user roles to be notified
+    is_sox_restricted: false, // restrict assignee's permissions if enabled sox302
+    get_read_only_fields: [], // readOnly attributes names to restrict permissions
   },
   statuses: ['Not Started', 'In Progress', 'In Review',
     'Verified', 'Completed', 'Deprecated', 'Rework Needed'],

--- a/src/ggrc-client/js/templates/assessments/header.stache
+++ b/src/ggrc-client/js/templates/assessments/header.stache
@@ -18,7 +18,7 @@ Copyright (C) 2019 Google Inc.
         isLoading:from="isLoading"
         instance:from="instance"
         value:from="instance.title"
-        isEditIconDenied:from="isEditDenied">
+        isEditIconDenied:from="isReadOnlyAttribute('title')">
           {{#unless editMode}}
             <confirm-edit-action
               on:setEditMode="setEditModeInline(scope.event)"
@@ -71,9 +71,9 @@ Copyright (C) 2019 Google Inc.
       <div class="info-pane-utility">
         <three-dots-menu>
           {{#is_allowed 'update' instance context='for'}}
-            {{^if instance.archived}}
+            {{^if_edit_is_denied instance}}
               {{> /static/templates/base_objects/edit_object_link.stache}}
-            {{/if}}
+            {{/if_edit_is_denied}}
           {{/is_allowed}}
           <li>
             <permalink-component instance:from="instance"/>
@@ -102,7 +102,7 @@ Copyright (C) 2019 Google Inc.
           {{#if_in instance.status "Not Started,In Progress"}}
             {{#is_allowed 'update' instance context='for'}}
               <li>
-                {{#unless instance.archived}}
+                {{^if_edit_is_denied instance}}
                   <reminder-component
                     instance:from="instance"
                     type:from="statusToPerson"
@@ -113,13 +113,13 @@ Copyright (C) 2019 Google Inc.
                         Send reminder to assignees
                       </a>
                   </reminder-component>
-                {{/unless}}
+                {{/if_edit_is_denied}}
               </li>
             {{/is_allowed}}
           {{/if_in}}
 
           {{#is_allowed 'update' instance context='for'}}
-            {{^if instance.archived}}
+            {{^if_edit_is_denied instance}}
               <li>
                 {{^is(instance.status, "Rework Needed")}}
                   {{#is(instance.status, "Deprecated")}}
@@ -153,20 +153,20 @@ Copyright (C) 2019 Google Inc.
                   </object-change-state>
                 {{/is}}
               </li>
-            {{/if}}
+            {{/if_edit_is_denied}}
           {{/is_allowed}}
 
           {{#is_allowed 'delete' instance}}
-            {{^if instance.archived}}
-              <li>
-                <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
-                  data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
-                  data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
-                  <i class="fa fa-trash"></i>
-                  Delete
-                </a>
-              </li>
-            {{/if}}
+            {{^if_edit_is_denied instance}}
+               <li>
+                 <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
+                   data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
+                   data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
+                   <i class="fa fa-trash"></i>
+                   Delete
+                 </a>
+               </li>
+            {{/if_edit_is_denied}}
           {{/is_allowed}}
         </three-dots-menu>
 

--- a/src/ggrc-client/js/templates/assessments/header.stache
+++ b/src/ggrc-client/js/templates/assessments/header.stache
@@ -70,11 +70,9 @@ Copyright (C) 2019 Google Inc.
       {{/if}}
       <div class="info-pane-utility">
         <three-dots-menu>
-          {{#is_allowed 'update' instance context='for'}}
-            {{^if_edit_is_denied instance}}
-              {{> /static/templates/base_objects/edit_object_link.stache}}
-            {{/if_edit_is_denied}}
-          {{/is_allowed}}
+          {{#unless isRestricted}}
+            {{> /static/templates/base_objects/edit_object_link.stache}}
+          {{/unless}}
           <li>
             <permalink-component instance:from="instance"/>
           </li>
@@ -100,48 +98,35 @@ Copyright (C) 2019 Google Inc.
           {{/if}}
 
           {{#if_in instance.status "Not Started,In Progress"}}
-            {{#is_allowed 'update' instance context='for'}}
+            {{#unless isRestricted}}
               <li>
-                {{^if_edit_is_denied instance}}
-                  <reminder-component
-                    instance:from="instance"
-                    type:from="statusToPerson"
-                    modal_title:from="'Reminder for Assignees set'"
-                    modal_description:from="'A reminder to complete the Assessment for Assignees will be sent in the next daily email digest.'">
-                      <a href="javascript://" on:el:click="reminder">
-                        <i class="fa fa-bell-o"></i>
-                        Send reminder to assignees
-                      </a>
-                  </reminder-component>
-                {{/if_edit_is_denied}}
+                <reminder-component
+                  instance:from="instance"
+                  type:from="statusToPerson"
+                  modal_title:from="'Reminder for Assignees set'"
+                  modal_description:from="'A reminder to complete the Assessment for Assignees will be sent in the next daily email digest.'">
+                    <a href="javascript://" on:el:click="reminder">
+                      <i class="fa fa-bell-o"></i>
+                      Send reminder to assignees
+                    </a>
+                </reminder-component>
               </li>
-            {{/is_allowed}}
+            {{/unless}}
           {{/if_in}}
 
-          {{#is_allowed 'update' instance context='for'}}
-            {{^if_edit_is_denied instance}}
-              <li>
-                {{^is(instance.status, "Rework Needed")}}
-                  {{#is(instance.status, "Deprecated")}}
-                    {{! Set default state }}
-                    <object-change-state
-                      toState:from="initialState"
-                      on:onStateChange="onStateChange(scope.event)">
-                        <a href="javascript:void(0)">
-                          <i class="fa fa-reply"></i>
-                          Restore
-                        </a>
-                    </object-change-state>
-                  {{else}}
-                    <object-change-state
-                      toState:from="deprecatedState"
-                      on:onStateChange="onStateChange(scope.event)">
-                        <a href="javascript:void(0)">
-                          <i class="fa fa-times-circle"></i>
-                          Deprecate
-                        </a>
-                    </object-change-state>
-                  {{/is}}
+          {{#unless isRestricted}}
+            <li>
+              {{^is(instance.status, "Rework Needed")}}
+                {{#is(instance.status, "Deprecated")}}
+                  {{! Set default state }}
+                  <object-change-state
+                    toState:from="initialState"
+                    on:onStateChange="onStateChange(scope.event)">
+                      <a href="javascript:void(0)">
+                        <i class="fa fa-reply"></i>
+                        Restore
+                      </a>
+                  </object-change-state>
                 {{else}}
                   <object-change-state
                     toState:from="deprecatedState"
@@ -152,21 +137,30 @@ Copyright (C) 2019 Google Inc.
                       </a>
                   </object-change-state>
                 {{/is}}
-              </li>
-            {{/if_edit_is_denied}}
-          {{/is_allowed}}
+              {{else}}
+                <object-change-state
+                  toState:from="deprecatedState"
+                  on:onStateChange="onStateChange(scope.event)">
+                    <a href="javascript:void(0)">
+                      <i class="fa fa-times-circle"></i>
+                      Deprecate
+                    </a>
+                </object-change-state>
+              {{/is}}
+            </li>
+          {{/unless}}
 
           {{#is_allowed 'delete' instance}}
-            {{^if_edit_is_denied instance}}
-               <li>
-                 <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
-                   data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
-                   data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
-                   <i class="fa fa-trash"></i>
-                   Delete
-                 </a>
-               </li>
-            {{/if_edit_is_denied}}
+            {{^is_edit_denied instance}}
+              <li>
+                <a data-toggle="modal-ajax-deleteform" data-object-plural="{{model.table_plural}}"
+                  data-object-singular="{{model.model_singular}}" data-modal-reset="reset"
+                  data-modal-class="modal" data-object-id="{{instance.id}}" href="javascript://">
+                  <i class="fa fa-trash"></i>
+                  Delete
+                </a>
+              </li>
+            {{/is_edit_denied}}
           {{/is_allowed}}
         </three-dots-menu>
 

--- a/src/ggrc-client/js/templates/base_objects/dropdown_menu.stache
+++ b/src/ggrc-client/js/templates/base_objects/dropdown_menu.stache
@@ -5,13 +5,13 @@
 
 <three-dots-menu>
     {{#is_allowed 'update' instance context='for'}}
-      {{^if instance.archived}}
+      {{^is_edit_denied instance}}
         {{^if instance.constructor.isChangeableExternally}}
           {{^if instance.readonly}}
             {{> /static/templates/base_objects/edit_object_link.stache}}
           {{/if}}
         {{/if}}
-      {{/if}}
+      {{/is_edit_denied}}
     {{/is_allowed}}
 
     {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}


### PR DESCRIPTION
**Should be merged into _GGRC-7772_ branch**

<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

When checkbox "Enable SOX 302 assessment workflow" in the assessment template is switched on, 
all assessments created based on this template shall provide restricted permissions to the assessment assignees. 

1) if assessment is in "Not Started", "In Progress", "Rework needed" or "In Review" statuses:
- assignee cannot edit any built-in, global custom attribute on the assessment
- assignee cannot add/remove labels
- assignee cannot map/unmap any snapshot to assessment
- assignee cannot deprecate assessment
- assignee cannot raise/unmap issue to assessment
- assignee cannot turn on/off linking to issue tracker
+ assignee can add/edit answers to Local Custom Attributes
+ assignee can add/update/delete/reuse evidence url, files
+ assignee can add comments
+ assignee can Undo changes by clicking Undo button in UI
2) if assessment is in "Completed" or "Completed&Verified", "Deprecated" state assignees:
- assignee cannot edit any built-in, global custom attribute on the assessment
- assignee cannot add/remove labels
- assignee cannot map/unmap any snapshot to assessment
- assignee cannot deprecate assessment
- assignee cannot raise/unmap issue to assessment
- assignee cannot turn on/off linking to issue tracker
- assignee cannot move assessment into any other status
- assignee cannot update answers to Local Custom Attributes
- assignees cannot add/update/delete evidence files or evidence urls
- assignees cannot reuse evidence files or evidence urls from related assessments
+ assignee can add comments
+ assignee can Undo changes by clicking Undo button in UI


# Steps to test the changes

Set `is_sox_restricted` to `true` and add properties names to `get_read_only_fields`. Verify that corresponding components are hidden. 

# Solution description

- Registered `if_Sox302_restricted` and `if_edit_is_denied` helpers to hide elements in the stache templates
- Added `isRestricted`, `isSemiRestrictedOnStatus` attributes and `isReadOnlyAttribute` function to hide elements on `assessment-info-pane` component
- Extended `noItemsText` to show message only in isSemiRestrictedOnStatus case

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
