### PR TITLE
GGRC-6513 Shift Local Custom Attributes columns after Global Custom Attributes

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -215,6 +215,7 @@ class AttributeInfo(object):
       "comments",
       "last_comment",
       CUSTOM_ATTR_PREFIX,
+      OBJECT_CUSTOM_ATTR_PREFIX,
       "issue_tracker",
       "component_id",
       "enabled",

--- a/test/integration/ggrc/converters/test_export_assessments.py
+++ b/test/integration/ggrc/converters/test_export_assessments.py
@@ -343,3 +343,37 @@ class TestExport(query_helper.WithQueryApi, TestCase):
 
     self.assertEquals(expected_evid_file_string, resp["Evidence File"])
     self.assertEquals(evid_url_link, resp["Evidence URL"])
+
+  def test_exported_columns_order(self):
+    """Test GCA and LCA columns order in exported file"""
+
+    with factories.single_commit():
+      assessment1 = factories.AssessmentFactory(
+          title="test assessment",
+      )
+      factories.CustomAttributeDefinitionFactory(
+          title="Test LCA",
+          definition_type="assessment",
+          definition_id=assessment1.id,
+          attribute_type="Text",
+      )
+      factories.CustomAttributeDefinitionFactory(
+          title="Test GCA",
+          definition_type="assessment",
+          attribute_type="Text",
+      )
+
+    search_request = [{
+        "object_name": "Assessment",
+        "filters": {
+            "expression": {}
+        },
+        "fields": "all"
+    }]
+
+    response = self.export_csv(search_request)
+    # Here expected string contains the part of sorted headers sequence
+    # Normal Attributes, GCA, LCA and Ticket Tracker
+    expected_order = 'Last Comment,Test GCA,Test LCA,Ticket Tracker'
+    header_line = response.data.split("\r\n")[1]
+    self.assertIn(expected_order, header_line)


### PR DESCRIPTION

# Issue description

Local Custom Attributes columns are displayed after Ticket Tracker fields.

# Steps to test the changes

1. Open ggrc-app
2. Create audit
3. Create objective to audit
4. Create assessment with GCA and LCA columns
5. Export assessment table
6. Check columns order

# Solution description

Added LCA columns(OBJECT_CUSTOM_ATTR_PREFIX) to ordered attributes after GCA columns

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".