### PR TITLE
GGRC-7894 / GGRC-7895 [SV] Negative options for CADs

### DIFF
--- a/src/ggrc/converters/handlers/template.py
+++ b/src/ggrc/converters/handlers/template.py
@@ -44,7 +44,8 @@ class TemplateCaColumnHandler(handlers.ColumnHandler):
       ca_type = ca_type[10:].strip()
     return ca_type, mandatory
 
-  def _get_multiple_choice(self, choices):
+  @staticmethod
+  def _get_multiple_choice(choices):
     """Get option and mandatory strings for a list of choices."""
     options = []
     mandatory = []
@@ -54,7 +55,9 @@ class TemplateCaColumnHandler(handlers.ColumnHandler):
         man += 1
       if "(a)" in option.lower():
         man += 2
-      options.append(re.sub("\([aAcC]\)", "", option).strip())
+      if "(n)" in option.lower():
+        man += 8
+      options.append(re.sub(r"\([aAcCnN]\)", "", option).strip())
       mandatory.append(str(man))
     return ",".join(options), ",".join(mandatory)
 

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -251,10 +251,19 @@ class AssessmentTemplate(assessment.AuditRelationship,
               "and trailing spaces are ignored.\n"
               "list of attribute values: Comma separated list, only used if "
               "attribute type is 'Dropdown'. Prepend '(a)' if the value has a "
-              "mandatory attachment and/or (c) if the value requires a "
+              "mandatory attachment and/or '(c)' if the value requires a "
               "mandatory comment.\n\n"
-              "Limitations: Dropdown values can not start with either '(a)' or"
-              "'(c)' and attribute names can not contain commas ','."
+              "list of attribute values (only if 'SOX 302 Assessment "
+              "workflow' = YES):\n"
+              "- for Dropdown: Comma separated list. Prepend '(a)' if the "
+              "value has a mandatory attachment and/or '(c)' if the value "
+              "requires a mandatory comment and/or '(n)' if the value should "
+              "be treated as negative answer.\n"
+              "- for Text and Reach text: options possible are 'Not empty' or "
+              "'Empty'. Prepend '(n)' if the value should be treated as "
+              "negative answer.\n\n"
+              "Limitations: Dropdown values can not start with either '(a)', "
+              "'(c)' or '(n)' and attribute names can not contain commas ','."
           ),
       },
   }

--- a/src/ggrc/models/custom_attribute_definition.py
+++ b/src/ggrc/models/custom_attribute_definition.py
@@ -211,6 +211,7 @@ class CustomAttributeDefinition(CustomAttributeDefinitionBase):
     COMMENT_REQUIRED = 0b001
     EVIDENCE_REQUIRED = 0b010
     URL_REQUIRED = 0b100
+    IS_NEGATIVE = 0b1000
 
   VALID_TYPES = {
       "Text": "Text",
@@ -270,6 +271,28 @@ class CustomAttributeDefinition(CustomAttributeDefinitionBase):
     else:
       self.definition_type = ''
     return setattr(self, self.definition_attr, value)
+
+  @property
+  def negative_options(self):
+    """Get list of negative options of this CAD.
+
+    Return list of negative options of CAD this property is called on. CAD
+    option is considered to be a negative one when it has appropriate bitmask
+    in `multi_choice_mandatory` field. This field stores bitmasks for each
+    option in comma-separated manner. It means that first bitmask is related to
+    first option in `multi_choice_options`, second bitmask to second option and
+    so on. Option is negative when binary AND of its bitmask and `IS_NEGATIVE`
+    from `MultiChoiceMandatoryFlags` enum evaluates to True.
+
+    Returns:
+      List of options that are marked as negative ones.
+    """
+    bitmasks = self.multi_choice_mandatory.split(",")
+    options = self.multi_choice_options.split(",")
+    return [
+        option for option, bitmask in zip(options, bitmasks)
+        if int(bitmask) & self.MultiChoiceMandatoryFlags.IS_NEGATIVE
+    ]
 
   def _clone(self, target):
     """Clone custom attribute definitions."""


### PR DESCRIPTION
# Dependencies

_After review this PR should be targeted into `GGRC-7771-sox-skip-verify` branch._

This PR is on hold until following dependencies are merged:
- [x] #10071

# Issue description

This PR contains SOX 302 functionality for Custom Attributes (support for negative options is added). After all builds pass should be targeted into common branch.

# Steps to test the changes

**_Import / export of Assessment Template with Custom Attributes with specified negative options_**

Scenario I (Assessment Template create via import)

1. Download CSV import template for Assessment Template objects;
2. Fill all needed fields along with Custom Attributes. Custom Attributes should be of _"Dropdown"_ / _"Text"_ / _"Rich Text"_ type with marked negative options (see hint in CSV for more details);
3. Import CSV and check that Assessment Template was created with Custom Attribute Definitions. Check via REST API that created CADs have correct value in `multi_choice_mandatory` field which holds bitmasks.

Scenario II (Assessment Template update via import)

Try the same steps described in _Scenario I_ but with already existing Assessment Template.

# Solution description

This PR contains following changes:

- New bit flag `IS_NEGATIVE=0b1000` is added to `MultiChoiceMandatoryFlags` enum on CAD model. This flag will be used to indicate options which should be treated as a negative ones.

- New property `negative_options` is added on CAD model. This property returns list of all the options which are marked as negative.

- Description for `template_custom_attributes` alias on `AssessmentTemplate` is updated to contain the information regarding negative options.

- `TemplateCaColumnHandler` is updated to parse `(n)` prefix (as it already does with `(a)` and `(c)`) from data provided in CSV template.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
