### PR TITLE
QUICK-FIX Fix index out of range errors during onetime back-sync job

### DIFF
--- a/src/ggrc/integrations/synchronization_jobs/one_time_back_sync.py
+++ b/src/ggrc/integrations/synchronization_jobs/one_time_back_sync.py
@@ -65,17 +65,17 @@ def _compare_values_for_issues():
 
   logger.info("Collecting issues those need to be updated")
   for info in external_issues:
-    for issue_id in info:
+    for issue_id, issue_data in info.iteritems():
       local_component = local_issues[issue_id].get("component_id")
       local_hotlist = local_issues[issue_id].get("hotlist_id")
 
-      if local_component != info[issue_id]["component_id"]:
-        issues_to_update[issue_id]["component_id"] = \
-            info[issue_id]["component_id"]
+      if local_component != issue_data["component_id"]:
+        issues_to_update[issue_id]["component_id"] = issue_data["component_id"]
 
-      if local_hotlist not in info[issue_id]["hotlist_ids"]:
-        issues_to_update[issue_id]["hotlist_id"] = \
-            info[issue_id]["hotlist_ids"][0]
+      if not issue_data["hotlist_ids"]:
+        issues_to_update[issue_id]["hotlist_id"] = None
+      elif local_hotlist not in issue_data["hotlist_ids"]:
+        issues_to_update[issue_id]["hotlist_id"] = issue_data["hotlist_ids"][0]
 
   return issues_to_update
 

--- a/test/integration/ggrc/integrations/test_onetime_back_sync.py
+++ b/test/integration/ggrc/integrations/test_onetime_back_sync.py
@@ -47,7 +47,13 @@ class TestOnetimeBackSync(TestCase):
       issue_4 = factories.IssueTrackerIssueFactory(
           hotlist_id='qwe',
           component_id=None,
-          issue_id=333
+          issue_id=444
+      )
+      # Invalid hotlist_id
+      issue_5 = factories.IssueTrackerIssueFactory(
+          hotlist_id='123',
+          component_id=456,
+          issue_id=555
       )
 
     sync_result_mock.return_value = [{
@@ -57,8 +63,7 @@ class TestOnetimeBackSync(TestCase):
             "priority": "P2",
             "severity": "S2",
             "component_id": int(issue_1.component_id),
-            "hotlist_ids": [correct_hotlist_id]
-
+            "hotlist_ids": [correct_hotlist_id],
         },
         int(issue_2.issue_id): {
             "status": "NEW",
@@ -66,8 +71,7 @@ class TestOnetimeBackSync(TestCase):
             "priority": "P2",
             "severity": "S2",
             "component_id": correct_component_id,
-            "hotlist_ids": [int(issue_2.hotlist_id)]
-
+            "hotlist_ids": [int(issue_2.hotlist_id)],
         },
         int(issue_3.issue_id): {
             "status": "NEW",
@@ -75,8 +79,7 @@ class TestOnetimeBackSync(TestCase):
             "priority": "P2",
             "severity": "S2",
             "component_id": correct_component_id,
-            "hotlist_ids": [correct_hotlist_id]
-
+            "hotlist_ids": [correct_hotlist_id],
         },
         int(issue_4.issue_id): {
             "status": "NEW",
@@ -84,10 +87,16 @@ class TestOnetimeBackSync(TestCase):
             "priority": "P2",
             "severity": "S2",
             "component_id": correct_component_id,
-            "hotlist_ids": [correct_hotlist_id]
-
-        }
-
+            "hotlist_ids": [correct_hotlist_id],
+        },
+        int(issue_5.issue_id): {
+            "status": "NEW",
+            "type": "PROCESS",
+            "priority": "P2",
+            "severity": "S2",
+            "component_id": correct_component_id,
+            "hotlist_ids": [],
+        },
     }]
 
     response = self.client.post('/admin/onetime_back_sync')
@@ -112,6 +121,7 @@ class TestOnetimeBackSync(TestCase):
     issue_2 = all_models.IssuetrackerIssue.query.get(issue_2.id)
     issue_3 = all_models.IssuetrackerIssue.query.get(issue_3.id)
     issue_4 = all_models.IssuetrackerIssue.query.get(issue_4.id)
+    issue_5 = all_models.IssuetrackerIssue.query.get(issue_5.id)
 
     self.assertEqual(int(issue_1.hotlist_id), correct_hotlist_id)
     self.assertEqual(int(issue_2.component_id), correct_component_id)
@@ -119,3 +129,5 @@ class TestOnetimeBackSync(TestCase):
     self.assertEqual(int(issue_3.hotlist_id), correct_hotlist_id)
     self.assertEqual(int(issue_4.hotlist_id), correct_hotlist_id)
     self.assertEqual(int(issue_4.component_id), correct_component_id)
+    self.assertEqual(issue_5.hotlist_id, None)
+    self.assertEqual(int(issue_5.component_id), correct_component_id)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

For some issues empty `hotlist_ids` is returned from Issue Tracker. This case isn't handled correctly during back-sync due to absence of check if list is not empty before accessing its elements. This leads to list-out-of-range errors during back-sync job.

# Steps to test the changes

1. Deploy this branch to GAE with dump from ggrc-test / ggrc-uat in DB;
2. Login in GGRC and execute `$.post("/admin/onetime_back_sync")` in devtools console;
3. Check logs after job finishes and make sure there wasn't any errors _(note that 200 status code will be returned even in case of an error, so job logs should be checked)_

# Solution description

Solutions consist of additional check for `hotlist_ids` obtained from Issue Tracker. If `hotlist_ids` is an empty list, `None` will be used as value for `IssuetrackerIssue.hotlist_id`.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
