### PR TITLE
BC: QUICK-FIX Fix font-size for person input and fa-times position and height of date input

### DIFF
--- a/src/ggrc-client/styles/components/assessments-local-custom-attributes/_assessments-local-custom-attributes.scss
+++ b/src/ggrc-client/styles/components/assessments-local-custom-attributes/_assessments-local-custom-attributes.scss
@@ -5,6 +5,7 @@
 
 .assessments-lca {
   margin: 15px 0 0;
+  font-size: 13px;
 
   .field-wrapper {
     padding: 0 0 20px 20px;

--- a/src/ggrc-client/styles/components/form/fields/_date-form-field.scss
+++ b/src/ggrc-client/styles/components/form/fields/_date-form-field.scss
@@ -31,10 +31,6 @@ date-form-field {
           top: 6px;
           left: 7px;
         }
-
-        .datepicker__remove-value {
-          top: 6px;
-        }
       }
     }
   }

--- a/src/ggrc-client/styles/modules/_datepicker.scss
+++ b/src/ggrc-client/styles/modules/_datepicker.scss
@@ -16,8 +16,7 @@
   max-width: 100%;
   width: 100% !important;
   margin-bottom: 0;
-  // This is not good, but our global inputs have fixed height and paddings
-  height: 26px !important;
+  height: 28px;
 
   &--denied {
     background: $white;
@@ -37,7 +36,7 @@
   .datepicker__remove-value {
     cursor: pointer;
     position: absolute;
-    top: 4px;
+    top: 5px;
     right: 5px;
     i {
       font-size: 16px;


### PR DESCRIPTION
**Should be merged in "asmt-bulk"**

# Issue description

Fix font-size for person input in LCA section on Bulk Complete modal and fix fa-times position and height of date input globally.

# Steps to test the changes

1. Check person input font-size in LCA section on Bulk Complete modal. It should be 13px.
2. Check all places where date input is used. fa-times should be in the center of date input.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

