### PR TITLE
GGRC-7988 / GGRC-7984 Fix to show daily digest

### DIFF
--- a/src/ggrc/notifications/data_handlers.py
+++ b/src/ggrc/notifications/data_handlers.py
@@ -179,7 +179,7 @@ def _get_updated_fields(obj, created_at, definitions, roles):  # noqa: C901
 
   new_rev, old_rev = _get_revisions(obj, created_at)
   if not old_rev:
-    return []
+    return {}
 
   new_attrs = new_rev.content
   old_attrs = old_rev.content


### PR DESCRIPTION
Issue description

The error appears when we try to open notification page if we restore QA / UAT DB dump

# Steps to test the changes

1 Install QA DB dump
2 Login to the system as Superuser
3 Open notification pending page on the link: localhost:8080/_notifications/show_daily_digest

# Solution description

Type of empty arg returned of '_get_updated_fields'  function was changed

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".