### PR TITLE
GGRC-7897 [SV] Add sox_302_enabled field for Assessment

### DIFF
--- a/src/ggrc/converters/handlers/assessment_template.py
+++ b/src/ggrc/converters/handlers/assessment_template.py
@@ -26,6 +26,7 @@ class AssessmentTemplateColumnHandler(handlers.MappingColumnHandler):
     self.value = self.parse_item()
     if not self.dry_run and self.row_converter.is_new:
       self.create_custom_attributes()
+      self.set_sox_302_enabled_flag()
 
   def insert_object(self):
     pass
@@ -41,6 +42,12 @@ class AssessmentTemplateColumnHandler(handlers.MappingColumnHandler):
         key = (cad.definition_id, cad.title)
         self.row_converter.block_converter._ca_definitions_cache[key] = cad
     db.session.flush(created_cads)
+
+  def set_sox_302_enabled_flag(self):
+    """Set `sox_302_enabled` flag for newly created Assessment instance."""
+    if not self.value:
+      return
+    asmt_hooks.set_sox_302_enabled(self.row_converter.obj, self.value[0])
 
   def get_value(self):
     return ""

--- a/src/ggrc/migrations/versions/20191011_0f827fe39ad5_add_sox302_flag_for_asmt.py
+++ b/src/ggrc/migrations/versions/20191011_0f827fe39ad5_add_sox302_flag_for_asmt.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2019 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Add SOX302 flag for Assessment.
+
+Create Date: 2019-10-11 11:27:11.645680
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0f827fe39ad5"
+down_revision = "015aeca94ac8"
+
+
+def add_sox302_flag():
+  """Add `sox_302_enabled` flag on `assessments` table."""
+  op.execute(sa.text("""
+      ALTER TABLE assessments
+        ADD sox_302_enabled TINYINT(1) NOT NULL DEFAULT 0
+  """))
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  add_sox302_flag()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -29,6 +29,7 @@ from ggrc.models.mixins import reminderable
 from ggrc.models.mixins import statusable
 from ggrc.models.mixins import labeled
 from ggrc.models.mixins import issue_tracker as issue_tracker_mixins
+from ggrc.models.mixins import with_sox_302
 from ggrc.models.mixins.assignable import Assignable
 from ggrc.models.mixins.autostatuschangeable import AutoStatusChangeable
 from ggrc.models.mixins.with_action import WithAction
@@ -41,15 +42,31 @@ from ggrc.models.relationship import Relatable
 from ggrc.fulltext.mixin import Indexed
 
 
-class Assessment(Assignable, statusable.Statusable, AuditRelationship,
-                 AutoStatusChangeable, TestPlanned,
-                 CustomAttributable, WithEvidence, Commentable,
-                 Personable, reminderable.Reminderable, Relatable,
-                 LastDeprecatedTimeboxed, WithSimilarityScore, FinishedDate,
-                 VerifiedDate, Notifiable, WithAction,
-                 labeled.Labeled, with_last_comment.WithLastComment,
-                 issue_tracker_mixins.IssueTrackedWithUrl, base.ContextRBAC,
-                 BusinessObject, Indexed, db.Model):
+class Assessment(Assignable,
+                 statusable.Statusable,
+                 AuditRelationship,
+                 AutoStatusChangeable,
+                 TestPlanned,
+                 CustomAttributable,
+                 WithEvidence,
+                 Commentable,
+                 Personable,
+                 reminderable.Reminderable,
+                 Relatable,
+                 LastDeprecatedTimeboxed,
+                 WithSimilarityScore,
+                 FinishedDate,
+                 VerifiedDate,
+                 Notifiable,
+                 WithAction,
+                 labeled.Labeled,
+                 with_last_comment.WithLastComment,
+                 issue_tracker_mixins.IssueTrackedWithUrl,
+                 base.ContextRBAC,
+                 BusinessObject,
+                 with_sox_302.WithSOX302FlowReadOnly,
+                 Indexed,
+                 db.Model):
   """Class representing Assessment.
 
   Assessment is an object representing an individual assessment performed on

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -115,6 +115,13 @@ def set_assessment_type(assessment, template):
     assessment.assessment_type = template.template_object_type
 
 
+def set_sox_302_enabled(assessment, template):
+   # type: (models.Assessment, models.AssessmentTemplate) -> None
+  """Set sox_302_enabled flag from template."""
+  if template:
+    assessment.sox_302_enabled = template.sox_302_enabled
+
+
 # pylint: disable=too-many-arguments
 def _handle_assessment(assessment,  # type: models.Assessment
                        audit,  # type: models.Audit
@@ -129,6 +136,7 @@ def _handle_assessment(assessment,  # type: models.Assessment
   assessment.map_to(audit)
 
   if tmpl is not None:
+    set_sox_302_enabled(assessment, tmpl)
     _mark_cads_to_batch_insert(
         ca_definitions=tmpl.custom_attribute_definitions,
         attributable=assessment,

--- a/src/ggrc/models/mixins/with_sox_302.py
+++ b/src/ggrc/models/mixins/with_sox_302.py
@@ -55,3 +55,20 @@ class WithSOX302Flow(object):  # pylint: disable=too-few-public-methods
             "sox_302_enabled",
         ),
     )
+
+
+class WithSOX302FlowReadOnly(WithSOX302Flow):
+  """Mixin which adds support for SOX 302 flow. SOX flag is read only here."""
+
+  _aliases = {
+      "sox_302_enabled": {
+          "display_name": "SOX 302 assessment workflow",
+          "description": "Read only column and will be ignored on import.",
+          "mandatory": False,
+          "view_only": True,
+      },
+  }
+
+  _api_attrs = reflection.ApiAttributes(
+      reflection.Attribute('sox_302_enabled', create=False, update=False),
+  )


### PR DESCRIPTION
# Dependencies

_After review this PR should be targeted into `GGRC-7771-sox-skip-verify` branch._

This PR is `on hold` until the dependencies are merged:

- [x] #10071 
- [x] #10103

# Issue description

This PR contains SOX 302 functionality for Assessment. After all builds pass should be targeted into common branch `GGRC-7771-sox-skip-verify`.

# Steps to test the changes

*Include steps to test or reproduce (in case of a bugfix) the changes in the pull request. This section should help the reviewer verify your changes.*

# Solution description

This PR contains following changes:

* New migration which adds `sox_302_enabled` flag on `assessments` table:
```sql
ALTER TABLE assessment_templates ADD sox_302_enabled TINYINT(1) NOT NULL DEFAULT 0 ;
```
* New mixin `WithSOX302FlowReadOnly` is created which is a subclass of `WithSOX302Flow` mixin. New mixin provides the same functionality but makes `sox_302_enabled` read-only for API and imports.

* `Assessment` is modified so now it's derived from `WithSOX302FlowReadOnly` mixin. Also column handler for _"Template"_ CSV column and hook for Assessment POST are modified to set assessment's `sox_302_enabled` from AssessmentTemplate if one is provided. 

* Integration tests are provided which cover `sox_302_enabled` modification via REST API, import / export. Also tests cover search functionality.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
