### PR TITLE
GGRC-6207/GGRC-6181: Issue tracker doesn't sync empty Due Date in Assessment

### DIFF
--- a/src/ggrc/models/issuetracker_issue.py
+++ b/src/ggrc/models/issuetracker_issue.py
@@ -194,7 +194,7 @@ class IssuetrackerIssue(base.ContextRBAC, Base, db.Model):
     self.issue_url = info['issue_url']
 
     if 'due_date' in info:
-      self.due_date = info.get('due_date')
+      self.due_date = info['due_date']
 
     self.people_sync_enabled = info['people_sync_enabled']
 

--- a/test/integration/ggrc/integrations/test_asmt_sync_job.py
+++ b/test/integration/ggrc/integrations/test_asmt_sync_job.py
@@ -2,11 +2,13 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Integration test for Assessment object sync cron job."""
+from datetime import datetime
 
 import ddt
 import mock
 
 from ggrc import settings
+from ggrc.models import all_models
 from ggrc.integrations.synchronization_jobs import assessment_sync_job
 from ggrc.integrations.synchronization_jobs import sync_utils
 from ggrc.integrations import constants
@@ -35,6 +37,7 @@ class TestAsmtSyncJob(ggrc.TestCase):
       factories.IssueTrackerIssueFactory(
           enabled=True,
           issue_tracked_obj=asmt,
+          due_date=datetime.utcnow(),
           **TestAsmtSyncJob._issuetracker_data()
       )
       return asmt
@@ -137,3 +140,40 @@ class TestAsmtSyncJob(ggrc.TestCase):
       assessment_sync_job.sync_assessment_attributes()
 
     update_issue_mock.assert_called_once_with(*expected_upd_args)
+
+  def test_empty_due_date_sync(self, update_issue_mock):
+    """Test adding empty due_date in Issue"""
+    due_date = None
+    with factories.single_commit():
+      assmt = self._create_asmt(True)
+      assmt.start_date = due_date
+      issue = assmt.issuetracker_issue
+      issuetracker_issue_id = issue.id
+      iti = self._to_issuetrakcer_repr(assmt)
+      iti[assmt.issuetracker_issue.issue_id].update({
+          "custom_fields": [{
+              constants.CustomFields.DUE_DATE:
+                  issue.due_date.strftime("%Y-%m-%d")
+          }],
+      })
+      batches = [iti]
+
+    with mock.patch.object(
+        sync_utils,
+        "iter_issue_batches",
+        return_value=batches
+    ):
+      assessment_sync_job.sync_assessment_attributes()
+
+    issue_id = iti.keys()[0]
+    payload = iti[issue_id]
+    payload["custom_fields"] = [{
+        'display_string': 'Due Date',
+        'type': 'DATE',
+        'name': 'Due Date',
+        'value': None,
+    }]
+    payload["status"] = 'ASSIGNED'
+    update_issue_mock.assert_called_once_with(issue_id, payload)
+    issue = all_models.IssuetrackerIssue.query.get(issuetracker_issue_id)
+    self.assertIsNone(issue.due_date)

--- a/test/integration/ggrc/integrations/test_assessment_integration.py
+++ b/test/integration/ggrc/integrations/test_assessment_integration.py
@@ -473,6 +473,11 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
         'hotlist_ids': [333, ],
         'priority': u'P0',
         'type': constants.DEFAULT_ISSUETRACKER_VALUES['issue_type'],
+        'custom_fields': [{
+            'display_string': 'Due Date',
+            'type': 'DATE',
+            'name': 'Due Date',
+            'value': None}],
     }
     self.assertEqual(expected_info, with_info)
     self.assertEqual(without_info, with_info)
@@ -615,7 +620,13 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
               'title': iti_title,
               'hotlist_ids': [222222],
               'priority': "P2",
-              'comment': expected_comment}
+              'comment': expected_comment,
+              'custom_fields': [{
+                  'display_string': 'Due Date',
+                  'type': 'DATE',
+                  'name': 'Due Date',
+                  'value': None,
+              }]}
     mocked_update_issue.assert_called_once_with(iti_issue_id, kwargs)
 
   @mock.patch("ggrc.integrations.issues.Client.update_issue")
@@ -1029,7 +1040,13 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
                 'severity': "S4",
                 'title': iti.title,
                 'hotlist_ids': [],
-                'priority': "P4"}
+                'priority': "P4",
+                'custom_fields': [{
+                    'display_string': 'Due Date',
+                    'type': 'DATE',
+                    'name': 'Due Date',
+                    'value': None,
+                }]}
       mocked_update_issue.assert_called_once_with(iti_issue_id[0], kwargs)
 
   @mock.patch('ggrc.integrations.issues.Client.update_issue')
@@ -1074,7 +1091,13 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
                 'severity': iti.issue_severity,
                 'title': new_title,
                 'hotlist_ids': [],
-                'priority': iti.issue_priority}
+                'priority': iti.issue_priority,
+                'custom_fields': [{
+                    'display_string': 'Due Date',
+                    'type': 'DATE',
+                    'name': 'Due Date',
+                    'value': None,
+                }]}
       mocked_update_issue.assert_called_once_with(iti_issue_id[0], kwargs)
 
       issue = db.session.query(models.IssuetrackerIssue).get(iti.id)
@@ -1422,48 +1445,6 @@ class TestIssueTrackerIntegration(SnapshotterBaseTestCase):
                       "assessment", {}).get("issue_tracker",
                                             {}).get("_warnings", []))
 
-  @mock.patch('ggrc.integrations.issues.Client.update_issue')
-  @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
-  def test_reset_issuetracker_due_date(self, mocked_update_issue):
-    """Test issue due_date is properly reset to None."""
-    initial_date = '2018-09-12'
-    new_due_date = None
-    with mock.patch.object(
-        assessment_integration.AssessmentTrackerHandler,
-        '_is_tracker_enabled',
-        return_value=True
-    ):
-      iti = factories.IssueTrackerIssueFactory(
-          enabled=True,
-          component_id="123123",
-          issue_type="PROCESS",
-          issue_priority="P2",
-          issue_severity="S2",
-          due_date=initial_date
-      )
-      iti_id = iti.issue_id
-      asmt = iti.issue_tracked_obj
-      custom_fields = [{
-          'name': 'Due Date',
-          'value': new_due_date,
-          'type': 'DATE',
-          'display_string': 'Due Date',
-      }]
-      self.api.put(asmt, {
-          'start_date': new_due_date,
-          'title': 'title'
-      })
-      kwargs = {'status': 'ASSIGNED',
-                'component_id': 123123,
-                'severity': "S2",
-                'title': iti.title,
-                'hotlist_ids': [],
-                'priority': "P2",
-                'custom_fields': custom_fields}
-      mocked_update_issue(iti_id, kwargs)
-      issue = db.session.query(models.IssuetrackerIssue).get(iti.id)
-      self.assertIsNone(issue.due_date)
-
 
 @ddt.ddt
 @mock.patch.object(settings, "ISSUE_TRACKER_ENABLED", True)
@@ -1566,7 +1547,12 @@ class TestIntegrationAssessmentStatus(SnapshotterBaseTestCase):
         'severity': "S2",
         'title': iti.title,
         'hotlist_ids': [],
-        'priority': "P2"
+        'priority': "P2",
+        'custom_fields': [{
+            'display_string': 'Due Date',
+            'type': 'DATE',
+            'name': 'Due Date',
+            'value': None}]
     }
     asmt_link = self.tracker_handler._get_assessment_page_url(self.asmt)
     if 'comment' in additional_kwargs:

--- a/test/integration/ggrc/integrations/test_bulk_issue_generate.py
+++ b/test/integration/ggrc/integrations/test_bulk_issue_generate.py
@@ -921,12 +921,10 @@ class TestBulkIssuesUpdate(TestBulkIssuesSync):
     # 3 times for each assessment
     self.assertEqual(update_issue_mock.call_count, 9)
 
-  @ddt.data("Issue", "Assessment")
-  def test_get_issue_json(self, model):
-    """Test get_issue_json method issue's update"""
+  def test_issue_get_issue_json(self):
+    """Test Issue get_issue_json method issue's update"""
     with factories.single_commit():
-      factory = factories.get_model_factory(model)
-      obj = factory()
+      obj = factories.IssueFactory()
       factories.IssueTrackerIssueFactory(
           enabled=True,
           issue_tracked_obj=obj,
@@ -944,6 +942,39 @@ class TestBulkIssuesUpdate(TestBulkIssuesSync):
         'hotlist_ids': [222],
         'priority': u'P2',
         'type': u'PROCESS'
+    }
+    updater = issuetracker_bulk_sync.IssueTrackerBulkUpdater()
+    # pylint: disable=protected-access
+    result = updater._get_issue_json(obj)
+    self.assertEqual(expected_result, result)
+
+  def test_assmt_get_issue_json(self):
+    """Test Assessment get_issue_json method issue's update"""
+    with factories.single_commit():
+      obj = factories.AssessmentFactory()
+      factories.IssueTrackerIssueFactory(
+          enabled=True,
+          issue_tracked_obj=obj,
+          title='title',
+          component_id=111,
+          hotlist_id=222,
+          issue_type="PROCESS",
+          issue_priority="P2",
+          issue_severity="S2",
+      )
+    expected_result = {
+        'component_id': 111,
+        'severity': u'S2',
+        'title': u'title',
+        'hotlist_ids': [222],
+        'priority': u'P2',
+        'type': u'PROCESS',
+        'custom_fields': [{
+            'display_string': 'Due Date',
+            'name': 'Due Date',
+            'type': 'DATE',
+            'value': None
+        }],
     }
     updater = issuetracker_bulk_sync.IssueTrackerBulkUpdater()
     # pylint: disable=protected-access


### PR DESCRIPTION
This pr also fix GGRC-6181

# Dependencies

This PR is `on hold` GGRC-8543 will be fixed:

- [ ] GGRC-8543

# Issue description

Issue tracker doesn't sync empty Due Date in Assessment

# Steps to test the changes

Steps to reproduce:
1. Open any adit page with issue tracker turned ON
Hotlist ID: 700706
Component ID: 64445
2. Create Assessment with empty Due date and issue tracker turned ON
Hotlist ID: 700706
Component ID: 64445
3. On Assessment Info panel click Ticket link
4. Once Issue Tracker is displayed look at Due Date in Ticket: is empty (correct)
5. Add empty due date in Assessment
Actual Result: If due date is empty in assessment, it should sync with issue tracker

# Solution description

*Change all 'if' statements to accept None value of 'due_date' attr*

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
