### PR TITLE
GGRC-7976 Add Hint for the Global CA of People type

### DIFF
--- a/src/ggrc/models/reflection.py
+++ b/src/ggrc/models/reflection.py
@@ -439,7 +439,6 @@ class AttributeInfo(object):
     else:
       custom_attributes = object_class.get_custom_attribute_definitions(fields)
     for attr in custom_attributes:
-
       description = attr.helptext or u""
       if attr.multi_choice_options:
         if description:
@@ -449,6 +448,8 @@ class AttributeInfo(object):
         )
       elif attr.attribute_type == attr.ValidTypes.CHECKBOX:
         description += u"Allowed values are:\nTRUE\nFALSE"
+      elif attr.ValidTypes.MAP in attr.attribute_type:
+        description += u"Allowed values are emails"
       if attr.definition_id:
         ca_type = cls.Type.OBJECT_CUSTOM
         attr_name = u"{}{}".format(

--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -8,7 +8,6 @@ from os.path import abspath, dirname, join
 import collections
 import ddt
 from flask.json import dumps
-
 from ggrc import utils
 from ggrc.converters import get_exportables
 from ggrc.models import inflector, all_models
@@ -52,6 +51,25 @@ class TestExportEmptyTemplate(TestCase):
     response = self.client.post("/_service/export_csv",
                                 data=dumps(data), headers=self.headers)
     self.assertIn("Allowed values are:\nTRUE\nFALSE", response.data)
+
+  def test_custom_attr_people(self):
+    """Test if LCA Map:Person type has hint for Assessment ."""
+    with factories.single_commit():
+      assessment = factories.AssessmentFactory()
+      factories.CustomAttributeDefinitionFactory(
+          definition_type="assessment",
+          title="Included LCAD",
+          attribute_type="Map:Person",
+          definition_id=assessment.id,
+      )
+    data = {
+        "export_to": "csv",
+        "objects": [{"object_name": "Assessment", "fields": "all"}]
+    }
+    response = self.client.post("/_service/export_csv",
+                                data=dumps(data), headers=self.headers)
+    self.assertIn("Included LCAD", response.data)
+    self.assertIn("Allowed values are emails", response.data)
 
   def test_basic_policy_template(self):
     """Tests for basic policy templates."""
@@ -164,7 +182,6 @@ class TestExportEmptyTemplate(TestCase):
   @ddt.data("Assessment", "Issue")
   def test_ticket_tracker_field_order(self, model):
     """Tests if Ticket Tracker fields come before mapped objects for {}."""
-
     data = {
         "export_to": "csv",
         "objects": [
@@ -181,7 +198,6 @@ class TestExportEmptyTemplate(TestCase):
   @ddt.data("Assessment", "Issue")
   def test_ticket_tracker_fields(self, model):
     """Tests if Ticket Tracker fields are in export file for {}"""
-
     data = {
         "export_to": "csv",
         "objects": [
@@ -197,7 +213,6 @@ class TestExportEmptyTemplate(TestCase):
   @ddt.data("Process", "System")
   def test_network_zone_tip(self, model):
     """Tests if Network Zone column has tip message in export file for {}"""
-
     data = {
         "export_to": "csv",
         "objects": [
@@ -723,7 +738,7 @@ class TestExportSingleObject(TestCase):
 
 @ddt.ddt
 class TestExportMultipleObjects(TestCase):
-
+  """Test case for export multiple objects"""
   def setUp(self):
     super(TestExportMultipleObjects, self).setUp()
     self.client.get("/login")


### PR DESCRIPTION

# Dependencies

This PR is `on hold` until we'll discuss this test.


# Issue description

Hint for the User-defined Global Custom Attributes of People type

# Steps to test the changes

Written the test case and verified the data is coming properly or not.
GUI console doesn't have the CA of People type to test in GUI.

# Solution description

Changed the  method in 'src/ggrc/models/reflection.py' and 'src/ggrc/models/custom_attribute_definition.py' to full fill the requirement,

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
