### PR TITLE
GGRC-8009 Projects object icon is not marked as snapshot on Audit page

### DIFF
--- a/src/ggrc-client/styles/modules/_top-nav.scss
+++ b/src/ggrc-client/styles/modules/_top-nav.scss
@@ -23,7 +23,7 @@ div.nav {
         &.access_group, &.contract, &.control, &.data_asset, &.facility,
         &.market, &.objective, &.org_group, &.policy, &.process, &.product, &.product_group,
         &.metric, &.regulation, &.requirement, &.standard, &.system, &.vendor, &.risk,
-        &.technology_environment, &.threat, &.key_report, &.account_balance {
+        &.technology_environment, &.threat, &.key_report, &.account_balance, &.project {
           a {
             color: $blue;
             opacity: 1;


### PR DESCRIPTION
# Issue description
Projects object icon is not marked as snapshot on Audit page

# Steps to test the changes
1. Create a Program
2. Map any Project object to the Program
3. Create Audit
4. Open Created Audit
4. Review icon for Project
**Actual**l: Icon for Project object is not marked as all other snapshot objects
**Expected**: Project object is marked as all other snapshot objects

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".