### PR TITLE
GGRC-6181 Fix updating issue_tracker_issue due_date

### DIFF
--- a/src/ggrc/models/issuetracker_issue.py
+++ b/src/ggrc/models/issuetracker_issue.py
@@ -193,7 +193,7 @@ class IssuetrackerIssue(base.ContextRBAC, Base, db.Model):
     self.issue_id = info['issue_id']
     self.issue_url = info['issue_url']
 
-    if info.get('due_date'):
+    if 'due_date' in info:
       self.due_date = info.get('due_date')
 
     self.people_sync_enabled = info['people_sync_enabled']


### PR DESCRIPTION
# Issue description

Hourly cron job doesn't update due_date of ticket in Issue Tracker

# Steps to test the changes

1. Create assessment with issue tracker ON and set a due date
2. Open Issue Tracker and look at the due date in the ticket: is displayed [^screenshot-5.png]
3. Remove due date on assessment
4. Run a cron job
5. Open Issue Tracker and look at the due date has been changed 

# Solution description

Fix 'update_from_dict' mothod of IssuetrackerIssue

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".