### PR TITLE
GGRC-6133/GGRC-8077 Change Log shows 'Modified' and 'Created' for mappings

### DIFF
--- a/src/ggrc-client/js/components/related-objects/revisions/related-revisions.js
+++ b/src/ggrc-client/js/components/related-objects/revisions/related-revisions.js
@@ -14,7 +14,6 @@ import {
   buildParam,
   batchRequests,
 } from '../../../plugins/utils/query-api-utils';
-import QueryParser from '../../../generated/ggrc-filter-query-parser';
 
 export default canComponent.extend({
   tag: 'related-revisions',
@@ -101,9 +100,15 @@ export default canComponent.extend({
     },
 
     getQueryFilter() {
-      const instance = this.attr('instance');
-      return QueryParser.parse(
-        `${instance.type} not_empty_revisions_for ${instance.id}`);
+      const {type, id} = this.attr('instance');
+      return {
+        expression: {
+          op: {name: 'not_empty_revisions'},
+          resource_type: type,
+          resource_id: id,
+          ignore_relationships: true,
+        },
+      };
     },
   }),
   events: {

--- a/src/ggrc-client/js/components/revision-log/revision-log.js
+++ b/src/ggrc-client/js/components/revision-log/revision-log.js
@@ -122,23 +122,13 @@ export default canComponent.extend({
 
       if (!this.attr('options.showLastReviewUpdates')) {
         return QueryParser.parse(
-          `${instance.type} not_empty_revisions_for ${instance.id} OR
-          source_type = ${instance.type} AND
-          source_id = ${instance.id} OR
-          destination_type = ${instance.type} AND
-          destination_id = ${instance.id}`);
+          `${instance.type} not_empty_revisions_for ${instance.id}`);
       } else {
         const reviewDate = moment(this.attr('review.last_reviewed_at'))
           .format('YYYY-MM-DD HH:mm:ss');
 
         return QueryParser.parse(
           `${instance.type} not_empty_revisions_for ${instance.id} AND
-          created_at >= "${reviewDate}" OR
-          source_type = ${instance.type} AND
-          source_id = ${instance.id} AND
-          created_at >= "${reviewDate}" OR
-          destination_type = ${instance.type} AND
-          destination_id = ${instance.id} AND
           created_at >= "${reviewDate}"`);
       }
     },

--- a/test/unit/ggrc/query/test_validate_decorator.py
+++ b/test/unit/ggrc/query/test_validate_decorator.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Module for validate decorator tests"""
+
+import unittest
+
+import ddt
+
+from ggrc.query.custom_operators import validate
+from ggrc.query.exceptions import BadQueryException
+
+
+@ddt.ddt
+class TestValidateDecorator(unittest.TestCase):
+  """Tests for validate decorator"""
+
+  @ddt.data(
+      {
+          'a': 'A',
+          'd': 'D',
+          'c': 15,
+          'op': {'name': 'op'}
+      },
+      {
+          'b': 'B',
+          'd': 'D',
+          'op': {'name': 'op'}
+      },
+      {
+          't': 'T',
+          'p': 'P',
+          'op': {'name': 'op'}
+      },
+  )
+  def test_required_fields(self, func_args):
+    """test validate decorator validate correctly"""
+    @validate('a', 'b')
+    def test_func(*args):
+      return args
+
+    with self.assertRaises(BadQueryException):
+      test_func(func_args)


### PR DESCRIPTION
# Issue description

*Change Log shows 'Modified' and 'Created' for mappings*

# Steps to test the changes

*Send empty put or similar post for any object. Open change log tab.
There is no wrong revisions*

# Solution description

BE:
Change not_empty_revisions filter operator to get also relationship revisions for object
Add ignore relationship flag and modify validate decorator to handle optional args too
FE:
Change format of filter for revisions.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
