### PR TITLE
GGRC-8073 Impossible to create Assessment with snapshots automapped to Audit

### DIFF
--- a/src/ggrc/snapshotter/rules.py
+++ b/src/ggrc/snapshotter/rules.py
@@ -64,6 +64,16 @@ class Types(object):
       "Risk",
   }
 
+  @classmethod
+  def internal_types(cls):
+    """Return set of internal type names."""
+    return cls.all - cls.external
+
+  @classmethod
+  def external_types(cls):
+    """Return set of external type names."""
+    return cls.external
+
 
 class Rules(object):
   """Returns a dictionary of rules

--- a/test/integration/ggrc/snapshotter/test_indexing.py
+++ b/test/integration/ggrc/snapshotter/test_indexing.py
@@ -3,9 +3,9 @@
 
 """Test for indexing of snapshotted objects"""
 
+import ddt
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.sql.expression import tuple_
-import ddt
 
 from ggrc import db
 from ggrc import models


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

User cannot create an assessment with the snapshots from audit. In the Unified Mapper snapshots do not display while mapping a snapshot.

# Steps to test the changes

_Preconditions:_

1. Take latest dump from ggrc-uat.
2. Have Program with mapped object, e.g. Control.

_Steps to reproduce:_

1. Open a program;
2. Click Add tab and select Audit (do not check 'Manually map snapshots' checkbox);
3. Check that Control snapshot is automapped to the Audit;
4. Create an Assessment with mapped Control snapshot.

**Expected result:** Snapshot should be mapped to an assessment while creating it.

**Before changes**: Impossible to map a Snapshot to the Assessment while creating it as a Snapshot isn't displayed in Search results in the Unified mapper.

# Solution description

`_get_custom_attribute_dict` produced result containing duplicates of custom attribute definitions since it gathered both internal and external CADs and the CADs present in external custom attribute table are also present in internal one. It leads to errors during snapshot indexing.

This PR contains changes in `_get_custom_attribute_dict` function so now it gathers internal and external CADs (previously it were all CADs and external CADs).

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
