### PR TITLE
GGRC-8093 Check that GCA field cannot be edited for Risk

### DIFF
--- a/test/selenium/src/lib/service/webui_service.py
+++ b/test/selenium/src/lib/service/webui_service.py
@@ -479,14 +479,9 @@ class BaseWebUiService(base.WithBrowser):
     obj_page = self.open_info_page_of_obj(obj)
     obj_page.fill_global_cas_inline(custom_attributes)
 
-  def has_gca_inline_edit(self, obj, ca_type):
+  def has_gca_inline_edit(self, obj, ca_title):
     """Checks if edit_inline is open for selected gca."""
-    obj_page = self.open_info_page_of_obj(obj)
-    ca_title = next(
-        x for x in obj_page.get_custom_attributes().keys()
-        if ca_type.lower() in x.lower()
-    )
-    return obj_page.has_ca_inline_edit(ca_title)
+    return self.open_info_page_of_obj(obj).has_ca_inline_edit(ca_title)
 
   def edit_obj_via_edit_modal_from_info_page(self, obj):
     """Open generic widget of object, open edit modal from drop down menu.

--- a/test/selenium/src/lib/utils/selenium_utils.py
+++ b/test/selenium/src/lib/utils/selenium_utils.py
@@ -383,5 +383,5 @@ def filter_by_text(elements, text):
   #   browser.elements(cls=cls, text=text)
   # has O(N) complexity where N is the number of elements with class `cls`
   for element in elements:
-    if element.text.upper() == text or element.text == text:
+    if element.text.lower() == text.lower():
       return element


### PR DESCRIPTION
# Issue description

Add test checking that user cannot update GCAs for Risk

# Steps to test the changes

# Solution description

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
