### PR TITLE
GGRC-7931 Error appears on objects after applying Admin role for Global Creator user

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -441,10 +441,12 @@ def _load_permissions_from_database(user):
   return permissions
 
 
-def load_permissions_for(user):
-  """Permissions is dictionary that can be exported to json to share with
-  clients. Structure is:
-  ..
+def load_permissions_for(user, expire_old=False):
+  """Load permissions for provided user.
+
+  Load permissions from memcache (if present) or database. Permissions is
+  dictionary that can be exported to json to share with clients. Structure of
+  the dictionary is the following:
 
     permissions[action][resource_type][contexts]
                                       [conditions][context][context_conditions]
@@ -458,14 +460,26 @@ def load_permissions_for(user):
     keys.
   'condition' is the string name of a conditional operator, such as 'contains'.
   'terms' are the arguments to the 'condition'.
-  """
-  key = 'permissions:{}'.format(user.id)
 
+  Args:
+    user (models.User): Instance of `User` model representing user whose
+      permissions should be loaded.
+    expire_old (bool): Flag indicating whether previously loaded permissions\
+      should be expired if any. Defaults to `False`.
+
+  Returns:
+    Dictionary containing user's permissions.
+  """
+  with benchmark("load_permissions > invalidate memcache for specific user"):
+    if expire_old:
+      cache_utils.clear_users_permission_cache([user.id])
+
+  memcache_key = 'permissions:{}'.format(user.id)
   # try to get cached permissions from memcahe
   with benchmark("load_permissions > query memcache"):
     cache = _get_memcache_client()
     if cache:
-      result = query_memcache(cache, key)
+      result = query_memcache(cache, memcache_key)
       if result:
         return result
 
@@ -479,7 +493,7 @@ def load_permissions_for(user):
     # the permissions information for any subsequent request.
     with benchmark("load_permissions > store results into memcache"):
       if cache:
-        store_results_into_memcache(permissions, cache, key)
+        store_results_into_memcache(permissions, cache, memcache_key)
 
   return permissions
 

--- a/test/integration/ggrc_basic_permissions/test_permissions_loading.py
+++ b/test/integration/ggrc_basic_permissions/test_permissions_loading.py
@@ -127,6 +127,12 @@ class TestPermissionsLoading(TestMemcacheBase):
 
   def test_add_acl(self):
     """Permissions are recalculated only for assigned people on PUT."""
+    # Memcache should be cleared first since it contains permissions for
+    # both users on startup due to setUp method which creates users with
+    # `UserRole`. Creation of `UserRole` causes cached permissions
+    # recalculation.
+    self.memcache_client.delete("permissions:list")
+
     pa_role = all_models.AccessControlRole.query.filter(
         all_models.AccessControlRole.object_type == "Program",
         all_models.AccessControlRole.name == "Program Managers"

--- a/test/integration/ggrc_basic_permissions/test_permissions_loading.py
+++ b/test/integration/ggrc_basic_permissions/test_permissions_loading.py
@@ -10,7 +10,12 @@ from ggrc.models import all_models
 from ggrc.cache import utils as cache_utils
 from integration.ggrc import TestCase, generator
 from integration.ggrc.api_helper import Api
-from integration.ggrc.models import factories
+from integration.ggrc.models import factories as ggrc_factories
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
+
+
+# pylint: disable=invalid-name
 
 
 # stub for module, which cannot be imported in global scope bacause of
@@ -59,7 +64,7 @@ class TestPermissionsLoading(TestMemcacheBase):
 
   def test_permissions_loading(self):
     """Test if permissions created only once for GET requests."""
-    control_id = factories.ControlFactory().id
+    control_id = ggrc_factories.ControlFactory().id
     with mock.patch(
         "ggrc_basic_permissions.store_results_into_memcache",
         side_effect=ggrc_basic_permissions.store_results_into_memcache
@@ -453,8 +458,8 @@ class TestPermissionsLoading(TestMemcacheBase):
                     "type": "Person",
                 }
             }],
-            "link": factories.random_str(),
-            "title": factories.random_str(),
+            "link": ggrc_factories.random_str(),
+            "title": ggrc_factories.random_str(),
             "context": None,
         }
     })
@@ -579,9 +584,9 @@ class TestPermissionsCacheFlushing(TestMemcacheBase):
 
   def test_permissions_not_flush_on_simple_put(self):
     """Test that permissions in memcache are cleaned after PUT request."""
-    with factories.single_commit():
+    with ggrc_factories.single_commit():
       user = self.create_user_with_role("Creator")
-      objective = factories.ObjectiveFactory()
+      objective = ggrc_factories.ObjectiveFactory()
       objective_id = objective.id
       objective.add_person_with_role_name(user, "Admin")
 
@@ -600,9 +605,9 @@ class TestPermissionsCacheFlushing(TestMemcacheBase):
 
   def test_permissions_flush_on_delete(self):
     """Test that permissions in memcache are cleaned after DELETE request."""
-    with factories.single_commit():
+    with ggrc_factories.single_commit():
       user = self.create_user_with_role("Creator")
-      objective = factories.ObjectiveFactory()
+      objective = ggrc_factories.ObjectiveFactory()
       objective.add_person_with_role_name(user, "Admin")
       objective_id = objective.id
 
@@ -618,3 +623,48 @@ class TestPermissionsCacheFlushing(TestMemcacheBase):
 
     perm_ids = self.memcache_client.get("permissions:list")
     self.assertEqual(perm_ids, set())
+
+  def test_permissions_reload_on_role_post(self):
+    """Test permissions in memcache are recalculated on UserRole POST."""
+    person = ggrc_factories.PersonFactory()
+    person_permissions_key = "permissions:{}".format(person.id)
+    admin_role = all_models.Role.query.filter_by(name="Administrator").one()
+
+    self.memcache_client.delete("permissions:list")
+    response = self.api.post(
+        all_models.UserRole,
+        {
+            "user_role": {
+                "person": {
+                    "type": person.type,
+                    "id": person.id,
+                },
+                "role": {
+                    "type": admin_role.type,
+                    "id": admin_role.id,
+                },
+            },
+        },
+    )
+
+    self.assertStatus(response, 201)
+    cached_keys = self.memcache_client.get("permissions:list")
+    self.assertIn(person_permissions_key, cached_keys)
+
+  def test_permissions_reload_on_role_delete(self):
+    """Test permissions in memcache are recalculated on UserRole DELETE."""
+    admin_role = all_models.Role.query.filter_by(name="Administrator").one()
+    with ggrc_factories.single_commit():
+      person = ggrc_factories.PersonFactory()
+      person_permissions_key = "permissions:{}".format(person.id)
+      person_role = rbac_factories.UserRoleFactory(
+          role=admin_role,
+          person=person,
+      )
+
+    self.memcache_client.delete("permissions:list")
+    response = self.api.delete(person_role)
+
+    self.assertStatus(response, 200)
+    cached_keys = self.memcache_client.get("permissions:list")
+    self.assertIn(person_permissions_key, cached_keys)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Error appears on previously unavailable due to permissions object after applying `Admin` role for `Global Creator` user and refreshing the object's page.

# Steps to test the changes

1. Login as Global Creator user;
2. Open any Audit that Global creator has no access to;
3. Change Role for user from Global Creator to Admin;
4. Refresh Audit page.

**Expected result: Audit page should be opened without any errors.**

# Solution description

Perform permission recalculation for a user on its `UserRole` create and delete actions.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
