### PR TITLE
QUICK-FIX GGRC-7925 Logger.warning changed to logger.info

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -342,11 +342,6 @@ Result dispatch:
 
 def build_type_query(type_, result_spec):
   model = ggrc.models.get_model(type_)
-  if model is None:
-    logger.warning('get_model from %s is None', type_)
-    logger.warning('result_spec %s', result_spec)
-    return None, None
-
   mapper = model._sa_class_manager.mapper
   columns = []
   columns_indexes = {}
@@ -402,7 +397,6 @@ def build_type_query(type_, result_spec):
 
 
 def build_stub_union_query(queries):  # noqa: C901
-  logger.warning('Queries to build_stub_union_query: %s', queries)
   results = {}
   for (type_, conditions) in queries:
     if isinstance(conditions, (int, long, str, unicode)):
@@ -420,8 +414,11 @@ def build_stub_union_query(queries):  # noqa: C901
   type_column_indexes = {}
   type_queries = {}
   for (type_, result_spec) in results.items():
-    columns_indexes, query = build_type_query(type_, result_spec)
-    if columns_indexes is None or query is None:
+    try:
+      columns_indexes, query = build_type_query(type_, result_spec)
+    except AttributeError:
+      logger.info('type_ to build_type_query: %s', type_)
+      logger.info('result_spec to build_type_query: %s', result_spec)
       continue
     type_column_indexes[type_] = columns_indexes
     type_queries[type_] = query
@@ -518,7 +515,6 @@ def reify_representation(resource, results, type_columns):
 
 
 def publish_representation(resource):
-  logger.warning('Resource to publish_representation: %s', resource)
   queries = gather_queries(resource)
 
   if not queries:


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Existing logger.warning logged more data that needed.

# Steps to test the changes

The issue arises exceptionally and cannot be reproduced locally.

# Solution description

Excess logger.warning has been removed. A place with issue was placed in a try-except block. In except block, logger.warning was added to check for problematic data.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
