### PR TITLE
GGRC-8106 Add test to check that user cannot update predefined field for risk

### DIFF
--- a/test/selenium/src/lib/element/page_elements.py
+++ b/test/selenium/src/lib/element/page_elements.py
@@ -64,9 +64,12 @@ class SimpleField(object):
   (with h6 header and a text within the same element).
   """
 
-  def __init__(self, container, label):
+  def __init__(self, container, label, with_inline_edit=False):
     self._label_text = label
     self._container = container
+    if with_inline_edit:
+      self.inline_edit = InlineEdit(self.root)
+      self.input = self.root.input()
 
   @property
   def root(self):
@@ -137,12 +140,8 @@ class AssertionsDropdown(object):
     self._root = container.element(
         class_name="custom-attr-wrap").element(text=self.text)
     self.assertions_values = self._root.parent().text.splitlines()[1:]
-    self._inline_edit = InlineEdit(self._root)
+    self.inline_edit = InlineEdit(self._root)
     self.input = self._root.select(class_name="input-block-level")
-
-  def open_inline_edit(self):
-    """Open element for editing."""
-    self._inline_edit.open()
 
 
 class RelatedPeopleList(object):

--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -840,6 +840,11 @@ class Controls(page_mixins.WithAssignFolder, page_mixins.WithDisabledProposals,
     """Click Control Review Details button."""
     self._root.element(text="Control Review Details").click()
 
+  @property
+  def predefined_field(self):
+    """Returns assertions element as a predefined field for controls."""
+    return self.assertions
+
 
 class Objectives(page_mixins.WithAssignFolder, InfoWidget):
   """Model for Objective object Info pages and Info panels."""
@@ -1008,6 +1013,12 @@ class Risks(page_mixins.WithDisabledProposals,
   def risk_owners(self):
     """Returns Risk Owners page element."""
     return self._related_people_list(roles.RISK_OWNERS, self._root)
+
+  @property
+  def predefined_field(self):
+    """Returns description element as a predefined field for risk."""
+    return page_elements.SimpleField(
+        self._root, element.Common.DESCRIPTION, with_inline_edit=True)
 
 
 class Threat(InfoWidget):

--- a/test/selenium/src/lib/service/webui_facade.py
+++ b/test/selenium/src/lib/service/webui_facade.py
@@ -646,3 +646,13 @@ def open_dashboard(selenium):
     Dashboard page objects model."""
   selenium_utils.open_url(url.dashboard())
   return dashboard.Dashboard(selenium)
+
+
+def soft_assert_cannot_update_predefined_field(soft_assert, obj):
+  """Performs soft assert that click on predefined field's pencil icon doesn't
+  open an input field."""
+  field_element = factory.get_cls_webui_service(objects.get_plural(
+      obj.type))().open_info_page_of_obj(obj).predefined_field
+  field_element.inline_edit.open()
+  soft_assert.expect(not field_element.input.exist,
+                     "There should be no input field.")

--- a/test/selenium/src/tests/test_disabled_objects.py
+++ b/test/selenium/src/tests/test_disabled_objects.py
@@ -3,7 +3,6 @@
 """Disabled objects tests."""
 
 # pylint: disable=redefined-outer-name
-import copy
 import pytest
 
 from lib import base, browsers, factory, url
@@ -131,20 +130,15 @@ class TestDisabledObjects(base.Test):
     soft_assert.assert_expectations()
 
   @pytest.mark.smoke_tests
-  def test_user_cannot_update_predefined_field(self, control, selenium):
+  @pytest.mark.parametrize('obj', objects.SINGULAR_DISABLED_OBJS,
+                           indirect=True)
+  def test_user_cannot_update_predefined_field(self, obj, selenium,
+                                               soft_assert):
     """Tests that user cannot update predefined field."""
-    expected_conditions = {"predefined_field_updatable": False,
-                           "same_url_for_new_tab": True}
-    actual_conditions = copy.deepcopy(expected_conditions)
-
-    info_widget = webui_service.ControlsService(
-        selenium).open_info_page_of_obj(control)
-    info_widget.assertions.open_inline_edit()
-    actual_conditions[
-        "predefined_field_updatable"] = info_widget.assertions.input.exists
-    old_tab, new_tab = browsers.get_browser().windows()
-    actual_conditions["same_url_for_new_tab"] = (old_tab.url == new_tab.url)
-    assert expected_conditions == actual_conditions
+    webui_facade.soft_assert_cannot_update_predefined_field(soft_assert, obj)
+    soft_assert.expect(webui_facade.are_tabs_urls_equal(),
+                       "Urls should be equal.")
+    soft_assert.assert_expectations()
 
   @pytest.mark.smoke_tests
   @pytest.mark.parametrize("obj", objects.SINGULAR_DISABLED_OBJS,


### PR DESCRIPTION
# Issue description

Add test to check that user cannot update predefined field for risk

# Steps to test the changes

# Solution description

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
