### PR TITLE
GGRC-8032/GGRC-8031 "Create Task" button shouldn't be displayed on Active cycles tab on not active Workflows

### DIFF
--- a/src/ggrc-client/js/helpers.js
+++ b/src/ggrc-client/js/helpers.js
@@ -681,15 +681,13 @@ canStache.registerHelper('isScopeModel', function (instance, options) {
 });
 
 /*
-  Given an object, it determines if it's a workflow, and if it's a recurring
-  workflow or not.
+  Given an object, it determines if it's a recurring workflow or not.
 
   @param object - the object we want to check
   */
-canStache.registerHelper('if_recurring_workflow', function (object, options) {
+canStache.registerHelper('if_recurring_workflow', (object, options) => {
   object = isFunction(object) ? object() : object;
-  if (object.type === 'Workflow' &&
-      ['day', 'week', 'month'].includes(object.unit)) {
+  if (['day', 'week', 'month'].includes(object.unit)) {
     return options.fn(this);
   }
   return options.inverse(this);

--- a/src/ggrc-client/js/templates/cycle_task_group_object_tasks/tree_add_item.stache
+++ b/src/ggrc-client/js/templates/cycle_task_group_object_tasks/tree_add_item.stache
@@ -4,7 +4,32 @@
 }}
 
 {{#is_allowed 'create' 'CycleTaskGroupObjectTask' context=null}}
-  {{^if_recurring_workflow parent_instance}}
+  {{#is(parent_instance.type, "Workflow")}}
+    {{^if_recurring_workflow parent_instance}}
+      {{#is(parent_instance.status, "Active")}}
+        <a
+          class="btn btn-small btn-darkBlue"
+          href="javascript://"
+          rel="tooltip"
+          data-placement="left"
+          data-original-title="Create Cycle Task for object"
+          data-object-plural="cycle_task_group_object_tasks"
+          data-modal-class="modal-wide" href="javascript://"
+          data-object-singular="CycleTaskGroupObjectTask"
+          data-toggle="modal-ajax-form"
+          data-modal-reset="reset"
+          data-object-params='{
+            "modal_title": "Create Cycle Task",
+            "workflow": {
+              "id": {{parent_instance.id}},
+              "type": "Workflow"
+              }
+            }'>
+          Create Task
+        </a>
+      {{/is}}
+    {{/if_recurring_workflow}}
+  {{else}}
     <a
       class="btn btn-small btn-darkBlue"
       href="javascript://"
@@ -18,20 +43,14 @@
       data-modal-reset="reset"
       data-object-params='{
         "modal_title": "Create Cycle Task"
-        {{^if_instance_of parent_instance 'Person|Workflow'}}
+        {{^is(parent_instance.type, "Person")}}
           , "pre_mapped_objects": [{
             "type": "{{ parent_instance.type }}",
             "id": {{ parent_instance.id }}
           }]
-        {{/if_instance_of}}
-        {{#is(parent_instance.type, "Workflow")}}
-          , "workflow": {
-              "id": {{parent_instance.id}},
-              "type": "Workflow"
-              }
         {{/is}}
         }'>
       Create
     </a>
-  {{/if_recurring_workflow}}
+  {{/is}}
 {{/is_allowed}}


### PR DESCRIPTION
# Issue description

Rename "Create" button to "Create Task" and hide it for non active workflow on Active Cycles tab.

# Steps to test the changes

1. Open Active Cycles tab for any active Workflow.
**Expected result:** Button name should be "Create Task".
2. Open Active Cycles tab for any non active Workflow.
**Expected result:** Button "Create Task" shouldn't be displayed.
3. Check My Tasks page and Workflow Tasks tab for different objects type for which we can create a task.
**Expected result:** Button name should be "Create".

# Solution description

Rename "Create" button and add condition by which we show this button.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".