### PR TITLE
GGRC-5796: User has a possibility to restore Object review state

### DIFF
--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -26,6 +26,7 @@ from werkzeug.exceptions import InternalServerError
 
 from ggrc import db
 from ggrc import notifications
+from ggrc import utils
 from ggrc.services import signals
 from ggrc import models
 from ggrc.utils import errors
@@ -264,7 +265,8 @@ def handle_assignable_modified(obj, event=None):  # noqa: ignore=C901
     if val.history.has_changes():
       # the exact order of recipients in the string does not matter, hence the
       # need for an extra check
-      if attr_name == u"recipients" and not _recipients_changed(val.history):
+      if attr_name == u"recipients" and \
+         not utils.ordered_string_changed(val.history):
         continue
       is_changed = True
       break
@@ -358,30 +360,6 @@ def _align_by_ids(items, items2):
       first = next(items)
     if id_two == min_id:
       second = next(items2)
-
-
-def _recipients_changed(history):
-  """Check if the recipients attribute has been semantically modified.
-
-  The recipients attribute is a comma-separated string, and the exact order of
-  the items in it does not matter, i.e. it is not considered a change.
-
-  Args:
-    history (sqlalchemy.orm.attributes.History): recipients' value history
-
-  Returns:
-    True if there was a (semantic) change, False otherwise
-  """
-  old_val = history.deleted[0] if history.deleted else ""
-  new_val = history.added[0] if history.added else ""
-
-  if old_val is None:
-    old_val = ""
-
-  if new_val is None:
-    new_val = ""
-
-  return sorted(old_val.split(",")) != sorted(new_val.split(","))
 
 
 def handle_assignable_created(objects):

--- a/src/ggrc/utils/__init__.py
+++ b/src/ggrc/utils/__init__.py
@@ -468,3 +468,28 @@ def is_deferred_loaded(obj):
     if is_deferred:
       return False
   return True
+
+
+def ordered_string_changed(history, separator=','):
+  """Check if string attr has been semantically modified.
+
+  The attribute is a {separator}-separated string, and the exact order of
+  the items in it does not matter, i.e. it is not considered a change.
+
+  Args:
+    history (sqlalchemy.orm.attributes.History): attribute value history
+    separator: value to split the string
+
+  Returns:
+    True if there was a (semantic) change, False otherwise
+  """
+  old_val = history.deleted[0] if history.deleted else ""
+  new_val = history.added[0] if history.added else ""
+
+  if old_val is None:
+    old_val = ""
+
+  if new_val is None:
+    new_val = ""
+
+  return sorted(old_val.split(separator)) != sorted(new_val.split(separator))

--- a/test/integration/ggrc/models/test_program.py
+++ b/test/integration/ggrc/models/test_program.py
@@ -138,6 +138,28 @@ class TestProgramVersionHistory(TestCase):
         restored,
     )
 
+  def test_restore_review_status(self):
+    """Test empty restore from Version History
+    shouldn't restore review_status"""
+    factories.ReviewFactory(
+        status=all_models.Review.STATES.REVIEWED, reviewable=self.program
+    )
+
+    response = self.api.put(
+        self.program,
+        data={},
+    )
+
+    self.assert200(response)
+    self.program = self.refresh_object(
+        all_models.Program,
+        id_=self.program.id,
+    )
+    self.assertEqual(
+        self.program.review_status,
+        all_models.Review.STATES.REVIEWED
+    )
+
   def test_restore_cav_from_history(self):
     """Test CAV can be restored from Version History"""
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

*User has a possibility to restore Object review state.*

# Steps to test the changes

*Steps to reproduce:

1. Create a program as Admin user
2. Click Request Review button on the Program Info panel
3. Assign a reviewer and Save
4. Click Mark Reviewed button to Review Program
5. Open Version History tab
6. Click Review & Restore button
7. Click Restore Version
Open Attributes tab and look the Review state: is reviewed.*

# Solution description

Empty PUT for object might rewrite some fields while keeping the value semantically the same (e.g. order of recipients is changed but not the recipients itself).

Now such attributes will be checked without taking the order of values into the account.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
