### PR TITLE
GGRC-8033 Audit Captain is set as Verifier on autogenerated Assessment if no Auditors present

### DIFF
--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -277,7 +277,7 @@ def _get_people_ids_by_role(role_name, defaul_role_name, template_settings,
     return template_role
 
   default_people = role_name_people_id_map.get(defaul_role_name)
-  return role_name_people_id_map.get(template_role, default_people) or []
+  return role_name_people_id_map.get(template_role) or default_people
 
 
 def _generate_role_people_map(audit, snapshot, snapshot_rev_content):
@@ -313,13 +313,6 @@ def _generate_role_people_map(audit, snapshot, snapshot_rev_content):
       person.id for person, acl in audit.access_control_list
       if acl.ac_role_id == auditor_role_id
   ])
-
-  if not role_name_person_id_map["Auditors"]:
-    # If assessment is being generated with a snapshot and there is no auditors
-    # on it's audit, audit captains should be taken as auditors.
-    role_name_person_id_map["Auditors"].extend(
-        role_name_person_id_map["Audit Lead"],
-    )
 
   return role_name_person_id_map
 

--- a/test/integration/ggrc/models/test_assessment_generation.py
+++ b/test/integration/ggrc/models/test_assessment_generation.py
@@ -600,10 +600,12 @@ class TestAssessmentGeneration(TestAssessmentBase):
       template = factories.AssessmentTemplateFactory(
           default_people={"assignees": "Auditors", "verifiers": "Auditors"}
       )
+
     response = self.assessment_post(template)
+
     self.assert_assignees("Creators", response, "user@example.com")
     audit = all_models.Audit.query.get(self.audit_id)
     acp = audit.acr_name_acl_map["Audit Captains"].access_control_people[0]
     # If Auditor is not set, Audit Captain should be used as Assignee
     self.assert_assignees("Assignees", response, acp.person.email)
-    self.assert_assignees("Verifiers", response, acp.person.email)
+    self.assert_assignees("Verifiers", response)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Audit Captain is set as Verifier on an Assessment being generated from an Assessment Template and a Snapshot if no Auditors present, but it should not.

# Steps to test the changes

1. Create an Audit and map some snapshots to it;
2. Leave _"Auditors"_ field empty for created Audit;
2. Create an Assessment Template with default verifiers to be taken from _"Auditors"_;
3. Click _"Autogenerate"_ button on _"Audit Summary"_ tab;
4. Select Template and Snapshot and generate Assessment;
5. Open generated Assessment;

**Expected result: Assessment's _Verifiers_ field should be empty.**

# Solution description

### Source code changes

Previously the `_generate_role_people_map` method explicitly extended list of _Auditors_ with _Audit Captains_ it had if _Auditors_ where empty. This was made to populate _Assignees_ of generated Assessment with _Audit Captains_ if no _Assignees_ where present at creation time (and _Assignees_ where configured in template to be populated from _Auditors_). In this PR this part of the code is removed.

It is a correct solution since `_get_people_ids_by_role` method with correct parameters provided could return _Audit Captains_ as Assessment _Assignees_. Only one small fix is required there:
```py
return role_name_people_id_map.get(template_role, default_people) or []
```
should be replaced with
```py
return role_name_people_id_map.get(template_role) or default_people
```
which allows to get list of default people if there are no people with role specified in template settings. This change is also applied in scope of this PR.

### Tests changes

Existing tests fully cover the functionality since no new tests where written. Only one of the existing tests (`def test_generate_empty_auditor(self)`) was adjusted to the changes made in this PR.


# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
