### PR TITLE
GGRC-8118 Notifications for Task Assignee doesn't send

### DIFF
--- a/src/ggrc/notifications/common.py
+++ b/src/ggrc/notifications/common.py
@@ -266,7 +266,7 @@ def get_daily_notifications():
   notifications_data = {}
   for notif_list, notif_data in generate_daily_notifications():
     notifications.extend(notif_list.all())
-    notifications_data.update(notif_data)
+    notifications_data = merge_dict(notifications_data, notif_data)
 
   return notifications, notifications_data
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

We do not see some notification in daily digest email

# Steps to test the changes

We need to use DB with notifications count more than 5000 (ex.: qa dump).
1. Create any Workflow
2. Create task with any user assigned
3. Activate Workflow
4. Run _notifications/show_daily_digest
5. Find notifications that should be sent for Assignee

Actual: Notification that task was assigned is not presented in the daily digest

Expected: Notification about assigned task is presented

# Solution description

In for loop for generate_daily_notifications() iterator we are loosing old notifications when merging two dicts. Function for deep merging should be used.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
