### PR TITLE
GGRC-7451 Program restores unreview state

### DIFF
--- a/src/ggrc/builder/json.py
+++ b/src/ggrc/builder/json.py
@@ -161,7 +161,18 @@ class UpdateAttrHandler(object):
       cls._do_update_collection(obj, value, attr_name)
     else:
       try:
-        setattr(obj, attr_name, value)
+        if not(
+           attr_name in getattr(obj.__class__, 'SORT_DEPEND_ATTRS', set()) and
+           value == getattr(obj, attr_name)):
+          # Note: This if-statement was added because of method `setattr`
+          # malfunctioning here. Overrided `setattr` method in sqlalchemy
+          # sets unexpecting value to Text Column.
+          # Issue was defined on a Program.recipients column. Ex:
+          # > value = 'Program Editors,Primary Contacts,Secondary Contacts'
+          # > setattr(program_obj, 'recipients', value)
+          # > print(obj.value)
+          # 'Secondary Contacts,Program Editors,Primary Contacts'
+          setattr(obj, attr_name, value)
       except AttributeError as error:
         logger.error('Unable to set attribute %s: %s', attr_name, error)
         raise

--- a/src/ggrc/models/program.py
+++ b/src/ggrc/models/program.py
@@ -76,6 +76,7 @@ class Program(mega.Mega,
       "documents_file": None,
       "owners": None
   }
+  SORT_DEPEND_ATTRS = {'recipients'}
 
   @classmethod
   def eager_query(cls, **kwargs):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Restoring Review Program will change status to 'Unreviewed'. (Noticed that recipients field changed too)

# Steps to test the changes

1. Log in ggrc app
2. Create a program and mark Reviewed
3. Go to Version History tab
4. Review and Restore version

# Solution description

- Added if-statement in builder.json update fields which chages fields using setattr method only if request value != current database value
- Note: This if-statement was added because of method `setattr`
malfunctioning here. Overrided __setattr method in sqlalchemy
sets unexpecting value to Text Column.
Issue was defined on a Program.recipients column. Ex:
```
> value = 'Program Editors,Primary Contacts,Secondary Contacts'
> setattr(program_obj, 'recipients', value)
> print(obj.value)
'Secondary Contacts,Program Editors,Primary Contacts'
```

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
