### PR TITLE
GGRC-7646 Objects are not in alph order in Add tab menu

### DIFF
--- a/src/ggrc-client/js/components/inner-nav/inner-nav-vm.js
+++ b/src/ggrc-client/js/components/inner-nav/inner-nav-vm.js
@@ -51,7 +51,6 @@ export default canMap.extend({
 
     // add default sorting for hidden widgets by title
     let hiddenWidgets = new canList();
-    hiddenWidgets.attr('comparator', 'title');
     this.attr('hiddenWidgets', hiddenWidgets);
 
     // set up routing
@@ -135,11 +134,20 @@ export default canMap.extend({
      * @param {canMap} widget widget
      */
   addToHiddenWidgets(widget) {
-    let hiddenWidgets = this.attr('hiddenWidgets');
-    let hiddenWidget =
-        loFind(hiddenWidgets, (hidden) => hidden.id === widget.id);
+    const hiddenWidgets = this.attr('hiddenWidgets');
+    const hiddenWidget =
+      loFind(hiddenWidgets, (hidden) => hidden.id === widget.id);
 
-    if (!hiddenWidget) {
+    if (hiddenWidget) {
+      return;
+    }
+
+    const indexOfNewHiddenWidget =
+      loFindIndex(hiddenWidgets, (hidden) => hidden.title > widget.title);
+
+    if (indexOfNewHiddenWidget !== -1) {
+      hiddenWidgets.splice(indexOfNewHiddenWidget, 0, widget);
+    } else {
       hiddenWidgets.push(widget);
     }
   },

--- a/src/ggrc-client/js/components/inner-nav/tests/inner-nav-vm_spec.js
+++ b/src/ggrc-client/js/components/inner-nav/tests/inner-nav-vm_spec.js
@@ -479,6 +479,44 @@ describe('inner-nav view model', () => {
       expect(viewModel.attr('hiddenWidgets').length).toBe(1);
       expect(viewModel.attr('hiddenWidgets')[0]).toBe(widget);
     });
+
+    describe('should add widget to list according to alph order', () => {
+      it('if need add to the beginning of the array', () => {
+        let widget = new canMap({id: '1', title: 'A'});
+        const hiddenWidgets = [new canMap({id: '2', title: 'B'})];
+        viewModel.attr('hiddenWidgets', hiddenWidgets);
+
+        viewModel.addToHiddenWidgets(widget);
+
+        expect(viewModel.attr('hiddenWidgets').length).toBe(2);
+        expect(viewModel.attr('hiddenWidgets')[0]).toBe(widget);
+      });
+
+      it('if need add to the middle of the array', () => {
+        let widget = new canMap({id: '2', title: 'B'});
+        const hiddenWidgets = [
+          new canMap({id: '1', title: 'A'}),
+          new canMap({id: '3', title: 'C'}),
+        ];
+        viewModel.attr('hiddenWidgets', hiddenWidgets);
+
+        viewModel.addToHiddenWidgets(widget);
+
+        expect(viewModel.attr('hiddenWidgets').length).toBe(3);
+        expect(viewModel.attr('hiddenWidgets')[1]).toBe(widget);
+      });
+
+      it('if need add to the endning of the array', () => {
+        let widget = new canMap({id: '2', title: 'B'});
+        const hiddenWidgets = [new canMap({id: '1', title: 'A'})];
+        viewModel.attr('hiddenWidgets', hiddenWidgets);
+
+        viewModel.addToHiddenWidgets(widget);
+
+        expect(viewModel.attr('hiddenWidgets').length).toBe(2);
+        expect(viewModel.attr('hiddenWidgets')[1]).toBe(widget);
+      });
+    });
   });
 
   describe('removeFromHiddenWidgets(widget) method', () => {

--- a/src/ggrc-client/js/plugins/tests/utils/mega-object-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/mega-object-utils_spec.js
@@ -56,7 +56,7 @@ describe('getMegaObjectConfig method', () => {
       name: 'Program',
       originalModelName: 'Program',
       widgetId: 'Program_parent',
-      widgetName: 'Parent Programs',
+      widgetName: 'Programs (Parent)',
       relation: 'parent',
       isMegaObject: true,
     });

--- a/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/widgets-utils_spec.js
@@ -494,7 +494,7 @@ describe('GGRC Utils Widgets', function () {
       expect(result).toEqual({
         name: 'Program',
         widgetId: 'Program_parent',
-        widgetName: 'Parent Programs',
+        widgetName: 'Programs (Parent)',
         countsName: 'Program_parent',
         isObjectVersion: undefined,
         relation: 'parent',

--- a/src/ggrc-client/js/plugins/utils/mega-object-utils.js
+++ b/src/ggrc-client/js/plugins/utils/mega-object-utils.js
@@ -53,7 +53,7 @@ function getMegaObjectConfig(modelName) {
     name: originalModelName,
     originalModelName,
     widgetId: modelName,
-    widgetName: `${loCapitalize(relation)} ${modelTitle}`,
+    widgetName: `${modelTitle} (${loCapitalize(relation)})`,
     relation: relation,
     isMegaObject: true,
   };


### PR DESCRIPTION
# Issue description
Objects are not in alph order in Add tab menu.

> To initialize the list of objects "hiddenWidgets" in the "Add tab" menu, a request is made to the server. In our case, all objects are sent in one request[1], but another request[2] is sent, for a different purpose, in which there is a "Document" object. When working with a remote server, the first request is sent earlier than the second, but the response to the second comes earlier than the response to the first. Since when a new object is added to "hiddenWidgets", "push" is used, the objects that came after "Documen" will be in the list after it. But in such a scenario, the objects should be in the order [Documents, Access Group, ..., Workflow Tasks, ...], that is, first “Document”, and then in the same order as in the server response. This does not happen, the objects are in the reverse order: [Document, ..., Workflow Tasks, ..., Access Group]. When receiving a response from the server, for each object, a handler is called in the component "inner-nav" "{counts} change" (objects === "counts" in this component), where the chain of methods is called: setWidgetCount => updateHiddenWidgets => addToHiddenWidgets => hiddenWidgets.push (widget). The "updateHiddenWidgets" method has the line "this.attr ('showAllTabs')", as a result of which the event handler "{counts} change" is called. This is the second part of the bug. 

> Example:  
 As a result of normal operation, the call stack should look like "{counts} change" => setWidgetCount => updateHiddenWidgets => addToHiddenWidgets => hiddenWidgets.push (widget) =>  "{counts} change" => setWidgetCount => updateHiddenWidgets => addToHiddenWidgets => hiddenWidgets.push (widget) => ... And in our case it looks like "{counts} change" => setWidgetCount => updateHiddenWidgets => "{counts} change" => setWidgetCount => updateHiddenWidgets => .... => "{counts} change "=> setWidgetCount => updateHiddenWidgets => addToHiddenWidgets => hiddenWidgets.push (widget) => ... => addToHiddenWidgets => hiddenWidgets.push (widget)=>addToHiddenWidgets => hiddenWidgets.push (widget). That is, the work "this.attr ('showAllTabs')" calls the handler "{counts} change" for the next object in turn, and so the chain "{counts} change" => setWidgetCount => updateHiddenWidgets will be called recursively until it ends objects, after which the second parts of the chains begin to execute.

> Notes:  
-The bug is reproduced only remotely due to the speed of query execution. The response to the first request [1] occurs faster than the response to the second [2] on the local instance. On the remote instance, everything happens the other way around.  
-It can be  reproduced locally if you wrap the function "initCounts" in the file "src / ggrc-client / js / entrypoints / dashboard / bootstrap.js" in setTimeout (initCounts, 10000).


# Steps to test the changes 
1. Create a program.
2. Click on Add tab button.
**Actual Result**: Objects are not in alph order in Add tab menu.
**Expected Result**: Objects are should be in alph order in Add tab menu.

# Solution description 
Get rid of the dependence of the obtained order in "inner-nav". Add insertion objects in alphabetical order. Rename "Parent Programs" and "Child Programs" to "Programs Parent" and "Programs Child"(it changes need to keep Child Programs and Parent Programs together).

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [x] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".