### PR TITLE
GGRC-7766 Unify font style in notifications

### DIFF
--- a/src/ggrc/templates/notifications/email_digest_content.html
+++ b/src/ggrc/templates/notifications/email_digest_content.html
@@ -242,7 +242,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 {% if digest.get('assessment_updated') %}
                   <div style="padding-bottom: 15px;">
                   {% for assessment_id, assessment_data in digest['assessment_updated'].iteritems() %}
-                    <p {{ style.assessment_notification_title() }}>Assessment "{{ assessment_data['title'] }}" has been updated</p>
+                    <h2 {{ style.sub_title() }}>Assessment "{{ assessment_data['title'] }}" has been updated</h2>
                     <table {{ style.table_full() }}>
                       <thead>
                         <tr>


### PR DESCRIPTION
# Issue description

Font sizes in notifications was different because of wrong html tag in jinja-template

# Steps to test the changes

1. Open any Audit
2. Create Assessment
3. Make any changes in Assessment e.g change Description
4. Run Daily digest (_notifications/show_daily_digest)
5. Review the font in the notification - font size for 'New assessments were created' and 'Assessment ... has been updated' should be equal

# Solution description

Change tag in jinja-template

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

