### PR TITLE
GGRC-8090 Object Snapshot 3bb's dropdown menu is empty for Global Creator

### DIFF
--- a/src/ggrc-client/js/components/three-dots-menu/tests/three-dots-menu_spec.js
+++ b/src/ggrc-client/js/components/three-dots-menu/tests/three-dots-menu_spec.js
@@ -16,21 +16,24 @@ describe('three-dots-menu component', function () {
   describe('manageEmptyList() method', function () {
     let menuNode;
 
-    beforeEach(function () {
-      menuNode = {
-        children: [],
-      };
-    });
-
-    it('sets disabled field to true if the menu node does not have childrens',
+    it('sets disabled field to true if the menu node does not contain <li>',
       function () {
+        menuNode = $(`
+          <ul role="menu">
+            <empty-component></empty-component>
+          </ul>`);
         vm.manageEmptyList(menuNode);
         expect(vm.attr('disabled')).toBe(true);
       });
 
-    it('sets disabled field to false if the menu node has childrens',
+    it('sets disabled field to false if the menu node contains <li>',
       function () {
-        menuNode.children = [1, 2, 3];
+        menuNode = $(`
+          <ul role="menu">
+            <not-empty-component>
+              <li>123</li>
+            </not-empty-component>
+          </ul>`);
         vm.manageEmptyList(menuNode);
         expect(vm.attr('disabled')).toBe(false);
       });

--- a/src/ggrc-client/js/components/three-dots-menu/three-dots-menu.js
+++ b/src/ggrc-client/js/components/three-dots-menu/three-dots-menu.js
@@ -12,7 +12,8 @@ const viewModel = canMap.extend({
   disabled: true,
   observer: null,
   manageEmptyList(menuNode) {
-    const isEmpty = menuNode.children.length === 0;
+    // check to avoid rendering empty components
+    const isEmpty = $(menuNode).find('li').length === 0;
     this.attr('disabled', isEmpty);
   },
   mutationCallback(mutationsList) {


### PR DESCRIPTION
# Issue description

Object Snapshot 3bb's dropdown menu is empty for Global Creator.

# Steps to test the changes

**Note!** The issue is reproducible for all object snapshots only for Global Creator role.

1. Open GGRC as an Admin
2. Create an Audit with any object snapshots, e.g. Objective (example)
3. Create an Assessment of the Objective type (example) with mapped Objectives
4. Assign Global Creator as an Assignee in the Asmnt
5. Log in as a Global Creator and open the Audit
6. Click on Objective snapshots and open any of them
7. Click on 3bb's dropdown menu
**Actual result:** 3bb's dropdown menu is empty for Global Creator on Objective snapshots
**Expected result:** 3bb's dropdown menu should be disabled for Global Creator as they don't have permission to view the original object

# Solution description

Update check to disable 3bb's dropdown menu. Check only for `<li>` elements. Exclude empty components from consideration. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
