### PR TITLE
GGRC-8199 Assessments appear at "My assessments" not right away

### DIFF
--- a/src/ggrc/models/hooks/acl/propagation.py
+++ b/src/ggrc/models/hooks/acl/propagation.py
@@ -270,6 +270,9 @@ def _propagate(parent_acl_ids, user_id):
   for _ in range(PROPAGATION_DEPTH_LIMIT):
 
     child_ids = _handle_acl_step(parent_acl_ids, user_id)
+    user_ids = acl_utils.get_user_ids(
+        all_models.AccessControlList.id.in_(child_ids))
+    getattr(flask.g, "user_ids", set()).update(user_ids)
 
     count_query = child_ids.alias("counts").count()
     child_id_count = db.session.execute(count_query).scalar()
@@ -300,7 +303,7 @@ def _propagate_relationships(relationship_ids, new_acl_ids, user_id):
   user_ids = acl_utils.get_user_ids(
       all_models.AccessControlList.id.in_(child_ids)
   )
-  getattr(flask.g, "user_ids").update(user_ids)
+  getattr(flask.g, "user_ids", set()).update(user_ids)
 
 
 def _delete_orphan_acl_entries(deleted_objects):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

After generating _Assessments_ from _Assessment Template_ and _Snapshots_ they does not appear at _"My Assessments"_ tab for _Assignee_ right away and even after page reload, but they should.

# Steps to test the changes

1. Login as User 1 (Admin) in one tab
2. Login as User 2 (Global Creator) in other tab
3. User 1 creates Program and maps 3+ Snapshots to it
4. User 1 creates Audit for Program and Assessment Template (User 2 is a default assignee) for Audit
5. User 1 generates Assessments based on Assessment Template and Snapshots
6. User 1 checks that all assessments were generated
7. User 2 accesses _"My Assessments"_ tab

Results before: Assessments does not shown at the _"My assessments"_ tab right away though they appear in a couple of minutes.

Expected result: All Assessments should appear right away.


# Solution description

### Root cause

When User 2 logs in, his permissions are being stored in _memcache_. So any new objects that are generated for User 2 will not appear at UI until his cached permissions expire. That is why the new Assessments for User 2 does not appear right after they are generated.

### Solution

Permission cache should be recalculated or cleared during ACL propagation. Recalculation might negatively affect the performance of objects creation. So this leaves us with the second option - permissions cache should be cleared for users that are affected by ACL propagation. 

Currently there already is a support for permissions cache cleaning - it is being cleaned for users whose IDs are added into `flask.g.user_ids` during ACL propagation.

Currently only IDs of users related to ACLs returned by `_handle_relationship_step()` are added there (see function `_propagate_relationships()`)

`_propagate_relationships()` also invokes `_propagate()` which in turn calls `_handle_acl_step()`. So it would be right to clean permissions cache for users that are related to ACLs returned by `_handle_acl_step()`.

This PR contains changes that add IDs of users affected by `_handle_acl_step()` logic into `flask.g.user_ids` for later permission cache cleaning.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
