### PR TITLE
GGRC-8113: [MLV] Add support for Assessment Template Search API

### DIFF
--- a/src/ggrc/models/assessment.py
+++ b/src/ggrc/models/assessment.py
@@ -231,7 +231,7 @@ class Assessment(
   _aliases = {
       "owners": None,
       "verification_workflow": {
-          "display_name": "Verification Workflow",
+          "display_name": "Assessment Workflow",
           "description": (
               "Allowed values are:\n"
               "Standard flow\n"

--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -224,7 +224,7 @@ class AssessmentTemplate(
 
   _aliases = {
       "verification_workflow": {
-          "display_name": "Verification Workflow",
+          "display_name": "Assessment Workflow",
           "mandatory": False,
           "description": (
               "Allowed values are:\n"

--- a/test/integration/ggrc/converters/test_import_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_import_assessment_templates.py
@@ -216,7 +216,7 @@ class TestAssessmentTemplatesImport(TestCase):
 
 @ddt.ddt
 class TestMultiVerificationWorkflow(TestCase):
-  """Test Assessment Template Multi Verification Workflow"""
+  """Test Assessment Template Multi Assessment Workflow"""
 
   def setUp(self):
     """Set up for Assessment Template test cases."""
@@ -234,7 +234,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", VerificationWorkflow.MLV),
+            ("Assessment Workflow", VerificationWorkflow.MLV),
             ("Verification Levels", 2),
         ])
     ]
@@ -253,7 +253,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", VerificationWorkflow.MLV),
+            ("Assessment Workflow", VerificationWorkflow.MLV),
             ("Verification Levels", ""),
         ])
     ]
@@ -287,7 +287,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", workflow_type),
+            ("Assessment Workflow", workflow_type),
             ("Verification Levels", "ABC"),
         ])
     ]
@@ -321,7 +321,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", VerificationWorkflow.MLV),
+            ("Assessment Workflow", VerificationWorkflow.MLV),
             ("Verification Levels", levels_value),
         ])
     ]
@@ -344,7 +344,7 @@ class TestMultiVerificationWorkflow(TestCase):
     self._check_csv_response(response, expected_messages)
 
   def test_empty_workflow_type(self):
-    """Test empty Verification Workflow value"""
+    """Test empty Assessment Workflow value"""
     audit = factories.AuditFactory()
     assessment_data_template = [
         collections.OrderedDict([
@@ -354,7 +354,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", ""),
+            ("Assessment Workflow", ""),
             ("Verification Levels", "2"),
         ])
     ]
@@ -368,7 +368,7 @@ class TestMultiVerificationWorkflow(TestCase):
             "row_warnings": {
                 errors.MISSING_VERIFICATION_WORKFLOW_VALUE.format(
                     line=3,
-                    column_name="Verification Workflow"
+                    column_name="Assessment Workflow"
                 )
             },
             "row_errors": {
@@ -391,7 +391,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", ""),
+            ("Assessment Workflow", ""),
             ("Verification Levels", ""),
         ])
     ]
@@ -405,7 +405,7 @@ class TestMultiVerificationWorkflow(TestCase):
             "row_warnings": {
                 errors.MISSING_VERIFICATION_WORKFLOW_VALUE.format(
                     line=3,
-                    column_name="Verification Workflow"
+                    column_name="Assessment Workflow"
                 )
             },
         }
@@ -413,7 +413,7 @@ class TestMultiVerificationWorkflow(TestCase):
     self._check_csv_response(response, expected_messages)
 
   def test_wrong_workflow_type(self):
-    """Test wrong Verification Workflow value"""
+    """Test wrong Assessment Workflow value"""
     audit = factories.AuditFactory()
     assessment_data_template = [
         collections.OrderedDict([
@@ -423,7 +423,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", "Wrong Flow"),
+            ("Assessment Workflow", "Wrong Flow"),
             ("Verification Levels", "2"),
         ])
     ]
@@ -438,7 +438,7 @@ class TestMultiVerificationWorkflow(TestCase):
             "row_errors": {
                 errors.WRONG_VALUE_ERROR.format(
                     line=3,
-                    column_name="Verification Workflow"
+                    column_name="Assessment Workflow"
                 )
             },
         }
@@ -457,7 +457,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Assignees*", "Auditors"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", workflow_type),
+            ("Assessment Workflow", workflow_type),
             ("Verification Levels", "2"),
         ])
     ]
@@ -490,7 +490,7 @@ class TestMultiVerificationWorkflow(TestCase):
             ("Default Verifiers", "user@example.com"),
             ("Default Assessment Type", "Control"),
             ("Title", "Template 1"),
-            ("Verification Workflow", VerificationWorkflow.MLV),
+            ("Assessment Workflow", VerificationWorkflow.MLV),
             ("Verification Levels", "2"),
         ])
     ]

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -440,7 +440,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Priority",
         "Issue Type",
         "Ticket Tracker Integration",
-        "Verification Workflow",
+        "Assessment Workflow",
         "Verification Levels",
     }
     expected_fields = {
@@ -507,7 +507,7 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Issue Type",
         "Ticket Title",
         "Ticket Tracker Integration",
-        "Verification Workflow",
+        "Assessment Workflow",
         "Verification Levels",
     }
     expected_fields = {


### PR DESCRIPTION
# Dependencies

This PR merge requirements:
- [x] merge #10325
- [x] remove **unitest.skip decorator on review_levels_count** test

# Issue description

Add support for Assessment Template Search API

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
