### PR TITLE
BUMP UP 2.24.0-Pumpkin version

### DIFF
--- a/src/ggrc/settings/default.py
+++ b/src/ggrc/settings/default.py
@@ -59,7 +59,7 @@ except ImportError:
 # for more info) and if the version name were to exceed 30 characters, all
 # deployments would go to the same GAE app version. Please take that into
 # consideration when modifying this string.
-VERSION = "2.23.0-Pumpkin" + BUILD_NUMBER
+VERSION = "2.24.0-Pumpkin" + BUILD_NUMBER
 
 # Migration owner
 MIGRATOR = os.environ.get(


### PR DESCRIPTION

# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] https://github.com/google/ggrc-core/pull/10346

