### PR TITLE
GGRC-8189 Hint for Recipients and Send by Default attribute

### DIFF
--- a/test/integration/ggrc/converters/test_export_csv.py
+++ b/test/integration/ggrc/converters/test_export_csv.py
@@ -491,6 +491,24 @@ class TestExportEmptyTemplate(TestCase):
     self.assertIn("Allowed values are:\n{}".format('\n'.join(
         constants.AVAILABLE_PRIORITIES)), response.data)
 
+  @ddt.data("AccessGroup", "AccountBalance", "DataAsset", "Facility",
+            "KeyReport", "Market", "Metric", "OrgGroup", "Process",
+            "Product", "ProductGroup", "Project", "System",
+            "TechnologyEnvironment", "Vendor", "Threat", "Objective",
+            "Issue", "Contract", "Policy", "Regulation", "Requirement",
+            "Standard", "Program", "Assessment")
+  def test_recipients_tips(self, model):
+    """Tests if {} has hint for Recipients and Send by default"""
+    data = {
+        "export_to": "csv",
+        "objects": [{"object_name": model, "fields": ["recipients",
+                                                      "send_by_default"]}]
+    }
+    response = self.client.post("/_service/export_csv",
+                                data=dumps(data), headers=self.headers)
+
+    self.assertIn("Automatically provided values", response.data)
+
 
 @ddt.ddt
 class TestExportSingleObject(TestCase):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

For attributes 

Recipients 
Send by Default
the following hint should be added:

'Automatically provided values'

# Steps to test the changes

1.Log into GGRC app(login as Admin).
2. Goto Export page.
3. Select the Object Type and export the csv file.
4. Open the excel.
5. check for the recipients and send by default attribute you can find:
'Automatically provided values'

# Solution description

Modified the _aliases object where ever required in files. Verified using the test case for the above scenario as the solution was provided in PR #10215

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [ ] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
