### PR TITLE
GGRC-8222 Check that newly created disabled obj cannot be mapped via um

### DIFF
--- a/test/selenium/src/lib/page/modal/unified_mapper.py
+++ b/test/selenium/src/lib/page/modal/unified_mapper.py
@@ -37,8 +37,6 @@ class CommonUnifiedMapperModal(BaseUnifiedMapperModal):
     self.tree_view = base.UnifiedMapperTreeView(
         self._driver, obj_name=obj_name)
     self._add_attr_btn = None
-    self.search_result_toggle = base.Toggle(
-        self.modal_elem, self._locators.RESULT_TOGGLE_CSS)
     self.open_in_new_frontend_btn = self._browser.link(
         class_name=["btn", "btn-small", "btn-white"],
         text="Open in new frontend")

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -96,23 +96,24 @@ class TestControlsPage(base.Test):
     assert not map_modal.is_present, (
         "There should be no modal windows in new browser tab.")
 
-  def test_cannot_map_control_via_um_create_new_obj(self, control,
-                                                    dashboard_controls_tab,
-                                                    soft_assert, selenium):
-    """Tests that user cannot map control to scope objects/directives
+  @pytest.mark.parametrize('obj', objects.SINGULAR_DISABLED_OBJS,
+                           indirect=True)
+  def test_cannot_map_created_disabled_obj_via_um(self, obj,
+                                                  soft_assert, selenium):
+    """Tests that user cannot map disabled object to scope objects/directives
     via unified mapper (create a new scope/directive object)."""
-    dashboard_controls_tab.get_control(control).select_map_to_this_object()
+    obj_name = objects.get_plural(obj.type)
+    service = factory.get_cls_webui_service(obj_name)()
+    (service.open_obj_dashboard_tab().tree_view
+     .open_tree_actions_dropdown_by_title(title=obj.title).select_map())
     map_modal = webui_facade.perform_disabled_mapping(
         entities_factory.RegulationsFactory().create(), create_new_obj=True)
-    new_tab = browsers.get_browser().windows()[1]
+    _, new_tab = browsers.get_browser().windows()
     soft_assert.expect(new_tab.url == url.Urls().dashboard_info_tab,
                        "Dashboard info page should be opened in new tab.")
-    soft_assert.expect(
-        not(objects.get_normal_form(objects.REGULATIONS)
-            in webui_service.ControlsService(selenium).open_info_page_of_obj(
-            control).top_tabs.tab_names),
-        "There should be no scope/directive object mapped to Control.")
-    new_tab.use()
-    soft_assert.expect(not map_modal.is_present,
-                       "There should be no modal windows in new browser tab.")
+    tab_names = service.open_info_page_of_obj(obj).top_tabs.tab_names
+    soft_assert.expect(not any([name.startswith(regulation.obj_type())
+                                for name in tab_names]),
+                       "There should be no regulation mapped to Control.")
+    webui_facade.soft_assert_no_modals_present(map_modal, soft_assert)
     soft_assert.assert_expectations()

--- a/test/selenium/src/tests/test_unified_mapper.py
+++ b/test/selenium/src/tests/test_unified_mapper.py
@@ -112,8 +112,9 @@ class TestControlsPage(base.Test):
     soft_assert.expect(new_tab.url == url.Urls().dashboard_info_tab,
                        "Dashboard info page should be opened in new tab.")
     tab_names = service.open_info_page_of_obj(obj).top_tabs.tab_names
-    soft_assert.expect(not any([name.startswith(regulation.obj_type())
-                                for name in tab_names]),
-                       "There should be no regulation mapped to Control.")
+    soft_assert.expect(not any(
+        [name.startswith(objects.get_normal_form(objects.REGULATIONS))
+         for name in tab_names]),
+        "There should be no regulation mapped to {}.".format(obj.type))
     webui_facade.soft_assert_no_modals_present(map_modal, soft_assert)
     soft_assert.assert_expectations()


### PR DESCRIPTION
# Issue description

Check that user cannot map Risk to Scope Objects/ Directives via Unified Mapper (create a new scope/directive object)

# Steps to test the changes

# Solution description

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).


# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
