### PR TITLE
GGRC-8229 Clean up / refactor FE-related code

### DIFF
--- a/src/ggrc-client/js/components/assessment/assessment-local-ca.js
+++ b/src/ggrc-client/js/components/assessment/assessment-local-ca.js
@@ -15,7 +15,6 @@ import {
 import {VALIDATION_ERROR, RELATED_ITEMS_LOADED} from '../../events/event-types';
 import tracker from '../../tracker';
 import {isAllowedFor} from '../../permission';
-import isFunction from 'can-util/js/is-function/is-function';
 import {getPageInstance} from '../../plugins/utils/current-page-utils';
 import {getPlainText} from '../../plugins/ggrc-utils';
 
@@ -250,19 +249,6 @@ export default canComponent.extend({
       $container.animate({
         scrollTop: $(field).offset().top - $body.offset().top,
       }, 500);
-    },
-  },
-  helpers: {
-    isInvalidField: function (show, valid, highlightInvalidFields, options) {
-      show = isFunction(show) ? show() : show;
-      valid = isFunction(valid) ? valid() : valid;
-      highlightInvalidFields = isFunction(highlightInvalidFields) ?
-        highlightInvalidFields() : highlightInvalidFields;
-
-      if (highlightInvalidFields && show && !valid) {
-        return options.fn(options.context);
-      }
-      return options.inverse(options.context);
     },
   },
 });

--- a/src/ggrc-client/js/components/assessment/assessment-local-ca.js
+++ b/src/ggrc-client/js/components/assessment/assessment-local-ca.js
@@ -110,7 +110,7 @@ export default canComponent.extend({
       let value = field.value;
       let isMandatory = field.validation.mandatory;
       let errorsMap = field.errorsMap || {
-        evidence: false,
+        attachment: false,
         comment: false,
         url: false,
       };
@@ -141,7 +141,7 @@ export default canComponent.extend({
             requiresUrl),
         },
         errorsMap: {
-          evidence: hasMissingEvidence,
+          attachment: hasMissingEvidence,
           comment: hasMissingComment,
           url: hasMissingUrl,
         },

--- a/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
+++ b/src/ggrc-client/js/components/assessment/info-pane/assessment-info-pane.stache
@@ -211,7 +211,8 @@
                             isLocalCa:from="true"
                             fields:from="fields"
                             editMode:from="canEdit"
-                            on:valueChanged="attributeChanged(scope.event)">
+                            on:valueChanged="attributeChanged(scope.event)"
+                            on:addRequiredInfo="showRequiredInfoModal(scope.event)">
                       </custom-attributes>
                     </assessment-local-ca>
                     <!-- Modal Window to fix validation issues of CA fields -->

--- a/src/ggrc-client/js/components/assessment/tests/assessment-local-ca_spec.js
+++ b/src/ggrc-client/js/components/assessment/tests/assessment-local-ca_spec.js
@@ -241,7 +241,7 @@ describe('assessment-local-ca component', () => {
         },
         errorsMap: {
           comment: false,
-          evidence: false,
+          attachment: false,
           url: false,
         },
       });
@@ -262,7 +262,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -281,7 +281,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -303,7 +303,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: true,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -324,7 +324,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -334,7 +334,7 @@ describe('assessment-local-ca component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'evidence required');
 
-      dropdownField.attr('errorsMap.evidence', true);
+      dropdownField.attr('errorsMap.attachment', true);
       performDropdownValidation(dropdownField);
 
       expect(viewModel.attr('evidenceAmount')).toBe(0);
@@ -347,7 +347,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: true,
+        attachment: true,
         url: false,
       });
     });
@@ -369,7 +369,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -380,7 +380,7 @@ describe('assessment-local-ca component', () => {
       dropdownField.attr('value', 'com+ev required');
 
       dropdownField.attr('errorsMap.comment', true);
-      dropdownField.attr('errorsMap.evidence', true);
+      dropdownField.attr('errorsMap.attachment', true);
 
       performDropdownValidation(dropdownField);
 
@@ -393,7 +393,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: true,
-        evidence: true,
+        attachment: true,
         url: false,
       });
     });
@@ -403,7 +403,7 @@ describe('assessment-local-ca component', () => {
       viewModel.attr('fields', [dropdownField]);
       dropdownField.attr('value', 'com+ev required');
 
-      dropdownField.attr('errorsMap.evidence', true);
+      dropdownField.attr('errorsMap.attachment', true);
       performDropdownValidation(dropdownField);
 
       expect(dropdownField.attr().validation).toEqual({
@@ -415,7 +415,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: true,
+        attachment: true,
         url: false,
       });
     });
@@ -439,7 +439,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: true,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -461,7 +461,7 @@ describe('assessment-local-ca component', () => {
       });
       expect(dropdownField.attr().errorsMap).toEqual({
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       });
     });
@@ -488,14 +488,14 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: false,
         });
       });
 
       it('if evidence is missing', () => {
         viewModel.attr('urlsAmount', 1);
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
 
         performDropdownValidation(dropdownField);
 
@@ -508,7 +508,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: true,
+          attachment: true,
           url: false,
         });
       });
@@ -528,14 +528,14 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: true,
         });
       });
 
       it('if both of them missing', () => {
         dropdownField.attr('errorsMap.url', true);
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
 
         performDropdownValidation(dropdownField);
 
@@ -548,7 +548,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: true,
+          attachment: true,
           url: true,
         });
       });
@@ -575,7 +575,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: false,
         });
       });
@@ -595,7 +595,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: true,
-          evidence: false,
+          attachment: false,
           url: false,
         });
       });
@@ -614,7 +614,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: true,
         });
       });
@@ -634,7 +634,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: true,
-          evidence: false,
+          attachment: false,
           url: true,
         });
       });
@@ -662,14 +662,14 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: false,
         });
       });
 
       it('if evidence is missing', () => {
         viewModel.attr('urlsAmount', 1);
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
 
         performDropdownValidation(dropdownField);
 
@@ -682,7 +682,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: true,
+          attachment: true,
           url: false,
         });
       });
@@ -702,13 +702,13 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: false,
+          attachment: false,
           url: true,
         });
       });
 
       it('if evidence and url is missing', () => {
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
         dropdownField.attr('errorsMap.url', true);
 
         performDropdownValidation(dropdownField);
@@ -722,7 +722,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: false,
-          evidence: true,
+          attachment: true,
           url: true,
         });
       });
@@ -743,7 +743,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: true,
-          evidence: false,
+          attachment: false,
           url: true,
         });
       });
@@ -751,7 +751,7 @@ describe('assessment-local-ca component', () => {
       it('if comment and evidence is missing', () => {
         viewModel.attr('urlsAmount', 1);
         dropdownField.attr('errorsMap.comment', true);
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
 
         performDropdownValidation(dropdownField);
 
@@ -764,14 +764,14 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: true,
-          evidence: true,
+          attachment: true,
           url: false,
         });
       });
 
       it('if all of them missing', () => {
         dropdownField.attr('errorsMap.url', true);
-        dropdownField.attr('errorsMap.evidence', true);
+        dropdownField.attr('errorsMap.attachment', true);
         dropdownField.attr('errorsMap.comment', true);
 
         performDropdownValidation(dropdownField);
@@ -785,7 +785,7 @@ describe('assessment-local-ca component', () => {
         });
         expect(dropdownField.attr().errorsMap).toEqual({
           comment: true,
-          evidence: true,
+          attachment: true,
           url: true,
         });
       });
@@ -838,7 +838,7 @@ describe('assessment-local-ca component', () => {
         },
         errorsMap: {
           comment: false,
-          evidence: false,
+          attachment: false,
           url: false,
         },
       });

--- a/src/ggrc-client/js/components/assessment/view-models/assessments-bulk-updatable-vm.js
+++ b/src/ggrc-client/js/components/assessment/view-models/assessments-bulk-updatable-vm.js
@@ -4,7 +4,10 @@
 */
 
 import ObjectOperationsBaseVM from '../../view-models/object-operations-base-vm';
-import {notifier} from '../../../plugins/utils/notifiers-utils';
+import {
+  notifier,
+  connectionLostNotifier,
+} from '../../../plugins/utils/notifiers-utils';
 import {trackStatus} from '../../../plugins/utils/background-task-utils';
 import {
   create,
@@ -61,7 +64,7 @@ export default ObjectOperationsBaseVM.extend({
   },
   handleBulkUpdateErrors() {
     if (isConnectionLost()) {
-      notifier('error', 'Internet connection was lost.');
+      connectionLostNotifier();
     } else {
       notifier('error', 'Bulk update is failed. ' +
       'Please refresh the page and start bulk update again.');

--- a/src/ggrc-client/js/components/assessment/view-models/tests/assessments-bulk-updatable-vm_spec.js
+++ b/src/ggrc-client/js/components/assessment/view-models/tests/assessments-bulk-updatable-vm_spec.js
@@ -180,14 +180,12 @@ describe('assessments-bulk-updatable-vm component', () => {
   });
 
   describe('handleBulkUpdateErrors() method', () => {
-    it('calls notifier() with specified params if connection is lost', () => {
+    it('calls connectionLostNotifier() if connection is lost', () => {
       spyOn(ErrorUtils, 'isConnectionLost').and.returnValue(true);
-      spyOn(NotifierUtils, 'notifier');
+      spyOn(NotifierUtils, 'connectionLostNotifier');
       viewModel.handleBulkUpdateErrors();
 
-      expect(NotifierUtils.notifier).toHaveBeenCalledWith(
-        'error',
-        'Internet connection was lost.');
+      expect(NotifierUtils.connectionLostNotifier).toHaveBeenCalled();
     });
 
     it('calls notifier() with specified params if connection is not lost',

--- a/src/ggrc-client/js/components/ca-object/ca-object-modal-content.js
+++ b/src/ggrc-client/js/components/ca-object/ca-object-modal-content.js
@@ -29,7 +29,7 @@ export default canComponent.extend({
       },
       evidence: {
         get() {
-          return this.attr('content.fields').indexOf('evidence') > -1 &&
+          return this.attr('content.fields').indexOf('attachment') > -1 &&
             this.attr('state.open');
         },
       },
@@ -93,7 +93,7 @@ export default canComponent.extend({
       });
       this.attr('content.contextScope.errorsMap.comment', false);
       this.attr('content.contextScope.validation.valid',
-        !this.attr('content.contextScope.errorsMap.evidence'));
+        !this.attr('content.contextScope.errorsMap.attachment'));
       this.attr('state.open', false);
       this.attr('state.save', false);
 

--- a/src/ggrc-client/js/components/custom-attributes/custom-attributes.js
+++ b/src/ggrc-client/js/components/custom-attributes/custom-attributes.js
@@ -10,6 +10,7 @@ import '../form/form-validation-icon';
 import '../form/form-validation-text';
 import '../custom-attributes/custom-attributes-field-view';
 import template from './custom-attributes.stache';
+import isFunction from 'can-util/js/is-function/is-function';
 
 export default canComponent.extend({
   tag: 'custom-attributes',
@@ -24,8 +25,27 @@ export default canComponent.extend({
         type: 'valueChanged',
         fieldId: e.fieldId,
         value: e.value,
-        field: field,
+        field,
+      });
+    },
+    addRequiredInfo(e, field) {
+      this.dispatch({
+        type: 'addRequiredInfo',
+        field,
       });
     },
   }),
+  helpers: {
+    isInvalidField(show, valid, highlightInvalidFields, options) {
+      show = isFunction(show) ? show() : show;
+      valid = isFunction(valid) ? valid() : valid;
+      highlightInvalidFields = isFunction(highlightInvalidFields) ?
+        highlightInvalidFields() : highlightInvalidFields;
+
+      if (highlightInvalidFields && show && !valid) {
+        return options.fn(options.context);
+      }
+      return options.inverse(options.context);
+    },
+  },
 });

--- a/src/ggrc-client/js/components/custom-attributes/custom-attributes.stache
+++ b/src/ggrc-client/js/components/custom-attributes/custom-attributes.stache
@@ -30,7 +30,7 @@
           <div class="form-field__validation-hint-placeholder">
               <button type="button"
                       class="btn btn-small btn-link btn-link-nopadding"
-                      on:el:click="showRequiredInfoModal(scope.event, %context)">
+                      on:el:click="addRequiredInfo(scope.event, %context)">
                 Add required info
               </button>
           </div>

--- a/src/ggrc-client/js/components/gdrive/ggrc-gdrive-picker-launcher.js
+++ b/src/ggrc-client/js/components/gdrive/ggrc-gdrive-picker-launcher.js
@@ -41,7 +41,6 @@ export default canComponent.extend({
     modelType: 'Document',
     tooltip: null,
     instance: {},
-    link_class: '',
     click_event: '',
     confirmationCallback: '',
     disabled: false,

--- a/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-picker-launcher.stache
+++ b/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-picker-launcher.stache
@@ -4,7 +4,7 @@
 }}
 
 <button
-  class="{{link_class}} btn btn-small btn-white"
+  class="btn btn-small btn-white"
   type="button"
   {{#isInactive}}disabled{{/isInactive}}
   {{#if tooltip}}

--- a/src/ggrc-client/js/components/required-info-modal/required-info-modal.js
+++ b/src/ggrc-client/js/components/required-info-modal/required-info-modal.js
@@ -13,7 +13,7 @@ import canStache from 'can-stache';
 import canMap from 'can-map';
 import template from './required-info-modal.stache';
 import {uploadFiles} from '../../plugins/utils/gdrive-picker-utils';
-import {notifier} from '../../plugins/utils/notifiers-utils';
+import {connectionLostNotifier} from '../../plugins/utils/notifiers-utils';
 import {isConnectionLost} from '../../plugins/utils/errors-utils';
 import {getPlainText} from '../../plugins/ggrc-utils';
 
@@ -64,7 +64,7 @@ const viewModel = canMap.extend({
       this.attr('filesList').push(...filesList);
     } catch (err) {
       if (isConnectionLost()) {
-        notifier('error', 'Internet connection was lost.');
+        connectionLostNotifier();
       }
     }
   },

--- a/src/ggrc-client/js/modules/widget-descriptor.js
+++ b/src/ggrc-client/js/modules/widget-descriptor.js
@@ -74,7 +74,6 @@ function makeInfoWidget(instance, widgetView) {
   widgetView [optional] - a template for rendering the info.
 */
 function makeSummaryWidget(instance, widgetView) {
-  let defaultView = '/base_objects/summary.stache';
   return createWidgetDescriptor(
     instance.constructor.model_singular + ':summary', {
       widget_id: 'summary',
@@ -86,7 +85,7 @@ function makeSummaryWidget(instance, widgetView) {
       content_controller_options: {
         instance: instance,
         model: instance.constructor,
-        widget_view: widgetView || defaultView,
+        widget_view: widgetView,
       },
       order: 3,
       uncountable: true,
@@ -94,7 +93,6 @@ function makeSummaryWidget(instance, widgetView) {
 }
 
 function makeDashboardWidget(instance, widgetView) {
-  let defaultView = '/base_objects/dashboard.stache';
   return createWidgetDescriptor(
     instance.constructor.model_singular + ':dashboard', {
       widget_id: 'dashboard',
@@ -109,7 +107,7 @@ function makeDashboardWidget(instance, widgetView) {
       content_controller_options: {
         instance: instance,
         model: instance.constructor,
-        widget_view: widgetView || defaultView,
+        widget_view: widgetView,
       },
       order: 6,
       uncountable: true,

--- a/src/ggrc-client/js/plugins/ajax-extensions.js
+++ b/src/ggrc-client/js/plugins/ajax-extensions.js
@@ -3,9 +3,7 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-import {
-  notifier,
-} from '../plugins/utils/notifiers-utils';
+import {connectionLostNotifier} from '../plugins/utils/notifiers-utils';
 import {
   isConnectionLost,
   handleAjaxError,
@@ -148,7 +146,7 @@ $(document).ajaxError(function (event, jqxhr, settings, exception) {
 
   if (!jqxhr.hasFailCallback) {
     if (isConnectionLost()) {
-      notifier('error', 'Internet connection was lost.');
+      connectionLostNotifier();
     } else {
       handleAjaxError(jqxhr, exception);
     }

--- a/src/ggrc-client/js/plugins/utils/ca-utils.js
+++ b/src/ggrc-client/js/plugins/utils/ca-utils.js
@@ -160,7 +160,7 @@ function prepareCustomAttributes(definitions, values) {
       preconditions_failed: [],
       errorsMap: {
         comment: false,
-        evidence: false,
+        attachment: false,
         url: false,
       },
     };
@@ -175,12 +175,12 @@ function prepareCustomAttributes(definitions, values) {
           empty: errors.indexOf('value') > -1,
           mandatory: def.mandatory,
           valid: errors.indexOf('comment') < 0 &&
-            errors.indexOf('evidence') < 0 &&
+            errors.indexOf('attachment') < 0 &&
             errors.indexOf('url') < 0,
         };
         value.errorsMap = {
           comment: errors.indexOf('comment') > -1,
-          evidence: errors.indexOf('evidence') > -1,
+          attachment: errors.indexOf('attachment') > -1,
           url: errors.indexOf('url') > -1,
         };
         valueData = value;
@@ -388,13 +388,7 @@ function applyChangesToCAValue(values, changes) {
 }
 
 function getLCAPopupTitle(validationMap) {
-  let fixedValidationMap = Object.assign({}, validationMap);
-
-  if (validationMap.evidence) {
-    fixedValidationMap.attachment = true;
-  }
-
-  return LCA_DROPDOWN_TITLES_MAP[ddValidationMapToValue(fixedValidationMap)];
+  return LCA_DROPDOWN_TITLES_MAP[ddValidationMapToValue(validationMap)];
 }
 
 export {

--- a/src/ggrc-client/js/plugins/utils/errors-utils.js
+++ b/src/ggrc-client/js/plugins/utils/errors-utils.js
@@ -92,7 +92,7 @@ function getRequestErrorDetails({
 
   if (isConnectionLost()) {
     name = 'Connection Lost Error';
-    details = 'Internet connection was lost.';
+    details = messages.connectionLost;
   }
 
   return {

--- a/src/ggrc-client/js/plugins/utils/notifiers-utils.js
+++ b/src/ggrc-client/js/plugins/utils/notifiers-utils.js
@@ -15,6 +15,7 @@ const messages = {
   ' Please refresh the page and try saving again',
   '412': 'One of the form fields isn\'t right. ' +
   'Check the form for any highlighted fields.',
+  connectionLost: 'Internet connection was lost.',
 };
 
 /**
@@ -53,6 +54,10 @@ function notifierXHR(type, xhr) {
   notifier(type, message);
 }
 
+function connectionLostNotifier() {
+  notifier('error', messages.connectionLost);
+}
+
 window.addEventListener('error', (event) => {
   notifier('error', event.message);
 });
@@ -61,4 +66,5 @@ export {
   messages,
   notifier,
   notifierXHR,
+  connectionLostNotifier,
 };

--- a/src/ggrc-client/js/plugins/utils/query-api-utils.js
+++ b/src/ggrc-client/js/plugins/utils/query-api-utils.js
@@ -10,9 +10,7 @@ import loMap from 'lodash/map';
 import {ggrcAjax} from '../../plugins/ajax-extensions';
 import makeArray from 'can-util/js/make-array/make-array';
 import QueryParser from '../../generated/ggrc-filter-query-parser';
-import {
-  notifier,
-} from './notifiers-utils';
+import {connectionLostNotifier} from './notifiers-utils';
 import {
   isConnectionLost,
   handleAjaxError,
@@ -255,7 +253,7 @@ function _resolveBatch(queue) {
     });
   }).catch((jqxhr, textStatus, exception) => {
     if (isConnectionLost()) {
-      notifier('error', 'Internet connection was lost.');
+      connectionLostNotifier();
     } else {
       handleAjaxError(jqxhr, exception);
     }


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

After first part of "Bulk complete" epic, there were found several places where code can be improved/cleaned up. 

# Steps to test the changes

1. Unused templates.
1.1 Open any object with info tab.
1.2 Open any object with custom dashboard or add a custom dashboard to object:
Open admin dashboard. Open custom attributes. 
Create new custom attribute with this parameters:
Attribute title: `Dashboard_ ` any text 
Attribute type: text
Create new object with created custom attribute. 
Add some link to created custom attribute. 
Link should start from `https://`
Open created object.
1.3 Open any audit. (Only there we can find summary widget)
1.4 Expected: Widgets works correctly.
2. `getLCAPopupTitle` util
2.1  Launch GGRC.
2.2 Create audit.
2.3 Create assessment template with `dropdown` as custom attribute.
2.4 Make `url` `file` and `comment` required.
2.5 Create assessment and chose created template.
2.6 Try to add/delete data in required CA fields
2.7 Expected: Modal title should be correct in dependency of missing CA fields.

# Solution description

## Issue
There is mention of "dashboard.stache" in our code but the code base doesn't contain this file. Need to investigate possibility to remove this mention.
### Solution
After some investigation I've noticed that we can remove `/base_objects/dashboard.stache` and `/base_objects/summary.stache` templates as default template from code. Because we can see in 
`init_widgets()` method from `src/ggrc-client/js/apps/business-objects.js` that `SummaryWidget` and `DashboardWidget` will be created if condition satisfied. But `InfoWidget` will be created for every widget and sometimes dosen't have view template.
## Issue
There is "widget_initial_content" field which contains an empty string or an empty `<ul>` list in most cases. Need to investigate possibility to remove this field. Does this field affect our code?
### Solution
Render happen in these elements.
## Issue
Investigate possibility to remove "fixedValidationMap" from getLCAPopupTitle method in "ca-utils.js". We need to pass "validationMap" which'll initially contain "attachment" field instead of "evidence".
### Solution
After some investigation I've noticed that we can rename `evidence` field on `attachment` without
without negative influence on our code, because only `getLCAPopupTitle` util and `performDropdownValidation` method uses this fields. That giving us opportunite for delete extra logic from  `getLCAPopupTitle` util.
## Issue
There are a lot of duplications of "Internet connection was lost." error. Need to have a single place where this text is defined (or functionality which'll show this message).
### Solution
Created separate util for notify this error.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
