### PR TITLE
GGRC-7799 Mapped objects don't display in "map:.." columns in Export

### DIFF
--- a/src/ggrc/converters/base_block.py
+++ b/src/ggrc/converters/base_block.py
@@ -600,17 +600,18 @@ class ExportBlockConverter(BlockConverter):
     """Setup fields property."""
     if fields == "all":
       fields = self.object_headers.keys()
+    else:
+      # There may be cases when `fields` (sent from FE) contains local CAs
+      # but self.object_headers does not have them since there are no such
+      # local CAs for objects being exported.
+      fields = set(fields) & set(self.object_headers.keys())
+
     self.fields = import_helper.get_column_order(fields)
 
   def generate_csv_header(self):
     """Generate 2D array with csv header description."""
     headers = []
     for field in self.fields:
-      if field not in self.object_headers:
-        # There may be cases when self.fields contains local custom attribute
-        # fields passed from FE, but self.object_headers does not have them
-        # since there are no such LCAs for objects being exported.
-        continue
       description = self.object_headers[field]["description"]
       display_name = self.object_headers[field]["display_name"]
       if self.object_headers[field]["mandatory"]:


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If a user tries to export object and selects fields on UI that the object doesn't have, values in resulting file will be shifted (will be written in wrong columns).

# Steps to test the changes

1. Create two Assessments with different sets of LCAs;
2. Go to _"Export"_ page;
3. Select "Assessment";
4. Filter Assessment in _"FILTER QUERY"_ by title;
5. Select some LCAs that filtered Assessment doesn't have;
6. Click _"Start Export"_ button;
7. Open exported Assessment in Sheets;

Expected result: values in Issue Tracker and Mappings columns should be correct (not shifted);

# Solution description

### Root cause
The issue is related with the fact that `self.fields` and `self.object_headers` are of different length in `ExportBlockConverter`.

`self.fields` contains all fields that are passed in HTTP response from UI. Thus, if some fields that are not present on the object are selected, they still will be present in `self.fields` on export block. And values for columns in CSV are generated based on `self.fields`.

`self.object_headers` contains **only** fields that are present on the object being exported. And header row in exported CSV in being constructed from this field.

Taken all of the above, when `self.fields` and `self.object_headers` have different number of fields, values in exported CSV will be shifted.

### Solution
This PR contains changes in `organize_fields` method which assigns value for `self.fields` field. Now `self.fields` will contain only fields that are present both in fields sent from UI and in object headers.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
