### PR TITLE
GGRC-7800 [FE] Date and date.time. Calendar widget has two variants of picked date.

### DIFF
--- a/src/ggrc-client/js/components/datepicker/datepicker-component.stache
+++ b/src/ggrc-client/js/components/datepicker/datepicker-component.stache
@@ -18,15 +18,15 @@
   <div class="datepicker__input-wrapper">
     <i class="fa fa-calendar"></i>
     <input type="text" class="datepicker__input date {{#if readonly}}datepicker__input--denied{{/if}}"
-           placeholder="{{MOMENT_DISPLAY_FMT}}"
-           value:bind="_date"
+           placeholder="{{placeholder}}"
+           value:bind="inputDate"
            on:el:focus="onFocus"
            {{#if disabled}} disabled {{/if}}
            {{#if readonly}} readonly {{/if}}/>
     {{#if date}}
-    <a class="datepicker__remove-value" on:el:click="removeValue(scope.event)">
-      <i class="fa fa-times"></i>
-    </a>
+      <a class="datepicker__remove-value" on:el:click="removeValue(scope.event)">
+        <i class="fa fa-times"></i>
+      </a>
     {{/if}}
     <div
       class="datepicker__calendar {{#if showTop}}datepicker__calendar--top{{/if}}

--- a/src/ggrc-client/js/components/tests/datepicker-component_spec.js
+++ b/src/ggrc-client/js/components/tests/datepicker-component_spec.js
@@ -9,361 +9,497 @@ import {getComponentVM} from '../../../js_specs/spec-helpers';
 import Component from '../datepicker/datepicker-component';
 
 
-describe('datepicker component', function () {
+describe('datepicker component', () => {
   let events;
+  let viewModel;
+  let someValue;
+  let expectedResult;
 
-  beforeAll(function () {
+  beforeEach(() => {
+    viewModel = getComponentVM(Component);
+    viewModel.attr('date', null);
+    viewModel.attr('inputDate', null);
+    viewModel.attr('minDate', null);
+    viewModel.attr('maxDate', null);
+    viewModel.attr('setMinDate', null);
+    viewModel.attr('setMaxDate', null);
+    someValue = null;
+    expectedResult = null;
+  });
+
+  beforeAll(() => {
     events = Component.prototype.events;
   });
 
-  describe('viewModel', function () {
-    let viewModel;
+  describe('viewModel', () => {
+    describe('date setter', () => {
+      it('should call "updatePicker" with correct params',
+        () => {
+          someValue = '2019-03-03';
+          spyOn(viewModel, 'updatePicker');
+          expectedResult = ['setDate', '2019-03-03'];
 
-    beforeEach(function () {
-      viewModel = getComponentVM(Component);
+          viewModel.attr('date', someValue);
+
+          expect(viewModel.updatePicker)
+            .toHaveBeenCalledWith(...expectedResult);
+        });
+
+      it('should return date for ISO date argument',
+        () => {
+          someValue = '2019-03-03';
+          expectedResult = '2019-03-03';
+
+          viewModel.attr('date', someValue);
+
+          expect(viewModel.attr('date')).toBe(expectedResult);
+        });
+
+      it('should return null for not ISO date argument',
+        () => {
+          someValue = '2019-03-03';
+          viewModel.attr('date', '03/03/2019');
+
+          expect(viewModel.attr('date')).toBeNull();
+        });
     });
 
-    describe('onSelect() method', function () {
-      it('sets new date', function () {
-        viewModel.attr('date', 'oldDate');
-        viewModel.onSelect('newDate');
-        expect(viewModel.attr('date')).toEqual('newDate');
+    describe('inputDate setter', () => {
+      it(`should return date in FTM format
+      if format of argument is FTM`, () => {
+        someValue = '03/03/2019';
+        expectedResult = '03/03/2019';
+
+        viewModel.attr('inputDate', someValue);
+
+        expect(viewModel.attr('inputDate')).toBe(expectedResult);
       });
-      it('sets false to isShown attribute', function () {
+
+      it(`should set date in ISO format to date
+      if format of argument is FTM`, () => {
+        someValue = '03/03/2019';
+        expectedResult = '2019-03-03';
+
+        viewModel.attr('inputDate', someValue);
+
+        expect(viewModel.attr('date')).toBe(expectedResult);
+      });
+
+      it(`should update maximum allowable date
+      if new date more than it`, () => {
+        someValue = '03/03/2019';
+        viewModel.attr('maxDate', '2019-03-02');
+        viewModel.attr('inputDate', someValue);
+        expectedResult = '2019-03-03';
+
+        expect(viewModel.attr('maxDate')).toBe(expectedResult);
+      });
+
+      it(`should update minimum allowable date
+      if new date less than it`, () => {
+        someValue = '03/03/2019';
+        viewModel.attr('minDate', '2019-03-04');
+        viewModel.attr('inputDate', someValue);
+        expectedResult = '2019-03-03';
+
+        expect(viewModel.attr('minDate')).toBe(expectedResult);
+      });
+
+      it(`should return null
+      if format of argument is not FTM`, () => {
+        someValue = '2019-03-03';
+        viewModel.attr('inputDate', someValue);
+
+        expect(viewModel.attr('inputDate')).toBeNull();
+      });
+
+      it(`should set null to date
+      if format of argument is not FTM`, () => {
+        someValue = '2019-03-03';
+        viewModel.attr('inputDate', someValue);
+
+        expect(viewModel.attr('date')).toBeNull();
+      });
+    });
+
+    describe('minDate setter', () => {
+      it('should return date in ISO format',
+        () => {
+          someValue = '2019-03-03';
+          expectedResult = '2019-03-03';
+
+          viewModel.attr('minDate', someValue);
+
+          expect(viewModel.attr('minDate')).toBe(expectedResult);
+        });
+
+      it('should call "updatePicker" method with correct params',
+        () => {
+          someValue = '2019-03-03';
+          spyOn(viewModel, 'updatePicker');
+          expectedResult = ['minDate', '2019-03-03'];
+
+          viewModel.attr('minDate', someValue);
+
+          expect(viewModel.updatePicker)
+            .toHaveBeenCalledWith(...expectedResult);
+        });
+    });
+
+    describe('maxDate setter', () => {
+      it('should return date in ISO format',
+        () => {
+          someValue = '2019-03-03';
+          expectedResult = '2019-03-03';
+
+          viewModel.attr('maxDate', someValue);
+
+          expect(viewModel.attr('maxDate')).toBe(expectedResult);
+        });
+
+      it('should call "updatePicker" method with correct params',
+        () => {
+          someValue = '2019-03-03';
+          spyOn(viewModel, 'updatePicker');
+          expectedResult = ['maxDate', '2019-03-03'];
+
+          viewModel.attr('maxDate', someValue);
+
+          expect(viewModel.updatePicker)
+            .toHaveBeenCalledWith(...expectedResult);
+        });
+    });
+
+    describe('init() method', () => {
+      it(`should set initial value of inputDate
+        from date in FMT format`, () => {
+        someValue = '2019-03-03';
+        viewModel.attr('date', someValue);
+        expectedResult = '03/03/2019';
+
+        viewModel.init();
+
+        expect(viewModel.attr('inputDate')).toBe(expectedResult);
+      });
+    });
+
+    describe('onSelect() method', () => {
+      it('sets new date', () => {
+        someValue = '2019-03-03';
+        viewModel.attr('date', someValue);
+        expectedResult = '2019-04-04';
+
+        viewModel.onSelect('2019-04-04');
+
+        expect(viewModel.attr('date')).toBe(expectedResult);
+      });
+
+      it('sets false to isShown attribute', () => {
         viewModel.attr('isShown', true);
         viewModel.onSelect();
-        expect(viewModel.attr('isShown')).toEqual(false);
+        expectedResult = false;
+
+        expect(viewModel.attr('isShown')).toBe(expectedResult);
       });
     });
 
-    describe('onFocus() method', function () {
-      it('sets false to showTop attribute', function () {
+    describe('onFocus() method', () => {
+      it('sets false to showTop attribute', () => {
         spyOn(Utils, 'inViewport')
           .and.returnValue(true);
-        viewModel.attr('showtop', true);
+        viewModel.attr('showTop', true);
         viewModel.onFocus();
-        expect(viewModel.attr('showTop')).toEqual(false);
+        expectedResult = false;
+
+        expect(viewModel.attr('showTop')).toBe(expectedResult);
       });
-      it('sets true to isShown attribute', function () {
+
+      it('sets true to isShown attribute', () => {
         spyOn(Utils, 'inViewport')
           .and.returnValue(true);
         viewModel.attr('isShown', false);
         viewModel.onFocus();
-        expect(viewModel.attr('isShown')).toEqual(true);
+        expectedResult = true;
+
+        expect(viewModel.attr('isShown')).toBe(expectedResult);
       });
+
       it('does not set true to showTop attribute if picker is in viewport',
-        function () {
+        () => {
           spyOn(Utils, 'inViewport')
             .and.returnValue(true);
           viewModel.onFocus();
-          expect(viewModel.attr('showTop')).toEqual(false);
+          expectedResult = false;
+
+          expect(viewModel.attr('showTop')).toBe(expectedResult);
         });
+
       it('sets true to showTop attribute if picker is not in viewport',
-        function () {
-          spyOn(Utils, 'inViewport')
-            .and.returnValue(false);
+        () => {
+          spyOn(Utils, 'inViewport').and.returnValue(false);
           viewModel.onFocus();
-          expect(viewModel.attr('showTop')).toEqual(true);
+          expectedResult = true;
+
+          expect(viewModel.attr('showTop')).toBe(expectedResult);
         });
+    });
+
+    describe('removeValue() method', () => {
+      let event;
+
+      beforeEach(() => {
+        event = {
+          preventDefault: jasmine.createSpy(),
+        };
+      });
+
+      it('should cancel default action', () => {
+        viewModel.removeValue(event);
+
+        expect(event.preventDefault)
+          .toHaveBeenCalled();
+      });
+
+      it('should set null to "inputDate"', () => {
+        someValue = '2019-03-03';
+        viewModel.attr('inputDate', someValue);
+
+        viewModel.removeValue(event);
+
+        expect(viewModel.attr('inputDate'))
+          .toBeNull();
+      });
+    });
+
+    describe('validateDate() method', () => {
+      it('should return date if ISO date is valid', () => {
+        expectedResult = '2011-11-11';
+
+        expect(viewModel.validateDate('2011-11-11')).toBe(expectedResult);
+      });
+
+      it('should return date if FTM date is valid', () => {
+        expectedResult = '02/02/2018';
+
+        expect(
+          viewModel.validateDate('02/02/2018', DATE_FORMAT.MOMENT_DISPLAY_FMT)
+        ).toEqual(expectedResult);
+      });
+
+      it('should return null if date is invalid', () => {
+        expect(viewModel.validateDate(null)).toBeNull();
+        expect(viewModel.validateDate('')).toBeNull();
+        expect(viewModel.validateDate('2011-33-01')).toBeNull();
+        expect(viewModel.validateDate(
+          '11/12/2017',
+          DATE_FORMAT.MOMENT_ISO_DATE
+        )).toBeNull();
+      });
+    });
+
+    describe('formatDate() method', () => {
+      it('should return date in FTM format', () => {
+        someValue = '2019-03-03';
+        expectedResult = '03/03/2019';
+
+        expect(viewModel.formatDate(someValue, DATE_FORMAT.MOMENT_DISPLAY_FMT))
+          .toBe(expectedResult);
+      });
+
+      it('should return date in ISO format', () => {
+        someValue = '03/03/2019';
+        expectedResult = '2019-03-03';
+
+        expect(viewModel.formatDate(
+          someValue,
+          DATE_FORMAT.MOMENT_ISO_DATE,
+          DATE_FORMAT.MOMENT_DISPLAY_FMT
+        )).toBe(expectedResult);
+      });
+
+      it('should return null for invalid date', () => {
+        someValue = '2019-03-03';
+        expect(viewModel.formatDate(
+          someValue,
+          DATE_FORMAT.MOMENT_ISO_DATE,
+          DATE_FORMAT.MOMENT_DISPLAY_FMT
+        )).toBeNull();
+
+        expect(viewModel.formatDate(
+          '03/03/2019',
+          DATE_FORMAT.MOMENT_DISPLAY_FMT
+        )).toBeNull();
+
+        expect(viewModel.formatDate(null, DATE_FORMAT.MOMENT_DISPLAY_FMT))
+          .toBeNull();
+      });
+    });
+
+    describe('updatePicker() method', () => {
+      it(`should call "datepicker" method with correct params for "setDate"
+      if picker is initialized`,
+      () => {
+        someValue = '2019-03-03';
+        const picker = {datepicker: jasmine.createSpy()};
+        viewModel.attr('picker', picker);
+        expectedResult = ['setDate', '2019-03-03'];
+        const unexpectedResult = ['option', 'setDate', '2019-03-03'];
+
+        viewModel.updatePicker('setDate', someValue);
+
+        expect(viewModel.picker.datepicker)
+          .toHaveBeenCalledWith(...expectedResult);
+        expect(viewModel.picker.datepicker)
+          .not
+          .toHaveBeenCalledWith(...unexpectedResult);
+      });
+
+      it(`should call "datepicker" method with correct params for "minDate"
+      if picker is initialized`,
+      () => {
+        someValue = '2019-03-03';
+        const picker = {datepicker: jasmine.createSpy()};
+        viewModel.attr('picker', picker);
+        expectedResult = ['option', 'minDate', '2019-03-03'];
+        const unexpectedResult = ['minDate', '2019-03-03'];
+
+        viewModel.updatePicker('minDate', someValue);
+
+        expect(viewModel.picker.datepicker)
+          .toHaveBeenCalledWith(...expectedResult);
+        expect(viewModel.picker.datepicker)
+          .not
+          .toHaveBeenCalledWith(...unexpectedResult);
+      });
+    });
+
+    describe('correctDate() method', () => {
+      it('should return date increased by one day for "minDate"', () => {
+        someValue = '2019-03-03';
+        expectedResult = '2019-03-04';
+
+        expect(viewModel.correctDate('minDate', someValue))
+          .toBe(expectedResult);
+      });
+
+      it('should return the date reduced by one day for "maxDate"', () => {
+        someValue = '2019-03-03';
+        expectedResult = '2019-03-02';
+
+        expect(viewModel.correctDate('maxDate', someValue))
+          .toBe(expectedResult);
+      });
+
+      it('should return null if date is invalid', () => {
+        expect(viewModel.correctDate('minDate', null)).toBeNull();
+        expect(viewModel.correctDate('maxDate', '2011-33-01')).toBeNull();
+      });
     });
   });
 
-  describe('events', function () {
-    describe('inserted() method', function () {
-      let method;
-      let that;
-      let viewModel;
+  describe('events', () => {
+    let method;
+    let that;
+
+    beforeEach(() => {
+      that = {
+        viewModel,
+      };
+    });
+
+    describe('inserted() method', () => {
       let altField;
       let element;
 
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
+      beforeEach(() => {
+        viewModel.updatePicker = jasmine.createSpy();
         viewModel.onSelect.bind = jasmine.createSpy()
           .and.returnValue('mockOnSelect');
         element = $('<div class="datepicker__calendar"></div>');
         altField = $('<div class="datepicker__input"></div>');
         $('body').append(element);
         $('body').append(altField);
-        that = {
-          viewModel: viewModel,
-          element: $('body'),
-          getDate: function (date) {
-            return date;
-          },
-          updateDate: jasmine.createSpy(),
-        };
+        that.element = $('body');
         method = events.inserted.bind(that);
       });
-      afterEach(function () {
+
+      afterEach(() => {
         $('body').html('');
       });
 
-      it('create datepicker in specified format', function () {
+      it('create datepicker in specified format', () => {
         method();
         expect(element.datepicker('option', 'dateFormat'))
-          .toEqual(DATE_FORMAT.PICKER_ISO_DATE);
+          .toBe(DATE_FORMAT.PICKER_ISO_DATE);
         expect(element.datepicker('option', 'altField')[0])
-          .toEqual(altField[0]);
+          .toBe(altField[0]);
         expect(element.datepicker('option', 'altFormat'))
-          .toEqual(DATE_FORMAT.PICKER_DISPLAY_FMT);
+          .toBe(DATE_FORMAT.PICKER_DISPLAY_FMT);
       });
-      it('sets new datepicker to picker of viewModel', function () {
+
+      it('sets new datepicker to picker of viewModel', () => {
         method();
-        expect(viewModel.attr('picker')[0]).toEqual(element[0]);
-      });
-      it('sets date from viewModel to datepicker', function () {
-        element.datepicker('setDate', '2011-11-11');
-        viewModel.attr('date', '2012-12-12');
-        method();
-        expect(viewModel.picker.datepicker().val()).toEqual('2012-12-12');
-      });
-      it('sets min allowed date to viewModel', function () {
-        viewModel.attr('minDate', '2000-10-10');
-        viewModel.setMinDate = '2001-01-01';
-        method();
-        expect(viewModel.attr('setMinDate')).toEqual('2001-01-01');
-      });
-      it('sets max allowed date to viewModel', function () {
-        viewModel.attr('maxDate', '2000-10-10');
-        viewModel.setMaxDate = '2011-11-11';
-        method();
-        expect(viewModel.attr('setMaxDate')).toEqual('2011-11-11');
-      });
-      it('updates min date if setMinDate is define in viewModel', function () {
-        viewModel.setMinDate = '2001-01-01';
-        method();
-        expect(that.updateDate).toHaveBeenCalledWith('minDate', '2001-01-01');
-      });
-      it('updates max date if setMaxDate is define in viewModel', function () {
-        viewModel.setMaxDate = '2011-11-11';
-        method();
-        expect(that.updateDate).toHaveBeenCalledWith('maxDate', '2011-11-11');
-      });
-    });
-
-    describe('getDate() method', function () {
-      let method;
-      let that;
-      let viewModel;
-
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
-        that = {
-          viewModel: viewModel,
-          isValidDate: events.isValidDate.bind(that),
-        };
-        method = events.getDate.bind(that);
+        expect(viewModel.attr('picker')[0]).toBe(element[0]);
       });
 
-      it('returns formatted date if it is Date object', function () {
-        expect(method(new Date('2011-11-11T00:00:00'))).toEqual('2011-11-11');
-      });
-      it('returns date if it is valid date', function () {
-        expect(method('2012-12-12')).toEqual('2012-12-12');
-      });
-      it('returns null if it is invalid date', function () {
-        expect(method('2013-13-13')).toEqual(null);
-      });
-    });
+      it('should set minDate corrected value from setMinDate',
+        () => {
+          someValue = '2019-03-03';
+          viewModel.attr('setMinDate', someValue);
+          expectedResult = '2019-03-04';
 
-    describe('isValidDate() method', function () {
-      let method;
-      let that;
+          method();
 
-      beforeEach(function () {
-        that = {
-          viewModel: getComponentVM(Component),
-        };
-        method = events.isValidDate.bind(that);
-      });
-      it('returns true if it is valid date', function () {
-        expect(method('2011-11-11')).toEqual(true);
-      });
-      it('returns false if it is invalid date', function () {
-        expect(method('-2011-11-11')).toEqual(false);
-        expect(method('2011-33-01')).toEqual(false);
-        expect(method('2011-11-45')).toEqual(false);
-      });
-    });
-
-    describe('updateDate() method', function () {
-      let method;
-      let that;
-
-      beforeEach(function () {
-        that = {
-          viewModel: getComponentVM(Component),
-        };
-        that.viewModel.picker = {
-          datepicker: jasmine.createSpy(),
-        };
-        method = events.updateDate.bind(that);
-      });
-
-      it('returns undefined for empty date', function () {
-        expect(method('maxDate')).toBe(null);
-        expect(method('maxDate', null)).toBe(null);
-        expect(method('minDate', '')).toBe(null);
-      });
-
-      it('returns a date incremented by a day for maxDate', function () {
-        let result = method('maxDate', new Date(2017, 0, 1));
-
-        expect(result.getDate()).toBe(31);
-        expect(result.getFullYear()).toBe(2016);
-        expect(result.getMonth()).toBe(11);
-      });
-
-      it('returns a date decremented by a day for minDate', function () {
-        let result = method('minDate', new Date(2017, 0, 1));
-
-        expect(result.getDate()).toBe(2);
-        expect(result.getFullYear()).toBe(2017);
-        expect(result.getMonth()).toBe(0);
-      });
-    });
-
-    describe('prepareDate() method', function () {
-      let method;
-      let viewModel;
-
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
-        method = events.prepareDate.bind(viewModel);
-      });
-
-      it('returns null for incorrect date', function () {
-        expect(method(viewModel, 'some string')).toBe(null);
-        expect(method(viewModel, '11.12.68')).toBe(null);
-        expect(method(viewModel, '11.12.2017')).toBe(null);
-        expect(method(viewModel, '')).toBe(null);
-      });
-
-      it('returns ISO date formated for correct date', function () {
-        expect(method(viewModel, '11/12/2017')).toBe('2017-11-12');
-        expect(method(viewModel, ' 11/12/2017')).toBe('2017-11-12');
-        expect(method(viewModel, '11/12/2017 ')).toBe('2017-11-12');
-      });
-    });
-
-    describe('"{viewModel} setMinDate" handler', function () {
-      let method;
-      let viewModel;
-      let that;
-
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
-        that = {
-          viewModel,
-        };
-        method = events['{viewModel} setMinDate'].bind(that);
-      });
-      it('does not change _date if updated date is falsy', function () {
-        viewModel.attr('_date', '11/11/2011');
-        that.updateDate = jasmine.createSpy()
-          .and.returnValue(new Date());
-        method([viewModel], {});
-        expect(viewModel.attr('_date')).toEqual('11/11/2011');
-      });
-      it('does not change _date if updated date is before current date',
-        function () {
-          viewModel.attr('_date', '11/11/2011');
-          viewModel.attr('date', '2011-11-11');
-          that.updateDate = jasmine.createSpy()
-            .and.returnValue(new Date('2010-10-10'));
-          method([viewModel], {});
-          expect(viewModel.attr('_date')).toEqual('11/11/2011');
+          expect(viewModel.minDate).toBe(expectedResult);
         });
-      it('changes _date if updated date is after current date',
-        function () {
-          viewModel.attr('_date', '2011-11-11');
-          viewModel.attr('date', '2011-11-11');
-          that.updateDate = jasmine.createSpy()
-            .and.returnValue(new Date('2012-12-12'));
-          method([viewModel], {});
-          expect(viewModel.attr('_date')).toEqual('12/12/2012');
+
+      it('should set maxDate corrected value from setMaxDate',
+        () => {
+          someValue = '2019-03-03';
+          viewModel.attr('setMaxDate', someValue);
+          expectedResult = '2019-03-02';
+
+          method();
+
+          expect(viewModel.maxDate).toBe(expectedResult);
         });
     });
 
-    describe('"{viewModel} setMaxDate" handler', function () {
-      let method;
-      let that;
-      beforeEach(function () {
-        that = {
-          updateDate: jasmine.createSpy(),
-        };
-        method = events['{viewModel} setMaxDate'].bind(that);
-      });
-      it('calls updateDate with "maxDate" and new date as arguments',
-        function () {
-          let date = '11-11-2011';
-          method([], {}, date);
-          expect(that.updateDate).toHaveBeenCalledWith('maxDate', date);
-        });
-    });
-
-    describe('"{viewModel} _date" handler', function () {
-      let method;
-      let that;
-      let viewModel;
-
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
-        viewModel.picker = {
-          datepicker: jasmine.createSpy(),
-        };
-        that = {
-          prepareDate: jasmine.createSpy()
-            .and.returnValue('ISODate'),
-        };
-        method = events['{viewModel} _date'].bind(that);
-      });
-
-      it('sets prepared date to viewModel', function () {
-        method([viewModel], {}, {});
-        expect(viewModel.attr('date')).toEqual('ISODate');
-      });
-      it('sets prepared date to datepicker', function () {
-        method([viewModel], {}, {});
-        expect(viewModel.picker.datepicker)
-          .toHaveBeenCalledWith('setDate', 'ISODate');
-      });
-    });
-
-    describe('"{window} mousedown" handler', function () {
-      let method;
-      let that;
-      let viewModel;
-
-      beforeEach(function () {
-        viewModel = getComponentVM(Component);
-        that = {
-          viewModel: viewModel,
-        };
+    describe('"{window} mousedown" handler', () => {
+      beforeEach(() => {
         method = events['{window} mousedown'].bind(that);
       });
 
       it('sets isShown to false if datepicker is shown' +
-      ' and click was outside the datepicker', function () {
+      ' and click was outside the datepicker', () => {
         viewModel.attr('isShown', true);
-        spyOn(Utils, 'isInnerClick')
-          .and.returnValue(false);
+        spyOn(Utils, 'isInnerClick').and.returnValue(false);
+        expectedResult = false;
+
         method({}, {});
-        expect(viewModel.attr('isShown')).toEqual(false);
+
+        expect(viewModel.attr('isShown')).toBe(expectedResult);
       });
-      it('does nothing if datepicker is persistent', function () {
+
+      it('does nothing if datepicker is persistent', () => {
         viewModel.attr('persistent', true);
         viewModel.attr('isShown', true);
+        expectedResult = true;
+
         method({}, {});
-        expect(viewModel.attr('isShown')).toEqual(true);
+
+        expect(viewModel.attr('isShown')).toBe(expectedResult);
       });
-      it('does nothing if click was inside the datepicker', function () {
+
+      it('does nothing if click was inside the datepicker', () => {
         viewModel.attr('persistent', false);
         viewModel.attr('isShown', true);
-        spyOn(Utils, 'isInnerClick')
-          .and.returnValue(true);
+        spyOn(Utils, 'isInnerClick').and.returnValue(true);
+        expectedResult = true;
+
         method({}, {});
-        expect(viewModel.attr('isShown')).toEqual(true);
+
+        expect(viewModel.attr('isShown')).toBe(expectedResult);
       });
     });
   });

--- a/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
@@ -11,7 +11,7 @@ import CycleTaskGroup from './cycle-task-group';
 import Workflow from './workflow';
 import {REFRESH_SUB_TREE} from '../../events/event-types';
 import {getPageType} from '../../plugins/utils/current-page-utils';
-import {getClosestWeekday} from '../../plugins/utils/date-utils';
+import {getClosestWeekday, DATE_FORMAT} from '../../plugins/utils/date-utils';
 import IsOverdue from '../mixins/is-overdue';
 import AccessControlList from '../mixins/access-control-list';
 import CaUpdate from '../mixins/ca-update';
@@ -255,19 +255,19 @@ export default Cacheable.extend({
     }
     populateFromWorkflow(this, workflow);
   },
-  formPreload: function (newObjectForm, objectParams) {
+  formPreload(newObjectForm, objectParams) {
     let form = this;
     let cycle;
-    let startDate;
-    let endDate;
 
     if (newObjectForm) {
       // prepopulate dates with default ones
-      startDate = getClosestWeekday(new Date());
-      endDate = getClosestWeekday(moment().add({month: 3}).toDate());
+      const formattedStartDate = getClosestWeekday(moment())
+        .format(DATE_FORMAT.MOMENT_ISO_DATE);
+      const formattedEndDate = getClosestWeekday(moment().add({month: 3}))
+        .format(DATE_FORMAT.MOMENT_ISO_DATE);
 
-      this.attr('start_date', startDate);
-      this.attr('end_date', endDate);
+      this.attr('start_date', formattedStartDate);
+      this.attr('end_date', formattedEndDate);
 
       // if we are creating a task from the workflow page, the preset
       // workflow should be that one

--- a/src/ggrc-client/js/models/business-models/task-group-task.js
+++ b/src/ggrc-client/js/models/business-models/task-group-task.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import Cacheable from '../cacheable';
 import Workflow from './workflow';
 import TaskGroup from './task-group';
-import {getClosestWeekday} from '../../plugins/utils/date-utils';
+import {getClosestWeekday, DATE_FORMAT} from '../../plugins/utils/date-utils';
 import Contactable from '../mixins/contactable';
 import AccessControlList from '../mixins/access-control-list';
 import Stub from '../stub';
@@ -97,21 +97,23 @@ export default Cacheable.extend({
       },
     },
   },
-  init: function () {
-    // default start and end date
-    let startDate = this.attr('start_date') || new Date();
-    let endDate = this.attr('end_date') ||
-      new Date(moment().add(7, 'days').format());
+  init() {
     if (this._super) {
       this._super(...arguments);
     }
+    // default start and end date
+    const startDate = this.attr('start_date') || moment();
+    const endDate = this.attr('end_date') || moment().add(7, 'days');
 
-    startDate = getClosestWeekday(startDate);
-    endDate = getClosestWeekday(endDate);
+    const formattedStartDate = getClosestWeekday(startDate)
+      .format(DATE_FORMAT.MOMENT_ISO_DATE);
+    const formattedEndDate = getClosestWeekday(endDate)
+      .format(DATE_FORMAT.MOMENT_ISO_DATE);
+
     // Add base values to this property
     this.attr('response_options', []);
-    this.attr('start_date', startDate);
-    this.attr('end_date', endDate);
+    this.attr('start_date', formattedStartDate);
+    this.attr('end_date', formattedEndDate);
   },
   _refresh_workflow_people: function () {
     //  TaskGroupTask assignment may add mappings and role assignments in

--- a/src/ggrc-client/js/plugins/tests/date-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/date-utils_spec.js
@@ -9,25 +9,40 @@ import {
   getFormattedUtcDate,
   formatDate,
 } from '../utils/date-utils';
+import moment from 'moment';
 
 describe('GGRC DateUtil', () => {
   describe('getClosestWeekday() method', () => {
-    it('adjusts to Friday when weekend provided', () => {
-      let date = new Date(2017, 11, 24);
-      let actual;
+    it('adjusts to Friday when weekend provided (with moment)', () => {
+      const date = moment({years: 2017, months: 11, date: 24});
 
-      actual = getClosestWeekday(date);
+      const actual = getClosestWeekday(date);
 
-      expect(actual.getDate()).toEqual(22);
+      expect(actual.get('date')).toEqual(22);
     });
 
-    it('leaves date as is when week day provided', () => {
-      let date = new Date(2017, 11, 20);
-      let actual;
+    it('leaves date as is when week day provided (with moment)', () => {
+      const date = moment({years: 2017, months: 11, date: 20});
 
-      actual = getClosestWeekday(date);
+      const actual = getClosestWeekday(date);
 
-      expect(actual.getDate()).toEqual(20);
+      expect(actual.get('date')).toEqual(20);
+    });
+
+    it('adjusts to Friday when weekend provided (with string)', () => {
+      const date = moment('2017-12-24');
+
+      const actual = getClosestWeekday(date);
+
+      expect(actual.get('date')).toEqual(22);
+    });
+
+    it('leaves date as is when week day provided (with string)', () => {
+      const date = moment('2017-12-20');
+
+      const actual = getClosestWeekday(date);
+
+      expect(actual.get('date')).toEqual(20);
     });
   });
 

--- a/src/ggrc-client/js/plugins/utils/date-utils.js
+++ b/src/ggrc-client/js/plugins/utils/date-utils.js
@@ -25,18 +25,18 @@ const DATE_FORMAT = {
 /**
  * Adjust date to the closest week day that is less than current.
  *
- * @param {Date} date - date value
+ * @param {Moment|string} date - date value
  *
- * @return {Date} closest week date to provided
+ * @return {Moment} closest week date to provided
  */
 function getClosestWeekday(date) {
-  let momDate = moment(date);
+  const momDate = moment(date);
 
   if (momDate.isoWeekday() > 5) {
-    return momDate.isoWeekday(5).toDate();
+    return momDate.isoWeekday(5);
   }
 
-  return date;
+  return momDate;
 }
 
 /**


### PR DESCRIPTION
# Issue description
Date and date.time. Calendar widget has two variants of picked date.

# Steps to test the changes 
1. Try to create any object with start/end date:
2. **First option**: open calendar and choose date - today > save&close. Look at request payload in devtools - there are only date(for current user timezone) was send to BE.
**Second option**: do not open calendar(by default date = today) > save&close. Look at request payload in devtools - there are date.time(UTC) was send to BE.
**Actual Result**: FE send date to BE in with time.  
**Expected result**: FE send date to BE without time.  

# Solution description 
Add formatting of date for new date instances.
Refactor datepicker component. Fix datepicker bugs.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [x] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".