### PR TITLE
GGRC-8152 Prevent cloning w/o read permissions

### DIFF
--- a/src/ggrc_basic_permissions/__init__.py
+++ b/src/ggrc_basic_permissions/__init__.py
@@ -334,7 +334,7 @@ def _get_acl_filter(acl_model_alias):
     list of filter statements.
   """
   stubs = getattr(flask.g, "referenced_object_stubs", None)
-  if stubs is None:
+  if not stubs:
     logger.warning("Using full permissions query")
     return "AND {}.object_type != 'Relationship'".format(acl_model_alias)
 

--- a/test/integration/ggrc/access_control/acl_propagation/test_cycle_task_assignees.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_cycle_task_assignees.py
@@ -22,7 +22,7 @@ class TestCycleTaskAssigneesPropagation(base.TestACLPropagation):
               "update": False,
               "delete": False,
               "read_revisions": False,
-              "clone": (False, "unimplemented"),
+              "clone": False,
           },
           "TaskGroup": {
               "create": False,

--- a/test/integration/ggrc/access_control/acl_propagation/test_task_assignees.py
+++ b/test/integration/ggrc/access_control/acl_propagation/test_task_assignees.py
@@ -22,7 +22,7 @@ class TestTaskAssigneesPropagation(base.TestACLPropagation):
               "update": False,
               "delete": False,
               "read_revisions": False,
-              "clone": (False, "unimplemented"),
+              "clone": False,
           },
           "TaskGroup": {
               "create": False,

--- a/test/integration/ggrc_workflows/test_workflow_api_calls.py
+++ b/test/integration/ggrc_workflows/test_workflow_api_calls.py
@@ -739,6 +739,48 @@ class TestWorkflowsApiPost(TestCase):
     count = len(all_models.CycleTaskGroup.query.all())
     self.assertEquals(count, exp_count)
 
+  def test_workflow_cloning(self):
+    """Test cloning a workflow by users w/ and w/o read permissions
+
+    This test checks that a user can create a workflow and after
+    successfully clone it. But a cloning must be failed if some other user
+    without a read permission try to do it.
+    """
+    user_role = "Creator"
+    with factories.single_commit():
+      person1 = self.create_user_with_role(user_role)
+      person2 = self.create_user_with_role(user_role)
+      workflow = wf_factories.WorkflowFactory()
+      workflow.add_person_with_role_name(person1, 'Admin')
+
+    person2_id = person2.id  # noqa #pylint: disable=unused-variable
+    workflow_id = workflow.id
+    self.generator.activate_workflow(workflow)
+
+    data = [{
+        "workflow": {
+            "task_group_title": "Task Group 1",
+            "is_verification_needed": False,
+            "title": "",
+            "clone": workflow_id,
+            "context": None,
+            "clone_people": False,
+            "clone_tasks": False,
+            "clone_objects": True,
+            "access_control_list": [],
+        }
+    }]
+
+    # perform a request using a user w/ a read permission
+    self.api.set_user(person1)
+    response = self.api.post(all_models.Workflow, data)
+    self.assert200(response)
+
+    # perform a request using a user w/o a read permission
+    self.api.set_user(person2)
+    response = self.api.post(all_models.Workflow, data)
+    self.assert403(response)
+
   @ddt.data(
       ('Editor', 200, 0),
       ('Creator', 403, 1),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

User is not able to clone Workflow that user has no access to. There was a bug which allow to do that without proper permissions

Also, fixed bug with reading ACL permissions. 
If stubs list is an empty dict, a mistakes occurs and `load_access_control_list` returns an empty ACL permissions list. 

# Steps to test the changes

1. Login as Global Creator
2. Create any Workflow
3. Open dev tools and open created Workflow
4. Clone the just created Workflow
5. Copy Post request with title "workflow" as fetch
6. Paste request in console and change Workflow ID that Global Creator has no access to

# Solution description

Added check for a read permission before cloning.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
