### PR TITLE
GGRC-8230 Investigate possibility to use {{#each(expression)}} construction in stache files 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4592,24 +4592,45 @@
       }
     },
     "can-stache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-3.2.0.tgz",
-      "integrity": "sha1-f+Rfz7jIaHAVGxUqnIiRN5rE0BY=",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/can-stache/-/can-stache-3.15.1.tgz",
+      "integrity": "sha512-tXrSYCz/0agl27p9DiwA6bdAjoxYGoQveYgGjKZfY0YqNp5Z3tl5DnWwVwhxVBA/psBOsNpZqtFZL3aBW9hUFg==",
       "requires": {
-        "can-compute": "^3.3.0-pre.1",
+        "can-attribute-encoder": "^0.3.4",
+        "can-compute": "^3.3.1",
+        "can-globals": "<2.0.0",
+        "can-log": "^1.0.0",
         "can-namespace": "1.0.0",
-        "can-observation": "^3.3.0-pre.1",
-        "can-reflect": "^1.1.0-pre.2",
-        "can-route": "^3.2.0-pre.0",
-        "can-stache-key": "^0.0.2",
-        "can-symbol": "^1.0.0-pre.0",
-        "can-util": "^3.9.0-pre.4",
-        "can-view-callbacks": "^3.2.0-pre.0",
-        "can-view-live": "^3.2.0-pre.0",
-        "can-view-nodelist": "^3.1.0-pre.0",
-        "can-view-parser": "^3.4.0-pre.0",
-        "can-view-scope": "^3.3.0-pre.3",
-        "can-view-target": "^3.1.0-pre.0"
+        "can-observation": "^3.3.1",
+        "can-reflect": "^1.13.3",
+        "can-route": "^3.3.3",
+        "can-stache-key": "^0.1.2",
+        "can-symbol": "^1.0.0",
+        "can-util": "^3.14.0",
+        "can-view-callbacks": "^3.2.0",
+        "can-view-live": "^3.2.0",
+        "can-view-nodelist": "^3.1.0",
+        "can-view-parser": "^3.8.1",
+        "can-view-scope": "^3.6.0",
+        "can-view-target": "^3.1.0"
+      },
+      "dependencies": {
+        "can-stache-key": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/can-stache-key/-/can-stache-key-0.1.4.tgz",
+          "integrity": "sha512-PqCfO7XHnGX+Tl8/oqS3oTuf5adpuGRQ/kt+r4aAQWqjhvcc40GK0VF9/uQukJn3+raUlj/dZldYap0XM27f4g==",
+          "requires": {
+            "can-cid": "^1.0.0",
+            "can-event": "^3.5.0",
+            "can-log": "^1.0.0",
+            "can-namespace": "1.0.0",
+            "can-observation": "^3.3.0",
+            "can-reflect": "^1.1.0",
+            "can-reflect-promise": "^1.1.0",
+            "can-symbol": "^1.0.0",
+            "can-util": "^3.9.0"
+          }
+        }
       }
     },
     "can-stache-bindings": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "can-model": "3.1.0",
     "can-route": "3.3.4",
     "can-simple-observable": "2.4.1",
-    "can-stache": "3.2.0",
+    "can-stache": "^3.15.1",
     "can-util": "^3.14.0",
     "can-validate-legacy": "2.0.0",
     "can-view-model": "3.5.2",

--- a/src/ggrc-client/js/components/assessment/assessments-local-custom-attributes/assessments-local-custom-attributes.stache
+++ b/src/ggrc-client/js/components/assessment/assessments-local-custom-attributes/assessments-local-custom-attributes.stache
@@ -17,15 +17,15 @@
           </label>
           <div class="popover-component__container">
             <popover-component
-              header:from="popovers.relObjectsHeader(@index)"
-              content:from="popovers.relObjectsContent(@index)"
+              header:from="popovers.relObjectsHeader(scope.index)"
+              content:from="popovers.relObjectsContent(scope.index)"
             >
               <i class="fa fa-question-circle" data-popover-trigger></i>
             </popover-component>
             {{#if relatedAnswers.length}}
               <popover-component
-                header:from="popovers.relAnswersHeader(@index)"
-                content:from="popovers.relAnswersContent(@index)"
+                header:from="popovers.relAnswersHeader(scope.index)"
+                content:from="popovers.relAnswersContent(scope.index)"
               >
                 <i class="fa fa-exclamation-circle" data-popover-trigger></i>
               </popover-component>
@@ -41,13 +41,13 @@
         fieldId:from="id"
         placeholder:from="placeholder"
         options:from="multiChoiceOptions.values"
-        on:vm:valueChanged="fieldValueChanged(scope.event.value, @index)"
+        on:vm:valueChanged="fieldValueChanged(scope.event.value, scope.index)"
         class="form-field__content {{getFieldClass(type)}}" />
       {{#if attachments}}
         <div class="form-field__validation-hint-placeholder">
           <button type="button"
             class="btn btn-small btn-link btn-link-nopadding"
-            on:el:click="updateRequiredInfo(@index)">
+            on:el:click="updateRequiredInfo(scope.index)">
             {{#if validation.hasMissingInfo}}
               Add required info
             {{else}}

--- a/src/ggrc-client/js/components/import-export/download-template/download-template.stache
+++ b/src/ggrc-client/js/components/import-export/download-template/download-template.stache
@@ -52,12 +52,12 @@
             <div>
               <autocomplete-component searchItemsType:from="'AssessmentTemplate'"
                                       extraCssClass:from="'search-icon'"
-                                      on:vm:itemSelected="selectTemplate(scope.event.selectedItem, @index)"
-                                      on:vm:itemErased="eraseTemplate(@index)"
+                                      on:vm:itemSelected="selectTemplate(scope.event.selectedItem, scope.index)"
+                                      on:vm:itemErased="eraseTemplate(scope.index)"
                                       placeholder:from="'Enter text to search for Assessment Template'"
                                       class="autocomplete__large">
               </autocomplete-component>
-              <i class="fa fa-trash-o" on:el:click="removeTemplate(@index)"></i>
+              <i class="fa fa-trash-o" on:el:click="removeTemplate(scope.index)"></i>
             </div>
             {{#if isDuplicate}}
               <div class="download-template__template-error">

--- a/src/ggrc-client/js/components/import-export/templates/export-group.stache
+++ b/src/ggrc-client/js/components/import-export/templates/export-group.stache
@@ -10,7 +10,7 @@
       <div class="new-relevant-block">
         <export-panel type:from="type"
                       item:from="{.}"
-                      panel_index:from="@index"
+                      panel_index:from="scope.index"
                       removable:from="isRemovable">
        </export-panel>
      </div>

--- a/src/ggrc-client/js/components/import-export/templates/relevant-filter.stache
+++ b/src/ggrc-client/js/components/import-export/templates/relevant-filter.stache
@@ -14,16 +14,16 @@
 {{#each relevant}}
   <div class="single-line-filter">
     {{^if readOnly}}
-      <i class="fa fa-trash" on:el:click="removeFilter(scope.element, @index)"></i>
+      <i class="fa fa-trash" on:el:click="removeFilter(scope.element, scope.index)"></i>
     {{/if}}
-    {{#if @index}}
+    {{#if scope.index}}
       <dropdown-component optionsList:from="operators"
                 name:bind="operator"
                 class="inline-block">
       </dropdown-component>
     {{/if}}
     Mapped to:
-    <select class="filter-type-selector select-filter{{@index}}"
+    <select class="filter-type-selector select-filter{{scope.index}}"
             {{#if readOnly}}disabled="disabled"{{/if}}
             el:value:bind="model_name">
       {{#menu}}
@@ -41,11 +41,11 @@
           <div class="modal-search objective-selector">
             <input
               {{#if readOnly}}disabled="disabled"{{/if}}
-              class="input-large search-icon search-filter-{{@index}}"
+              class="input-large search-icon search-filter-{{scope.index}}"
               placeholder="Enter text to search for {{model_name}}"
               type="text"
-              data-index="{{@index}}"
-              name="filter_list.{{@index}}.filter"
+              data-index="{{scope.index}}"
+              name="filter_list.{{scope.index}}.filter"
               value="{{firstnonempty filter.name filter.email filter.title}}"
               data-lookup="{{this}}"
               data-template="/{{#is(model_name, 'Person')}}people{{else}}base_objects{{/is}}/autocomplete-result.stache"

--- a/src/ggrc-client/js/components/required-info-modal/required-info-modal.stache
+++ b/src/ggrc-client/js/components/required-info-modal/required-info-modal.stache
@@ -44,7 +44,7 @@
                 </div>
               </div>
               <div class="action-toolbar__controls">
-                <a href="javascript:void(0)" on:el:click="removeItemByIndex('filesList', @index)">
+                <a href="javascript:void(0)" on:el:click="removeItemByIndex('filesList', scope.index)">
                   <div class="action-toolbar__controls-item">
                     <i class="fa fa-trash"></i>
                   </div>
@@ -80,7 +80,7 @@
                 </div>
               </div>
               <div class="action-toolbar__controls">
-                <a on:el:click="removeItemByIndex('urlsList', @index)">
+                <a on:el:click="removeItemByIndex('urlsList', scope.index)">
                   <div class="action-toolbar__controls-item">
                     <i class="fa fa-trash"></i>
                   </div>

--- a/src/ggrc-client/js/components/unified-mapper/templates/mapper-results.stache
+++ b/src/ggrc-client/js/components/unified-mapper/templates/mapper-results.stache
@@ -48,7 +48,7 @@
     <div class="list-body {{#isLoading}}loading{{/isLoading}}">
       <object-list items:from="items" isLoading:from="isLoading" listType:from="'GRID'">
         <mapper-results-item class="{{#relatedAssessments.show}}has-related-assessments{{/relatedAssessments.show}}"
-                             itemData:from="data"
+                             itemData:from="this.data"
                              searchOnly:from="searchOnly"
                              selectedColumns:from="columns.selected"
                              serviceColumns:from="columns.service"

--- a/src/ggrc-client/js/components/workflow/task-group-objects/templates/task-group-objects.stache
+++ b/src/ggrc-client/js/components/workflow/task-group-objects/templates/task-group-objects.stache
@@ -21,7 +21,7 @@
         <a
           class="task-group-objects__unmap {{#if disabled}}disabled{{/if}}"
           href="javascript://"
-          data-item-index="{{@index}}">
+          data-item-index="{{scope.index}}">
           <i class="fa fa-trash"></i>
         </a>
          <spinner-component class="control-offset" toggle:from="unmapping" />

--- a/src/ggrc-client/js/plugins/console-interceptor.js
+++ b/src/ggrc-client/js/plugins/console-interceptor.js
@@ -15,7 +15,10 @@ const hideTemplates = [
   'can-component: Assigning a DefineMap or constructor type',
   'No property found for handling',
   'Dispatching a synthetic event on a disabled is problematic in FireFox',
-  'canStache/src/expression.js: Unable to find key or helper',
+  'is not in the current scope, so it is being read from a parent scope.',
+  'is deprecated. Use',
+  'is being called as a function.',
+  'Unable to find key or helper',
 ];
 
 const isHidden = function (text) {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

During the implementation of "Bulk Complete" epic, we needed to render the list of items. For now, "stache" mechanism allows us to use only deprecated syntax of #each helper (as was in CanJs v2) which is quite unclear in some situations. 
Need to investigate possibility to use new version of #each helper (#each(expression)) which'll allow us to iterate through the list items and explicitly give the name for each item (for now, we need to use . expression in order to get the current item of the list).
Doc with the new syntax: https://v3.canjs.com/doc/can-stache.helpers.each.html

# Steps to test the changes

1. Launch GGRC.
2. Open any tab or any object.
3. It works correctly.

# Solution description

Updated can-stache to the latest version. Now we can use `{{helper (expression, hash_expression)}}` or `{{helper expression, hash_expression)}}`.

In hash_expression we can use next options:
- current item of iteration = value
- current key value of iteration if we iterate through object = key
- current index if we iterate through array = index

It improves readability of ours code:

`list: [{`
`title: 'title1',`
`description: 'description1,`
`}, {`
`title: 'title2',`
`description: 'description1,`
`}]`
### old helper's syntax 
`{{#each list}}`
`<li>`
`<p>{{name}}</p>`
`<p>{{description}}</p>`
`</li>`
`{{/each}}`
### new helper's syntax
`{{#each (list, item=value)}}`
`<li>`
`<p>{{item.name}}</p>`
`<p>{{item.description}}</p>`
`</li>`
`{{/each}}`

Old syntax also works correctly.
# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
