### PR TITLE
GGRC-8213 Snapshot icons are displayed for Global Creator with no rights in Audit

### DIFF
--- a/src/ggrc/services/resources/audit.py
+++ b/src/ggrc/services/resources/audit.py
@@ -6,11 +6,12 @@
 When Audit-Snapshottable Relationship is POSTed, a Snapshot should be created
 instead.
 """
+import collections
 from collections import defaultdict
 
 import sqlalchemy as sa
 
-from werkzeug.exceptions import Forbidden
+from werkzeug import exceptions
 
 from ggrc import db
 from ggrc import models
@@ -46,7 +47,7 @@ class AuditResource(mixins.SnapshotCounts, common.ExtendedResource):
     with benchmark("check audit permissions"):
       audit = models.Audit.query.get(id)
       if not permissions.is_allowed_read_for(audit):
-        raise Forbidden()
+        raise exceptions.Forbidden()
     with benchmark("Get audit summary data"):
       #  evidence_relationship => evidence destination
       evidence_relationship_ds = db.session.query(
@@ -128,3 +129,19 @@ class AuditResource(mixins.SnapshotCounts, common.ExtendedResource):
       statuses_json.sort(key=lambda k: (k["name"], k["verified"]))
       response_object = {"statuses": statuses_json, "total": total}
       return self.json_success_response(response_object, )
+
+  def snapshot_counts_query(self, id):
+    """Get data for audit mapped objects counts grouped by child_type."""
+    # id name is used as a kw argument and can't be changed here
+    # pylint: disable=invalid-name,redefined-builtin
+
+    with benchmark("Check audit permissions"):
+      obj = self.model.query.get(id)
+      if not obj:
+        raise exceptions.NotFound()
+      if not permissions.is_allowed_read_for(obj):
+        raise exceptions.Forbidden()
+
+    result = collections.Counter([snap.child_type for snap in obj.snapshots
+                                  if permissions.is_allowed_read_for(snap)])
+    return self.json_success_response(result)

--- a/src/ggrc/services/resources/audit.py
+++ b/src/ggrc/services/resources/audit.py
@@ -142,6 +142,7 @@ class AuditResource(mixins.SnapshotCounts, common.ExtendedResource):
       if not permissions.is_allowed_read_for(obj):
         raise exceptions.Forbidden()
 
-    result = collections.Counter([snap.child_type for snap in obj.snapshots
-                                  if permissions.is_allowed_read_for(snap)])
+    with benchmark("Get snapshots count based on read permissions"):
+      result = collections.Counter([snap.child_type for snap in obj.snapshots
+                                    if permissions.is_allowed_read_for(snap)])
     return self.json_success_response(result)

--- a/test/integration/ggrc/services/resources/test_audit.py
+++ b/test/integration/ggrc/services/resources/test_audit.py
@@ -8,6 +8,8 @@ import ddt
 
 from ggrc.models import all_models
 from integration.ggrc import api_helper
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
 from integration.ggrc.models import factories
 from integration.ggrc.services import TestCase
 
@@ -19,6 +21,13 @@ class TestAuditResource(TestCase):
   def setUp(self):
     super(TestAuditResource, self).setUp()
     self.api = api_helper.Api()
+
+  def _get_snapshots_count(self, object_id):
+    """Get snapshots count for Audit with id {object_id}"""
+    response = self.api.client.get(
+        "/api/audits/{}/snapshot_counts".format(object_id),
+    )
+    return json.loads(response.data)
 
   def test_snapshot_counts_query(self):
     """Test snapshot_counts endpoint"""
@@ -33,35 +42,8 @@ class TestAuditResource(TestCase):
       )
       audit_2 = factories.AuditFactory()
 
-    with factories.single_commit():
-      revision = all_models.Revision.query.filter(
-          all_models.Revision.resource_type == "Audit",
-          all_models.Revision.resource_id == audit_1.id
-      ).first()
-      revision_2 = all_models.Revision.query.filter(
-          all_models.Revision.resource_type == "Audit",
-          all_models.Revision.resource_id == audit_2.id
-      ).first()
-      snapshot = factories.SnapshotFactory(
-          parent=audit_1,
-          child_type=control.type,
-          child_id=control.id,
-          revision=revision
-      )
-      factories.RelationshipFactory(
-          source=audit_1,
-          destination=snapshot,
-      )
-      snapshot2 = factories.SnapshotFactory(
-          parent=audit_2,
-          child_type=regulation.type,
-          child_id=regulation.id,
-          revision=revision_2
-      )
-      factories.RelationshipFactory(
-          source=audit_2,
-          destination=snapshot2,
-      )
+    self._create_snapshots(audit_1, [control])
+    self._create_snapshots(audit_2, [regulation])
 
     audits = [audit_1, audit_2]
     expected_snapshot_counts = {
@@ -70,8 +52,55 @@ class TestAuditResource(TestCase):
     }
 
     for audit in audits:
-      response = self.api.client.get(
-          "/api/audits/{}/snapshot_counts".format(audit.id),
-      )
-      snapshot_counts = json.loads(response.data)
+      snapshot_counts = self._get_snapshots_count(audit.id)
       self.assertEqual(snapshot_counts, expected_snapshot_counts[audit.id])
+
+  # pylint:disable=invalid-name
+  def test_snapshot_counts_query_no_perm(self):
+    """Test snapshot_counts endpoint counts only Snapshots that user has
+    access to"""
+
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      assmnt = factories.AssessmentFactory(audit=audit)
+      factories.RelationshipFactory(source=audit, destination=assmnt)
+      audit_id = audit.id
+
+      # Create Global Creator and assign as Assignees
+      user = factories.PersonFactory()
+      reader_role = all_models.Role.query.filter(
+          all_models.Role.name == "Creator").first()
+      rbac_factories.UserRoleFactory(role=reader_role, person=user)
+      acr = all_models.AccessControlRole.query.filter_by(
+          name="Assignees",
+          object_type=assmnt.type,
+      ).first()
+      factories.AccessControlPersonFactory(
+          person_id=user.id,
+          ac_list=assmnt.acr_acl_map[acr],
+      )
+
+      control_1 = factories.ControlFactory()
+      control_2 = factories.ControlFactory()
+      regulation = factories.RegulationFactory()
+      factories.RelationshipFactory(
+          source=audit,
+          destination=control_1
+      )
+
+    snapshots = self._create_snapshots(audit, [control_1,
+                                               control_2,
+                                               regulation])
+    factories.RelationshipFactory(
+        source=assmnt,
+        destination=snapshots[0]
+    )
+
+    self.api.set_user(user)
+
+    expected_snapshot_counts = {
+        audit_id: {"Control": 1},
+    }
+
+    snapshot_counts = self._get_snapshots_count(audit_id)
+    self.assertEqual(expected_snapshot_counts[audit_id], snapshot_counts)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Snapshot icons are displayed for Global Creator with no rights in Audit

# Steps to test the changes

Precondition:

As Admin create an Audit
Attach several snapshots of objectives, e.g. Controls, Regulations, Vendors
Create an Assessment with mapped Control snapshot
Assign Global Creator as Assignee
Steps to Reproduce:

Login as Global Creator to GGRC
Open a previously created Audit
Check snapshots icons display
Actual result: Controls, Regulations, Vendors snapshot icons are displayed on the panel for Global Creator. The snapshots are not visible to Global Creator except the mapped Control to the Assessment where GC user is assigned

Expected: Only a Control snapshot icon should be visible to a Global Creator, other snapshot icons shouldn't be displayed

# Solution description

Count only Snapshots that user able to read

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
