### PR TITLE
GGRC-8231 Add external Control attributes to Export page

### DIFF
--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -132,11 +132,6 @@ class Control(with_external_created_by.WithExternalCreatedBy,
           "due_date",
           "due_date",
       ),
-      attributes.FullTextAttr(
-          "created_by",
-          "created_by",
-          ["email", "name"],
-      ),
       attributes.DatetimeFullTextAttr(
           "last_submitted_at",
           "last_submitted_at",

--- a/src/ggrc/models/control.py
+++ b/src/ggrc/models/control.py
@@ -127,6 +127,34 @@ class Control(with_external_created_by.WithExternalCreatedBy,
       'verify_frequency',
       'version',
       'review_status_display_name',
+
+      attributes.DateFullTextAttr(
+          "due_date",
+          "due_date",
+      ),
+      attributes.FullTextAttr(
+          "created_by",
+          "created_by",
+          ["email", "name"],
+      ),
+      attributes.DatetimeFullTextAttr(
+          "last_submitted_at",
+          "last_submitted_at",
+      ),
+      attributes.FullTextAttr(
+          "last_submitted_by",
+          "last_submitted_by",
+          ["email", "name"],
+      ),
+      attributes.DatetimeFullTextAttr(
+          "last_verified_at",
+          "last_verified_at",
+      ),
+      attributes.FullTextAttr(
+          "last_verified_by",
+          "last_verified_by",
+          ["email", "name"],
+      )
   ]
 
   _sanitize_html = [
@@ -166,6 +194,27 @@ class Control(with_external_created_by.WithExternalCreatedBy,
       "review_status_display_name": {
           "display_name": "Review Status",
           "mandatory": False
+      },
+
+      "due_date": {
+          "display_name": "Due Date",
+          "mandatory": False,
+      },
+      "last_submitted_at": {
+          "display_name": "Last Owner Reviewed Date",
+          "mandatory": False,
+      },
+      "last_submitted_by": {
+          "display_name": "Last Owner Reviewed By",
+          "mandatory": False,
+      },
+      "last_verified_at": {
+          "display_name": "Last Compliance Reviewed Date",
+          "mandatory": False,
+      },
+      "last_verified_by": {
+          "display_name": "Last Compliance Reviewed By",
+          "mandatory": False,
       },
   }
 

--- a/src/ggrc/models/risk.py
+++ b/src/ggrc/models/risk.py
@@ -114,20 +114,23 @@ class Risk(with_external_created_by.WithExternalCreatedBy,
       'threat_event',
       'vulnerability',
       'review_status_display_name',
-      attributes.DateFullTextAttr('due_date', 'due_date'),
-      attributes.DatetimeFullTextAttr('last_submitted_at',
-                                      'last_submitted_at'),
-      attributes.DatetimeFullTextAttr('last_verified_at',
-                                      'last_verified_at'),
-      attributes.FullTextAttr(
-          "created_by",
-          "created_by",
-          ["email", "name"]
+
+      attributes.DateFullTextAttr(
+          'due_date',
+          'due_date',
+      ),
+      attributes.DatetimeFullTextAttr(
+          'last_submitted_at',
+          'last_submitted_at',
       ),
       attributes.FullTextAttr(
           "last_submitted_by",
           "last_submitted_by",
           ["email", "name"]
+      ),
+      attributes.DatetimeFullTextAttr(
+          'last_verified_at',
+          'last_verified_at',
       ),
       attributes.FullTextAttr(
           "last_verified_by",

--- a/test/integration/ggrc/converters/test_export_snapshots.py
+++ b/test/integration/ggrc/converters/test_export_snapshots.py
@@ -116,7 +116,13 @@ class TestExportSnapshots(TestCase):
                     "Other Contacts": u"",
                     "Principal Assignees": u"",
                     "Secondary Assignees": u"",
-                    "Admin": u""}
+                    "Admin": u"",
+                    "Due Date": u"",
+                    "Created By": u"",
+                    "Last Owner Reviewed Date": u"",
+                    "Last Owner Reviewed By": u"",
+                    "Last Compliance Reviewed Date": u"",
+                    "Last Compliance Reviewed By": u""}
     control_dict.update(new_values)
     return control_dict
 

--- a/test/integration/ggrc/converters/test_import_helpers.py
+++ b/test/integration/ggrc/converters/test_import_helpers.py
@@ -653,7 +653,12 @@ class TestGetObjectColumnDefinitions(TestCase):
         "Last Updated Date",
         "Last Updated By",
         "GDrive Folder ID",
+        "Due Date",
         "Created By",
+        "Last Owner Reviewed Date",
+        "Last Owner Reviewed By",
+        "Last Compliance Reviewed Date",
+        "Last Compliance Reviewed By",
     }
 
     # Control has additional mandatory field - Assertions

--- a/test/integration/ggrc/converters/test_snapshot_block.py
+++ b/test/integration/ggrc/converters/test_snapshot_block.py
@@ -86,6 +86,7 @@ class TestSnapshotBlockConverter(TestCase):
         ('test_plan', 'Assessment Procedure'),
         ('start_date', 'Effective Date'),
         ('end_date', 'Last Deprecated Date'),
+        ('due_date', 'Due Date'),
         ('archived', 'Archived'),
         ('status', 'State'),
         ('review_status_display_name', 'Review Status'),
@@ -103,7 +104,10 @@ class TestSnapshotBlockConverter(TestCase):
         ('created_at', 'Created Date'),
         ('folder', "GDrive Folder ID"),
         ('created_by', 'Created By'),
-
+        ('last_submitted_at', 'Last Owner Reviewed Date'),
+        ('last_submitted_by', 'Last Owner Reviewed By'),
+        ('last_verified_at', 'Last Compliance Reviewed Date'),
+        ('last_verified_by', 'Last Compliance Reviewed By'),
     ]
     ac_roles = db.session.query(all_models.AccessControlRole.name).filter(
         all_models.AccessControlRole.object_type == "Control",


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Following Q-side Control attributes should be displayed on UI on Control- and Export pages.

1. _"Created By"_;
2. _"Due Date"_;
3. _"Last Owner Reviewed Date"_;
4. _"Last Owner Reviewed By"_;
5. _"Last Compliance Reviewed Date"_;
6. _"Last Compliance Reviewed By"_.

# Steps to test the changes

1. Login in GGRC application;
2. Go on Export page and select "Control" in "Object type" dropdown;
3. See that all described attributes are present there.

# Solution description

The specified attributes already exist on Control model in GGRC Back-End, but they weren't added to `Control._aliases` and `Control._fulltext_attrs`. This is needed for these attributes to be shown on Export page and to allow the search of Controls by these attributes for further export.

Field names on `Control` model:
 - `created_by` ("Created By");
 - `due_date` ("Due Date");
 - `last_submitted_at` ("Last Owner Reviewed Date");
 - `last_submitted_by` ("Last Owner Reviewed By");
 - `last_verified_at` ("Last Compliance Reviewed Date");
 - `last_verified_by` ("Last Compliance Reviewed By").

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
