### PR TITLE
GGRC-7229 Count of Active workflow are not the same on My dashboard and LHN

### DIFF
--- a/src/ggrc/migrations/versions/20191210_a35b27563863_update_state_for_invalid_workflows.py
+++ b/src/ggrc/migrations/versions/20191210_a35b27563863_update_state_for_invalid_workflows.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Update state for invalid workflows.
+
+Create Date: 2019-12-10 12:32:50.253923
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+
+from alembic import op
+
+from ggrc.migrations import utils
+
+
+# revision identifiers, used by Alembic.
+revision = 'a35b27563863'
+down_revision = '55984900c508'
+
+
+def get_workflows_without_active_cycles(conn):
+  """Get workflows with no active cycles"""
+
+  res = conn.execute("""
+    SELECT id
+    FROM workflows
+    WHERE status='Active'
+    AND NOT EXISTS (
+    SELECT 1
+      FROM cycles
+      WHERE cycles.workflow_id = workflows.id)
+  """)
+
+  ids = [workflow[0] for workflow in res.fetchall()]
+  return ids
+
+
+def update_workflows():
+  """Update workflow status to Inactive to all wf without cycles."""
+
+  res = op.execute("""
+      UPDATE workflows
+      SET status='Inactive'
+      WHERE status='Active'
+      AND NOT EXISTS (
+      SELECT 1
+        FROM cycles
+        WHERE cycles.workflow_id = workflows.id)
+    """)
+
+  return res
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+
+  conn = op.get_bind()
+  ids = get_workflows_without_active_cycles(conn)
+  utils.add_to_objects_without_revisions_bulk(
+      conn, ids, obj_type="Workflow", action="modified"
+  )
+  update_workflows()
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Fix changes logic for wf status changes via api calls, adds migration which cleans db from wf with wrong 'Active" status by making a revision and changing the status without removing such objects.

# Steps to test the changes

1. in dev: using dump db, check count of active workflows in My dashboard and LHN.
expected - different number
2. Log in as globcreator@gmail com
3. in branch GGRC-7229 do the same, expected - numbers are equal

# Solution description

in order to forbid incorrect status changes via api calls, new checks were added. To fix currently existing wf with incorrect statuses (f.e. Active wf with no task groups and no tasks) new migration was added, that cleans db of such workflows without removing objects.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
