### PR TITLE
GGRC-8251 Replace Deferred with Promise part 7

### DIFF
--- a/src/ggrc-client/js/components/delete-button/delete-button.js
+++ b/src/ggrc-client/js/components/delete-button/delete-button.js
@@ -54,12 +54,14 @@ export default canComponent.extend({
 
         new ModalsController($target, modalSettings);
         $target.on('click', '[data-toggle="delete"]', () => {
-          const dfd = this.onConfirm();
+          const promise = new Promise((resolve) => {
+            this.onConfirm().then(resolve);
+          });
 
-          bindXHRToButton(dfd, $target.find('[data-dismiss="modal"]'));
-          bindXHRToButton(dfd, $target.find('[data-toggle="delete"]'));
+          bindXHRToButton(promise, $target.find('[data-dismiss="modal"]'));
+          bindXHRToButton(promise, $target.find('[data-toggle="delete"]'));
 
-          dfd.always(() => {
+          promise.finally(() => {
             $target.modal('hide').remove();
           });
         }).on('click.modal-form.close', '[data-dismiss="modal"]', () => {

--- a/src/ggrc-client/js/components/gdrive/ggrc-gdrive-picker-launcher.js
+++ b/src/ggrc-client/js/components/gdrive/ggrc-gdrive-picker-launcher.js
@@ -103,23 +103,20 @@ export default canComponent.extend({
 
     trigger_upload_parent: function (scope, el) {
       // upload files with a parent folder (audits and workflows)
-      let parentFolderDfd;
-      let folderId;
+      const promise = new Promise((resolve) => {
+        if (this.instance.attr('_transient.folder')) {
+          resolve({instance: this.instance.attr('_transient.folder')});
+        } else {
+          const folderId = this.instance.attr('folder');
+          resolve(findGDriveItemById(folderId));
+        }
+      });
 
-      if (this.instance.attr('_transient.folder')) {
-        parentFolderDfd = $.when(
-          [{instance: this.instance.attr('_transient.folder')}]
-        );
-      } else {
-        folderId = this.instance.attr('folder');
+      bindXHRToButton(promise, el);
 
-        parentFolderDfd = findGDriveItemById(folderId);
-      }
-      bindXHRToButton(parentFolderDfd, el);
-
-      return parentFolderDfd
-        .done((parentFolder) => this.uploadParentHelper(parentFolder, scope))
-        .fail(() => {
+      return promise
+        .then((parentFolder) => this.uploadParentHelper(parentFolder, scope))
+        .catch(() => {
           $(el).trigger('ajax:flash', {
             warning: 'Can\'t upload: No GDrive folder found',
           });

--- a/src/ggrc-client/js/controllers/modals/archive-modal-controller.js
+++ b/src/ggrc-client/js/controllers/modals/archive-modal-controller.js
@@ -16,19 +16,26 @@ export default ModalsController.extend({
   },
   'a.btn[data-toggle=archive]:not(:disabled) click': function (el) {
     // Disable the cancel button.
-    let cancelButton = this.element.find('a.btn[data-dismiss=modal]');
+    let cancelButton = this.element.find('a[data-dismiss=modal]');
     let modalBackdrop = this.element.data('modal_form').$backdrop;
-    const dfd = this.options.instance.refresh();
+    const promise = new Promise(async (resolve, reject) => {
+      try {
+        await this.options.instance.refresh();
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
     bindXHRToButton(
-      this.notifyArchivingResult(dfd),
+      this.notifyArchivingResult(promise),
       el.add(cancelButton).add(modalBackdrop)
     );
   },
-  notifyArchivingResult(dfd) {
-    return dfd
+  notifyArchivingResult(promise) {
+    return promise
       .then(() => this.archive())
       .then(() => this.displaySuccessNotify())
-      .fail((xhr, status) => {
+      .catch((xhr, status) => {
         this.displayErrorNotify(xhr, status);
       });
   },

--- a/src/ggrc-client/js/plugins/tests/utils/modal_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/modal_spec.js
@@ -3,98 +3,64 @@
   Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
-import {bindXHRToButton} from '../../utils/modals';
+import * as ModalsUtils from '../../utils/modals';
 
 describe('modal utils', () => {
   describe('bindXHRToButton() method', () => {
-    let dfd;
+    let element;
+    let actualInnerHtml;
+    let promise;
 
     beforeEach(() => {
-      dfd = new $.Deferred();
+      actualInnerHtml = 'actualInnerHtml';
+      element = $('<button>' + actualInnerHtml + '</button>');
+      promise = new Promise(() => {});
     });
 
-    const callBindXHRToButton = (done, actualInnerHtml, newtext, disable) => {
-      let element = $('<button>' + actualInnerHtml + '</button>');
+    it('sets true to "disabled" attribute', () => {
+      expect(element[0].disabled).toBe(false);
 
-      // call bindXHRToButton()
-      bindXHRToButton(dfd, element, newtext, disable);
+      ModalsUtils.bindXHRToButton(promise, element, 'newtext');
 
-      // button should have 'disabled' class after call bindXHRToButton
-      expect(element.hasClass('disabled')).toEqual(true);
-
-      if (disable) {
-        // button should have 'disabled' attr after call bindXHRToButton
-        expect(element.attr('disabled')).toEqual('disabled');
-      }
-
-      if (newtext) {
-        // button should have 'newText' before dfd.resolve()
-        expect(element[0].innerHTML).toEqual(newtext);
-      }
-
-      dfd.then(
-        setTimeout(() => {
-          expect(element[0].innerHTML).toEqual(actualInnerHtml);
-
-          // button should not have 'disabled' class after dfd.resolve()
-          expect(element.hasClass('disabled')).toEqual(false);
-
-          if (disable) {
-            // button should not have 'disabled' attr after call bindXHRToButton
-            expect(element.attr('disabled')).toEqual(undefined);
-          }
-          done();
-        }, 3)
-      );
-
-      dfd.resolve();
-    };
-
-    it('bindXHRToButton() should save text of button', (done) => {
-      callBindXHRToButton(done, 'HELLO WORLD');
+      expect(element[0].disabled).toBe(true);
     });
 
-    it('bindXHRToButton() should save icon inside button', (done) => {
-      callBindXHRToButton(done, '<i class="fa fa-icon"></i>');
+    it('adds "disabled" class to element', () => {
+      expect(element[0].getAttribute('class')).toBe(null);
+
+      ModalsUtils.bindXHRToButton(promise, element, 'newtext');
+
+      expect(element[0].getAttribute('class')).toBe('disabled');
     });
 
-    it('bindXHRToButton() should save icon and text inside button', (done) => {
-      callBindXHRToButton(done, '<i class="fa fa-icon"></i>My text');
+    it('add new text inside element', () => {
+      expect(element[0].innerHTML).toBe('actualInnerHtml');
+
+      ModalsUtils.bindXHRToButton(promise, element, 'newtext');
+
+      expect(element[0].innerHTML).toBe('newtext');
     });
 
-    it('bindXHRToButton() should save text of button. Disable button',
-      (done) => {
-        callBindXHRToButton(done, 'HELLO WORLD', '', true);
-      }
-    );
+    it('sets false to "disabled" attribute after promise has resolved',
+      async () => {
+        await ModalsUtils
+          .bindXHRToButton(Promise.resolve(), element, 'newtext');
 
-    it('bindXHRToButton() should save icon inside button. New text',
-      (done) => {
-        callBindXHRToButton(done, '<i class="fa fa-icon"></i>', 'My new text');
-      }
-    );
+        expect(element[0].disabled).toBe(false);
+      });
 
-    it('bindXHRToButton() should save text of button. New text. Disable button',
-      (done) => {
-        callBindXHRToButton(done, 'HELLO WORLD', '<i class="fa"></i>', true);
-      }
-    );
+    it('removes class "disabled" attribute after promise has resolved',
+      async () => {
+        await ModalsUtils
+          .bindXHRToButton(Promise.resolve(), element, 'newtext');
 
-    it('bindXHRToButton() should resolve empty element', (done) => {
-      let element = $('');
+        expect(element[0].getAttribute('class')).toBe('');
+      });
 
-      // call bindXHRToButton()
-      bindXHRToButton(dfd, element);
+    it('saves text inside element', async () => {
+      await ModalsUtils.bindXHRToButton(Promise.resolve(), element, 'newtext');
 
-      dfd.then(
-        setTimeout(() => {
-          // button should not have 'disabled' class after dfd.resolve()
-          expect(element.hasClass('disabled')).toEqual(false);
-          done();
-        }, 3)
-      );
-
-      dfd.resolve();
+      expect(element[0].innerHTML).toBe(actualInnerHtml);
     });
   });
 });

--- a/src/ggrc-client/js/plugins/utils/modals.js
+++ b/src/ggrc-client/js/plugins/utils/modals.js
@@ -191,7 +191,7 @@ const bindXHRToButton = (xhr, el, newtext) => {
   }
   $el.addClass('disabled');
   $el.attr('disabled', true);
-  xhr.always(() => {
+  xhr.finally(() => {
     // If .text(str) is used instead of innerHTML, the click event may not fire depending on timing
     if ($el.length) {
       $el.removeAttr('disabled')
@@ -210,7 +210,8 @@ const bindXHRToDisableElement = (xhr, el) => {
   }
 
   $el.addClass('disabled');
-  xhr.always(() => {
+
+  xhr.finally(() => {
     $el.removeClass('disabled');
   });
 };


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

In scope of the migration to CanJS 3 also jQuery was updated to version 3. In version 3 some async changes were introduced for Deferred. It allows to start replacement for Deferred to Promise usages.

# Steps to test the changes

### bindXHRToButton & bindXHRToDisableElement utils.
1. archive-modal-controller
1.1 Create or open existing audit.
1.2 Click archive from tree-dotted menu.
1.3 Confirm archiving.
1.4 Expected: Archive button has been disabled.
2. delete-modal-controller
2.1 Open or create audit.
2.2 Click delete form tree-dotted menu.
2.3  Confirm delete. 
2.4 Expected: Delete button has been disabled.
3. delete-button
3.1 Open or create audit.
3.2 Map to audit snapshotable object.
3.3 Open info-pane of mapped object.
3.4 Open tree-dotted menu and click delete.
3.5 Confirm delete.
3.6 Expected: Delete button has been disabled.
4. ggrc-gdrive-picker-launcher.
4.1 Create audit and assessment.
4.2 Add to audit gdrive folder.
4.3 Open assessment and try to attach some files.
4.4 Expected: Attach button has been disabled.
5. modals-controller
5.1 Start creating new object.
5.2 Click Save & Close.
5.3 Expected: Save & Close and Save & Add another button has been disabled.
5.4 Start creating new object.
5.5 Click Save & Add another.
5.6 Expected: Save & Close and Save & Add another button has been disabled.

# Solution description

Replace Deferred with Promise.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
