### PR TITLE
GGRC-8284 Confirm user cannot add comment to Risk

### DIFF
--- a/test/selenium/src/lib/constants/objects.py
+++ b/test/selenium/src/lib/constants/objects.py
@@ -177,5 +177,4 @@ def get_obj_type(obj_name):
 EXTERNAL_END_POINTS = [get_singular(x) for x
                        in DISABLED_OBJECTS + (EXTERNAL_CUSTOM_ATTRIBUTES,)]
 
-SINGULAR_TITLE_DISABLED_OBJS = [
-    get_singular(x, title=True) for x in DISABLED_OBJECTS]
+SINGULAR_DISABLED_OBJS = [get_singular(x) for x in DISABLED_OBJECTS]

--- a/test/selenium/src/lib/service/rest/client.py
+++ b/test/selenium/src/lib/service/rest/client.py
@@ -42,9 +42,9 @@ class RestClient(object):
   def is_relationship_types_external(self, obj_dict):
     """Check if source or destination objects type is external."""
     return (self.endpoint == objects.get_singular(objects.RELATIONSHIPS) and
-            (any(x for x in objects.SINGULAR_TITLE_DISABLED_OBJS
-                 if x in (obj_dict["source"]["type"],
-                          obj_dict["destination"]["type"]))))
+            (any(x for x in objects.SINGULAR_DISABLED_OBJS
+                 if x.title() in (obj_dict["source"]["type"],
+                                  obj_dict["destination"]["type"]))))
 
   def is_external_user_needed(self, obj_dict):
     """Return True if request related to controls or GCAs for controls."""

--- a/test/selenium/src/tests/test_disabled_objects.py
+++ b/test/selenium/src/tests/test_disabled_objects.py
@@ -149,10 +149,12 @@ class TestDisabledObjects(base.Test):
                        "There should be no 'Request Review button.")
     soft_assert.assert_expectations()
 
-  def test_cannot_add_comment(self, control, soft_assert, selenium):
+  @pytest.mark.parametrize("obj", objects.SINGULAR_DISABLED_OBJS,
+                           indirect=True)
+  def test_cannot_add_comment(self, obj, soft_assert, selenium):
     """Check that user can't add a comment: input field is not displayed and
     "Add Comment" button opens a new browser tab."""
-    webui_facade.soft_assert_cannot_add_comment(soft_assert, control)
+    webui_facade.soft_assert_cannot_add_comment(soft_assert, obj)
     soft_assert.expect(
         webui_facade.are_tabs_urls_equal(), "Tabs urls should be equal.")
     soft_assert.assert_expectations()


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #9851 

# Issue description

Check that comments can not be added to Risk

# Steps to test the changes

# Solution description

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
