### PR TITLE
GGRC-8204 Add warning import Asmt SOX 302 column change

### DIFF
--- a/src/ggrc/converters/column_handlers.py
+++ b/src/ggrc/converters/column_handlers.py
@@ -4,23 +4,23 @@
 """
 This module provides all column handlers for objects in the ggrc module.
 
-If you want to add column handler you should decide is it handler default
+If you want to add column handler you should decide is it default handler
 or custom for current model.
 If this handler is default than you will add it into _COLUMN_HANDLERS dict in
 subdict by key "DEFAULT_HANDLERS_KEY"
-If this handler is custom for current model you shuld add it in COLUMN_HANDLERS
-dict by key "Model.__name__"
+If this handler is custom for current model you should add it in
+_COLUMN_HANDLERS dict by key "Model.__name__"
 
 You may add column handlers in your extensions.
 To make this you should add "EXTENSION_HANDLERS_ATTR" in __init__.py in your
-extenstion.
+extension.
 It should be callable or dict.
 If you want to add default handler you should add it in you
 extension_handlers_dict by key "DEFAULT_HANDLERS_KEY"
 If it is custom handler for current model, you should add it in
 your "EXTENSION_HANDLERS_ATTR" dict by key "Model.__name__"
 
-If you want to get hendler for your model
+If you want to get handler for your model
 call function model_column_handlers with you model class as argument.
 
 Example:
@@ -31,7 +31,7 @@ It returns all dict like:
         "column_2": HandlerClass2,
         ...
     }
-Thich contain handler for your Model.
+Which contain handler for your Model.
 """
 
 from copy import deepcopy
@@ -169,6 +169,7 @@ EXTENSION_HANDLERS_ATTR = "contributed_column_handlers"
 
 _COLUMN_HANDLERS = {
     DEFAULT_HANDLERS_KEY: _DEFAULT_COLUMN_HANDLERS_DICT,
+    "Assessment": {"sox_302_enabled": boolean.ReadOnlyCheckboxColumnHandler},
 }
 
 

--- a/src/ggrc/converters/errors.py
+++ b/src/ggrc/converters/errors.py
@@ -278,6 +278,6 @@ STATE_WILL_BE_IGNORED = (u"Line {line}: State will be set to 'In progress' "
 SNAPSHOT_IMPORT_ERROR = (u"Line {line}: Import for Snapshot object is not "
                          u"available in GGRC.")
 
-REVIEWABLE_WILL_BE_IGNORED = (u"Line {line}: Field '{column_name}' is "
-                              u"non-editable via import. The the "
-                              u"'{column_name}' column will be ignored.")
+READONLY_WILL_BE_IGNORED = (u"Line {line}: Field '{column_name}' is "
+                            u"non-editable via import. The "
+                            u"'{column_name}' column will be ignored.")

--- a/src/ggrc/converters/handlers/boolean.py
+++ b/src/ggrc/converters/handlers/boolean.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2020 Google Inc.
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Handlers for boolean attributes."""
+# pylint: disable=inconsistent-return-statements
 
 from logging import getLogger
 
@@ -31,7 +32,7 @@ class CheckboxColumnHandler(handlers.ColumnHandler):
     return self.raw_value.lower()
 
   def parse_item(self):
-    """ mandatory checkboxes will get evelauted to false on empty value """
+    """Mandatory checkboxes will get evaluated to false on empty value."""
     raw_value = self.raw_column_value
     if raw_value in self.TRUE_VALUES:
       return True
@@ -130,7 +131,7 @@ class StrictBooleanColumnHandler(CheckboxColumnHandler):
 
   You can sent only true, false, and empty string values.
   If you send true in model will send boolean True.
-  If you send false in model will send boolean Flase.
+  If you send false in model will send boolean False.
   If you send empty string, and model already exists column will be skipped.
   If you send empty string and not existing instance and column is mandatory,
   Will be raised exception.
@@ -141,3 +142,20 @@ class StrictBooleanColumnHandler(CheckboxColumnHandler):
   @property
   def raw_column_value(self):
     return self.raw_value.lower().strip()
+
+
+class ReadOnlyCheckboxColumnHandler(CheckboxColumnHandler):
+  """Handler for read-only columns"""
+
+  def _validate_item(self):
+    """Adds 'readonly will be ignored' warnings if new value unequal initial"""
+
+    if self.raw_value and self.raw_value != self.get_value():
+      self.add_warning(
+          errors.READONLY_WILL_BE_IGNORED,
+          column_name=self.display_name
+      )
+
+  def set_value(self):
+    """Set value for current column after validating."""
+    self._validate_item()

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -1082,7 +1082,7 @@ class ReviewableColumnHandler(ExportOnlyColumnHandler):
     """Adds 'ignored message' warnings if new value unequal initial"""
     if self.raw_value and self.raw_value != self.get_value():
       self.add_warning(
-          errors.REVIEWABLE_WILL_BE_IGNORED,
+          errors.READONLY_WILL_BE_IGNORED,
           column_name=self.display_name
       )
 

--- a/test/integration/ggrc/converters/test_import_reviewable.py
+++ b/test/integration/ggrc/converters/test_import_reviewable.py
@@ -42,7 +42,7 @@ class TestImportReviewable(TestCase):
     expected_response = {
         "Program": {
             "row_warnings": {
-                errors.REVIEWABLE_WILL_BE_IGNORED.format(
+                errors.READONLY_WILL_BE_IGNORED.format(
                     column_name="Review State", line=3),
             },
         }
@@ -275,9 +275,9 @@ class TestImportReviewable(TestCase):
     expected_response = {
         object_type: {
             "row_warnings": {
-                errors.REVIEWABLE_WILL_BE_IGNORED.format(
+                errors.READONLY_WILL_BE_IGNORED.format(
                     column_name="Review State", line=3),
-                errors.REVIEWABLE_WILL_BE_IGNORED.format(
+                errors.READONLY_WILL_BE_IGNORED.format(
                     column_name="Reviewers", line=3),
             },
         }


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

For now, it is possible to create sox-302 assessment, export it to sheets, change value in sox_302_enabled column and import it without any warning or errors about the changes in read-only column.

# Steps to test the changes

1. Create an AssessmentTemplate with sox_302_enabled.
2. Create an Assessment with new Template. 
3. Export Assessments to google sheets, open - in column sox_302_workflow must be "yes". 
4. Change it to "no" and try to import. Warning should be displayed, and you can proceed. The column would be ignored.
5. In case of creating an Assessment via import, you can't make it "sox_302_enabled" without template. With the existing template, value from the template will be used instead of value in Assessment sox_302_workflow column. If there is a contradiction, warning would be displayed.

# Solution description

In order to forbid such behaviour for assessments, but allow such a change for AssessmentTemplates, was created a new column handler and applied only for assessments. After consultation with BA, the warning message is showed to user and this column is ignored while importing assessments. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
