### PR TITLE
GGRC-8297 Fix issue when "my_work_count" GET request is duplicated when add comment on objects via info pane

### DIFF
--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -61,6 +61,7 @@ import router from '../../router';
 import {notifier} from '../../plugins/utils/notifiers-utils';
 import Cacheable from '../../models/cacheable';
 import Relationship from '../../models/service-models/relationship';
+import Comment from '../../models/service-models/comment';
 import * as businessModels from '../../models/business-models';
 import exportMessage from './templates/export-message.stache';
 import {isSnapshotType} from '../../plugins/utils/snapshot-utils';
@@ -325,7 +326,8 @@ let viewModel = canMap.extend({
     function onCreated(ev, instance) {
       if (activeTabModel === instance.type) {
         _refresh(true);
-      } else if (!(instance instanceof Relationship)) {
+      } else if (!(instance instanceof Relationship)
+      && !(instance instanceof Comment)) {
         _refreshCounts();
       }
     }

--- a/src/ggrc-client/js/controllers/info-widget-controller.js
+++ b/src/ggrc-client/js/controllers/info-widget-controller.js
@@ -129,7 +129,8 @@ export default canControl.extend({
 
   // timeout required to let server correctly calculate changed counts
   updateCounts: loDebounce((ev, instance) => {
-    if (/dashboard/.test(window.location)) {
+    // skip refresh for Comment as this object type isn't displayed in the menu
+    if (/dashboard/.test(window.location) && instance.type !== 'Comment') {
       refreshCounts();
     }
   }, 250),


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

`my_work_count` GET request is duplicated when add comment on objects via info pane

# Steps to test the changes
1. Login in tha GGRC app
2. Open My Dashboard
3. Open any object e.g Access Group
4. Open Network Tab in Crome dev tools
5. Add any comment
6. Verify number of `my_work_count` requests

# Solution description

Request `my_work_count` is sent after every instance created request. When add comments, `my_work_count` is sent after create Comment and Relationship objects that's why duplicated. 
Removed calling of `refreshCounts` method for Comment object type as this type isn't displayed in the menu. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
