### PR TITLE
GGRC-7749 [Reopen] New revision record after update rels via post

### DIFF
--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -134,6 +134,8 @@ class ModelView(View):
   pk_type = 'int'
 
   _model = None
+  is_new = False
+  needs_update = False
 
   # Simple accessor properties
   @property
@@ -1075,11 +1077,12 @@ class Resource(ModelView):
 
     Returns:
       obj: An instance of current model.
-      needs_update: Flag shows if we need to update obj attributes.
     """
     obj = self.model()
     db.session.add(obj)
-    return obj, True
+    self.needs_update = True
+    self.is_new = True
+    return obj
 
   def _check_post_permissions(self, objects):
     """Check create permissions for a list of objects.append
@@ -1147,9 +1150,9 @@ class Resource(ModelView):
 
       for wrapped_src in body:
         src = self._unwrap_collection_post_src(wrapped_src)
-        obj, needs_update = self._get_model_instance(src)
+        obj = self._get_model_instance(src)
 
-        if not needs_update:
+        if not self.needs_update:
           obj.modified_by = get_current_user()
           db.session.flush()
           object_for_json = {} if no_result else self.object_for_json(obj)
@@ -1190,7 +1193,7 @@ class Resource(ModelView):
     with benchmark("Get modified objects"):
       modified_objects = get_modified_objects(db.session)
     with benchmark("Log event for all objects"):
-      if needs_update:
+      if self.is_new:
         event = log_event(db.session, obj, flush=False)
     with benchmark("Update memcache before commit for collection POST"):
       cache_utils.update_memcache_before_commit(
@@ -1207,7 +1210,7 @@ class Resource(ModelView):
       cache_utils.update_memcache_after_commit(self.request)
 
     with benchmark("Send model POSTed - after commit event"):
-      if needs_update:
+      if self.is_new:
         for obj, src in itertools.izip(objects, sources):
           signals.Restful.model_posted_after_commit.send(
               obj.__class__, obj=obj, src=src, service=self, event=event)
@@ -1215,7 +1218,7 @@ class Resource(ModelView):
           # relationships are set, so need to commit the changes
       db.session.commit()
     with benchmark("Send event job"):
-      if needs_update:
+      if self.is_new:
         # global_ac_roles may save a set of ACR objects in the session. If
         # session state is changed, all ACRs will be rerequested one by one.
         # To avoid such behavior link to ACRs objects should be removed
@@ -1326,6 +1329,7 @@ class Resource(ModelView):
         with benchmark("Build stub query cache"):
           self._build_request_stub_cache(body)
         try:
+          self.is_new = True
           self.collection_post_loop(body, res, no_result)
         except (IntegrityError, ValidationError, ValueError) as error:
           res.append(self._make_error_from_exception(error))

--- a/src/ggrc/services/resources/relationship.py
+++ b/src/ggrc/services/resources/relationship.py
@@ -96,25 +96,25 @@ class RelationshipResource(ggrc.services.common.Resource):
 
     Returns:
       obj: An instance of current model.
-      needs_update: Flag shows if we need to update obj attributes.
     """
-    needs_update = True
+    self.needs_update = True
     _, _, is_snapshot = self._parse_snapshot_data(src)
 
     if is_snapshot:
       snapshot = Snapshot()
       db.session.add(snapshot)
 
-      return snapshot, needs_update
+      return snapshot
 
     _relationship = self._get_relationship(src)
 
     if _relationship:
-      needs_update = _relationship.is_external
+      self.is_new = False
+      self.needs_update = _relationship.is_external
     else:
       _relationship = relationship.Relationship()
       db.session.add(_relationship)
-    return _relationship, needs_update
+    return _relationship
 
   def json_create(self, obj, src):
     """For Parent and Snapshottable src and dst, fill in the Snapshot obj."""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

New record in change log shouldn't appear if relationship was updated via POST request

# Steps to test the changes

1. Create Product in GGRC
2. Go to GGRCQ, find the Product from step#1 & created Questionnaire for it
3. Add 'Dependency' answer using Product from step#1
4. Send POST request to create relationships between objects from the previous steps
5. Open any mapped object's 'Change Log' tab.

# Solution description

- added **is_new** attribute to **ModelView** class **default = False**
- enable **is_new = True** if request method is POST
- disable **Is_new = False** if relationship was already created and it is external relationship
- replaced **needs_update** arg with **needs_update ModelView** attribute

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
