### PR TITLE
GGRC-8334 Fix issue when Assessments are filtered incorrect if open Assessments by state from Audit Summary tab

### DIFF
--- a/src/ggrc-client/js/components/tree-view-filter/templates/tree-view-filter.stache
+++ b/src/ggrc-client/js/components/tree-view-filter/templates/tree-view-filter.stache
@@ -10,6 +10,7 @@
   on:vm:openAdvanced="openAdvancedFilter()"
   on:vm:removeAdvanced="removeAdvancedFilters()"
   showAdvanced:from="statusFilterVisible"
+  filter:from="inputFilter"
   isFiltered:from="advancedSearch.filter"
   showEmailImport:from="showEmailImport"
 />
@@ -21,6 +22,7 @@
     on:vm:searchQueryChanged="searchQueryChanged(scope.event)"
     on:vm:treeFilterReady="treeFilterReady(scope.event)"
     on:vm:submitFilter="onFilter()"
+    inputFilter:from="inputFilter"
     disabled:from="advancedSearch.filter">
       <multiselect-dropdown options:from="filterStates"
         placeholder:from="'Filter by State'"

--- a/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-status-filter_spec.js
@@ -34,6 +34,7 @@ describe('tree-status-filter component', () => {
         type: 'searchQueryChanged',
         name: 'status',
         query: null,
+        triggerFilterOnChange: false,
       });
     });
 
@@ -44,6 +45,7 @@ describe('tree-status-filter component', () => {
         type: 'searchQueryChanged',
         name: 'status',
         query: null,
+        triggerFilterOnChange: false,
       });
     });
 
@@ -54,6 +56,7 @@ describe('tree-status-filter component', () => {
         type: 'searchQueryChanged',
         name: 'status',
         query: FILTER,
+        triggerFilterOnChange: false,
       });
     });
   });
@@ -173,12 +176,12 @@ describe('tree-status-filter component', () => {
     describe('launches search', () => {
       afterEach(() => {
         handler([router], null, newStatuses);
-        expect(viewModel.buildSearchQuery).toHaveBeenCalledWith(newStatuses);
+        expect(viewModel.buildSearchQuery)
+          .toHaveBeenCalledWith(newStatuses, true);
         expect(viewModel.setStatesDropdown).toHaveBeenCalledWith(newStatuses);
-        expect(viewModel.dispatch).toHaveBeenCalledWith('submitFilter');
       });
 
-      it(`when component is enabled,
+      it(`when component is
         launched on current widget and statuses were changed`, () => {
         viewModel.filterStates = [
           {value: 'A', checked: true},
@@ -187,7 +190,29 @@ describe('tree-status-filter component', () => {
         newStatuses = ['C', 'D'];
         viewModel.widgetId = 'test1';
         router.attr('widget', 'test1');
-        viewModel.disabled = false;
+      });
+
+      it('when input filter is not applied', () => {
+        viewModel.filterStates = [
+          {value: 'A', checked: true},
+          {value: 'B', checked: true},
+        ];
+        newStatuses = ['C', 'D'];
+        viewModel.inputFilter = '';
+        viewModel.widgetId = 'test1';
+        router.attr('widget', 'test1');
+      });
+
+      it(`when component is launched on current widget 
+      and statuses were not changed, input filter is applied`, () => {
+        viewModel.filterStates = [
+          {value: 'A', checked: true},
+          {value: 'B', checked: true},
+        ];
+        newStatuses = ['A', 'B'];
+        viewModel.widgetId = 'test1';
+        router.attr('widget', 'test1');
+        viewModel.inputFilter = 'test';
       });
     });
 
@@ -196,23 +221,10 @@ describe('tree-status-filter component', () => {
         handler([router], null, newStatuses);
         expect(viewModel.buildSearchQuery).not.toHaveBeenCalled();
         expect(viewModel.setStatesDropdown).not.toHaveBeenCalled();
-        expect(viewModel.dispatch).not.toHaveBeenCalled();
       });
 
-      it(`when component is disabled,
-        launched on current widget and statuses were changed`, () => {
-        viewModel.filterStates = [
-          {value: 'A', checked: true},
-          {value: 'B', checked: true},
-        ];
-        newStatuses = ['C', 'D'];
-        viewModel.widgetId = 'test1';
-        router.attr('widget', 'test1');
-        viewModel.disabled = true;
-      });
-
-      it(`when component is enabled,
-        launched on other widget and statuses were changed`, () => {
+      it(`when component is launched on other widget
+       and statuses were changed`, () => {
         viewModel.filterStates = [
           {value: 'A', checked: true},
           {value: 'B', checked: true},
@@ -220,11 +232,11 @@ describe('tree-status-filter component', () => {
         newStatuses = ['C', 'D'];
         viewModel.widgetId = 'test1';
         router.attr('widget', 'test2');
-        viewModel.disabled = false;
+        viewModel.inputFilter = 'test';
       });
 
-      it(`when component is enabled,
-        launched on current widget and statuses were not changed`, () => {
+      it(`when component is launched on current widget
+       and statuses were not changed, input filter is not applied`, () => {
         viewModel.filterStates = [
           {value: 'A', checked: true},
           {value: 'B', checked: true},
@@ -232,7 +244,7 @@ describe('tree-status-filter component', () => {
         newStatuses = ['A', 'B'];
         viewModel.widgetId = 'test1';
         router.attr('widget', 'test1');
-        viewModel.disabled = false;
+        viewModel.inputFilter = '';
       });
 
       it('when newStatuses is not defined', () => {
@@ -242,7 +254,6 @@ describe('tree-status-filter component', () => {
         ];
         newStatuses = null;
         router.attr('widget', 'test1');
-        viewModel.disabled = false;
       });
     });
   });

--- a/src/ggrc-client/js/components/tree/tests/tree-widget-container_spec.js
+++ b/src/ggrc-client/js/components/tree/tests/tree-widget-container_spec.js
@@ -184,16 +184,6 @@ describe('tree-widget-container component', () => {
       _widgetShown();
       expect(vm.loadItems).toHaveBeenCalled();
     });
-
-    it('should load items if count has changed', () => {
-      vm.refetch = false;
-      router.attr('refetch', false);
-      vm.options.forceRefetch = false;
-      vm.pageInfo.attr('total', 100); // less than current count
-
-      _widgetShown();
-      expect(vm.loadItems).toHaveBeenCalled();
-    });
   });
 
   describe('getAbsoluteItemNumber() method', () => {

--- a/src/ggrc-client/js/components/tree/tree-filter-input.js
+++ b/src/ggrc-client/js/components/tree/tree-filter-input.js
@@ -46,6 +46,7 @@ const ViewModel = canDefineMap.extend({
       type: 'searchQueryChanged',
       name: 'custom',
       query: newValue.length ? filter : null,
+      newValue,
     });
   },
   setupFilterFromUrl() {

--- a/src/ggrc-client/js/components/tree/tree-status-filter.js
+++ b/src/ggrc-client/js/components/tree/tree-status-filter.js
@@ -26,6 +26,9 @@ const ViewModel = canDefineMap.extend({
   widgetId: {
     value: null,
   },
+  inputFilter: {
+    value: '',
+  },
   modelName: {
     value: null,
   },
@@ -87,7 +90,7 @@ const ViewModel = canDefineMap.extend({
       router.removeAttr('state');
     }
   },
-  buildSearchQuery(states) {
+  buildSearchQuery(states, triggerFilterOnChange = false) {
     let allStates = this.allStates;
     let modelName = this.modelName;
     let query = (states.length && loDifference(allStates, states).length) ?
@@ -98,11 +101,11 @@ const ViewModel = canDefineMap.extend({
       type: 'searchQueryChanged',
       name: 'status',
       query,
+      triggerFilterOnChange,
     });
   },
   selectItems(event) {
     let selectedStates = event.selected.map((state) => state.value);
-
     this.buildSearchQuery(selectedStates);
     this.saveTreeStates(selectedStates);
     this.setStatesRoute(selectedStates);
@@ -159,17 +162,16 @@ export default canComponent.extend({
       }
 
       let isCurrent = this.viewModel.widgetId === router.attr('widget');
-      let isEnabled = !this.viewModel.disabled;
 
       let currentStates = this.viewModel.currentStates;
       let isChanged =
         loDifference(currentStates, newStatuses).length ||
-        loDifference(newStatuses, currentStates).length;
+        loDifference(newStatuses, currentStates).length ||
+        this.viewModel.inputFilter;
 
-      if (isCurrent && isEnabled && isChanged) {
-        this.viewModel.buildSearchQuery(newStatuses);
+      if (isCurrent && isChanged) {
+        this.viewModel.buildSearchQuery(newStatuses, true);
         this.viewModel.setStatesDropdown(newStatuses);
-        this.viewModel.filter();
       }
     },
     '{viewModel.router} widget'([router]) {

--- a/src/ggrc-client/js/components/tree/tree-widget-container.js
+++ b/src/ggrc-client/js/components/tree/tree-widget-container.js
@@ -4,7 +4,6 @@
  */
 
 import loDebounce from 'lodash/debounce';
-import loGet from 'lodash/get';
 import loFindIndex from 'lodash/findIndex';
 import loSortBy from 'lodash/sortBy';
 import loIsEmpty from 'lodash/isEmpty';
@@ -298,17 +297,11 @@ const ViewModel = canDefineMap.extend({
     this._triggerListeners(true);
   },
   _widgetShown() {
-    const countsName = this.options.countsName;
-    const total = this.pageInfo.attr('total');
-    const counts = loGet(getCounts(), countsName);
-
     this._triggerListeners();
 
     if (this.refetch ||
       router.attr('refetch') ||
-      this.options.forceRefetch ||
-      // this condition is mostly for Issues, Documents and Evidence as they can be created from other object info pane
-      (total !== counts)) {
+      this.options.forceRefetch) {
       this.loadItems();
       this.refetch = false;
     }

--- a/src/ggrc-client/js/controllers/summary-widget-controller.js
+++ b/src/ggrc-client/js/controllers/summary-widget-controller.js
@@ -15,6 +15,7 @@ import {
   getPageInstance,
 } from '../plugins/utils/current-page-utils';
 import {getCounts} from '../plugins/utils/widgets-utils';
+import * as StateUtils from '../plugins/utils/state-utils';
 import router from '../router';
 import {
   getDefaultStatesForModel,
@@ -63,6 +64,8 @@ export default canControl.extend({
       .on('widget_shown', this.widget_shown.bind(this));
     this.element.closest('.widget')
       .on('widget_hidden', this.widget_hidden.bind(this));
+    const states = StateUtils.getStatesForModel('Assessment');
+    const allStatesUrl = states.join('&state%5B%5D=');
     this.options.context = new canMap({
       model: this.options.model,
       instance: this.options.instance,
@@ -73,6 +76,7 @@ export default canControl.extend({
           legend: [],
         },
       },
+      allStatesUrl,
     });
 
     let frag = getFragment(this.get_widget_view(this.element),

--- a/src/ggrc-client/js/templates/audits/summary.stache
+++ b/src/ggrc-client/js/templates/audits/summary.stache
@@ -70,7 +70,7 @@
                         <tr data-row-index="{{rowIndex}}">
                           <td style="color: {{color}}">
                             <i class="fa fa-circle"></i>
-                            <a style="color: {{color}}" href="#assessment&state%5B%5D={{title}}">
+                            <a style="color: {{color}}" href="#assessment&state%5B%5D={{title}}&redirect=true">
                                 {{title}}
                             </a>
                           </td>
@@ -113,7 +113,7 @@
                             <hr>
                         </div>
                         <div class="span12 centered">
-                            <a href="#assessment">View all assessments &raquo;</a>
+                            <a href="#assessment&state%5B%5D={{allStatesUrl}}&redirect=true">View all assessments &raquo;</a>
                         </div>
                     {{else}}
                         {{#if charts.Assessment.isLoaded}}


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description
Assessments are filtered incorrect if open Assessments by state from Audit Summary tab

# Steps to test the changes

1. Open Audit Summary page and click on Assessments in any state e.g Deprecated.
2. Click any state on Audit summary, e.g. In Progress.
3. Review filtered assessments. 
4. Open Audit Summary page again and click on Assessments in another state.
5. Verify filtered assessments. 

# Solution description

1. Request to get assessments is sent before update filter values that's why incorrect values are shown => Updated buildSearchQuery to call onFilter event  after searchQueryChanged event. 
2. Removed `total !== counts` condition from `_widgetShown` so as this perform double requests to get assessment. And this condition is already covered by `_triggerListeners`.
3. Added `allStatesUrl` attribute to correctly trigger `'{viewModel.router} state'` event with all states selected. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
