### PR TITLE
GGRC-7676 Delete proposals from db when parent object is deleted

### DIFF
--- a/src/ggrc/migrations/versions/20200122_14891a489a2d_remove_hanging_proposals.py
+++ b/src/ggrc/migrations/versions/20200122_14891a489a2d_remove_hanging_proposals.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Delete proposals if instance_id = 0
+
+Create Date: 2020-01-22 11:48:08.884077
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from alembic import op
+
+from ggrc.migrations import utils
+
+# revision identifiers, used by Alembic.
+revision = '14891a489a2d'
+down_revision = 'a35b27563863'
+
+
+def remove_hanging_proposals(conn):
+  """Delete proposals if instance_id equals zero"""
+  sql = ("""
+      DELETE
+      FROM proposals
+      WHERE instance_id = 0;
+  """)
+  return conn.execute(sql)
+
+
+def update_revisions(conn):
+  """Updates revisions for deleted proposals."""
+  sql = ("""
+      SELECT id
+      FROM proposals
+      WHERE instance_id = 0;
+  """)
+
+  deleted_proposals = conn.execute(sql)
+  deleted_ids = [proposal.id for proposal in deleted_proposals]
+
+  # add objects to objects without revisions
+  if deleted_ids:
+    utils.add_to_objects_without_revisions_bulk(conn,
+                                                deleted_ids,
+                                                "Proposal",
+                                                action='deleted',
+                                                )
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  conn = op.get_bind()
+  update_revisions(conn)
+  remove_hanging_proposals(conn)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")

--- a/src/ggrc/models/proposal.py
+++ b/src/ggrc/models/proposal.py
@@ -287,4 +287,5 @@ class Proposalable(object):  # pylint: disable=too-few-public-methods
         Proposal,
         primaryjoin=join_function,
         backref=Proposal.INSTANCE_TMPL.format(cls.__name__),
+        cascade="all, delete-orphan",
     )

--- a/src/ggrc/services/signals.py
+++ b/src/ggrc/services/signals.py
@@ -101,8 +101,8 @@ class Restful(object):
       "Model DELETEd",
       """
       Indicates that a model object was DELETEd and will be removed from the
-      databse. The sender in the signal will be the model class of the DELETEd
-      resource. The followin garguments will be sent along with the signal:
+      database. The sender in the signal will be the model class of the DELETEd
+      resource. The following arguments will be sent along with the signal:
 
         :obj: The model instance removed.
         :service: The instance of Resource handling the DELETE request.
@@ -113,7 +113,7 @@ class Restful(object):
       """
       Indicates that a model object was DELETEd and has been removed from the
       database. The sender in the signal will be the model class of the DELETEd
-      resource. The followin garguments will be sent along with the signal:
+      resource. The following arguments will be sent along with the signal:
 
         :obj: The model instance removed.
         :service: The instance of Resource handling the DELETE request.

--- a/test/integration/ggrc/proposal/api/base.py
+++ b/test/integration/ggrc/proposal/api/base.py
@@ -12,7 +12,7 @@ from integration.ggrc.api_helper import Api
 
 
 class BaseTestProposalApi(TestCase):
-  """Base TestCase class proposal apip tests."""
+  """Base TestCase class proposal api tests."""
 
   def setUp(self):
     super(BaseTestProposalApi, self).setUp()

--- a/test/integration/ggrc/proposal/test_proposal_relationship.py
+++ b/test/integration/ggrc/proposal/test_proposal_relationship.py
@@ -122,3 +122,15 @@ class TestProposalRelationship(TestCase):
     response = self.api.delete(proposal)
     self.assert200(response)
     self.assertEqual(0, self.proposal_relationships(program).count())
+
+  def test_delete_proposal(self):
+    """Test delete proposal if program is removed"""
+    with factories.single_commit():
+      program = factories.ProgramFactory()
+      factories.ProposalFactory(instance=program,
+                                context_id=program.context_id,
+                                content={"Some text"})
+
+    response = self.api.delete(program)
+    self.assert200(response)
+    self.assertEqual(0, db.session.query(all_models.Proposal).count())


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Proposals are not deleted when a parent object is deleted.

# Steps to test the changes

Steps to reproduce:
1. Create a program
2. Add a proposal
3. Delete a program
4. A proposal has been deleted

# Solution description

Add _delete_proposals method to Program class in src/ggrc/models/program.py
Add _delete_proposals func call to _handle_delete hook in src/ggrc/models/program.py

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [x] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
