### PR TITLE
GGRC-7318 Removing mirrored (duplicated) relationships, revisions, event

### DIFF
--- a/src/ggrc/migrations/versions/20200110_c7620a843c18_removed_duplicated_comment_relations_.py
+++ b/src/ggrc/migrations/versions/20200110_c7620a843c18_removed_duplicated_comment_relations_.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Remove duplicated comment relations for external comments
+
+Create Date: 2020-01-10 10:58:02.220915
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+import sqlalchemy as sa
+from sqlalchemy.sql import func
+from sqlalchemy.sql import select
+
+from alembic import op
+
+from ggrc.models import all_models
+
+
+# revision identifiers, used by Alembic.
+revision = 'c7620a843c18'
+down_revision = '3141784ef298'
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  conn = op.get_bind()
+  # select duplicated relations
+  duplicated_relations = conn.execute("""
+    SELECT r1.id, r1.source_id, r1.source_type, r1.destination_id,
+        r1.destination_type
+    FROM relationships r1
+    JOIN relationships r2 ON r1.source_id = r2.destination_id
+        AND r1.destination_id = r2.source_id
+        AND r2.source_type = 'ExternalComment'
+        AND r1.destination_type = 'ExternalComment';
+    """).fetchall()
+
+  if not duplicated_relations:
+    print "Duplicated revisions were not found"
+    return
+
+  relations_ids = [rel[0] for rel in duplicated_relations]
+  relation_items = [rel[1:] for rel in duplicated_relations]
+
+  rev = all_models.Revision
+  revisions = rev.query.filter(
+      sa.tuple_(
+          rev.source_id, rev.source_type,
+          rev.destination_id, rev.destination_type
+      ).in_(relation_items)
+  ).all()
+
+  if revisions:
+    # find events
+    revision_ids = [rev_.id for rev_ in revisions]
+    event_ids = [rev_.event_id for rev_ in revisions]
+
+    # find unique events
+    table = rev.__table__
+    stmt = select([table.c.event_id]).where(table.c.event_id.in_(event_ids))\
+        .group_by(table.c.event_id).having(func.count(table.c.event_id) == 1)
+    events = conn.execute(stmt).fetchall()
+
+    # delete revisions
+    print "Delete duplicated revisions related to mirrored relations"
+    delete_stmt = rev.__table__.delete(rev.id.in_(revision_ids))
+    conn.execute(delete_stmt)
+
+    if events:
+      unique_event_ids = [event[0] for event in events]
+      # delete unique events
+      print "Delete duplicated unique events related to mirrored relations"
+      delete_stmt = all_models.Event.__table__.delete(
+          all_models.Event.id.in_(unique_event_ids))
+      conn.execute(delete_stmt)
+
+  # delete relations
+  print "Delete duplicated mirrored relations"
+  delete_stmt = all_models.Relationship.__table__.delete(
+      all_models.Relationship.id.in_(relations_ids))
+  conn.execute(delete_stmt)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #10462 

# Issue description
When user is create comment from GGRCQ side, GGRC is received 3 actions:
1) Create comment
2) Map comment to object
3) Map object to comment
In that case 2 mapping actions will be showed on Change Log for objects, that were synced with GGRCQ (Control, Comment)

Only one mapping action for comment - object should be showed on GGRC Change Log


# Steps to test the changes
Create comment from GGRCQ side and check that only one relationship has been created

# Solution description
Prevent creating mirrored relationships and revisions:
currently we do not create mirrored relationships. When a request for creating of a mirrored relationship is received we just return 201 code and a existing relationship. So now we do not create duplicated relationship when the second request for creating received.
But there was a side effect: some odd revisions and event were created. After #10462 we also stop creating odd revisions.

DB clear from odd records:
Added migration to remove odd (mirrored\duplicated) relationships, dependent revisions, dependent events if these events created only for removed revision.

# Sanity checklist

- [X] I have clicked through the app to make sure my changes work and not break the app.
- [X] I have applied the correct milestone and labels.
- [X] My changes fix the issue described in the description (and do nothing else). 🤞
- [X] My changes are covered by tests.
- [X] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [X] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [X] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
