### PR TITLE
GGRC-8445 Performance degradation of the whole application

### DIFF
--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -23,7 +23,6 @@ from ggrc.cache import utils as cache_utils
 from ggrc.fulltext import mixin
 from ggrc.integrations import integrations_errors, issues
 from ggrc.integrations.synchronization_jobs import one_time_back_sync
-from ggrc.integrations.external_app import constants
 from ggrc.models import background_task, reflection, revision, ExternalMapping
 from ggrc.models.hooks.issue_tracker import integration_utils
 from ggrc.notifications import common
@@ -627,19 +626,12 @@ def get_attributes_json():
   """Get a list of all custom attribute definitions"""
   with benchmark("Get attributes JSON"):
     with benchmark("Get attributes JSON: query"):
-      # get only GCA and exclude external CADs
-      # external GCA should be deleted from internal GCA table
       attrs = models.CustomAttributeDefinition.eager_query().filter(
           models.CustomAttributeDefinition.definition_id.is_(None),
-          ~models.CustomAttributeDefinition.definition_type.in_(
-              constants.GGRCQ_OBJ_TYPES_FOR_SYNC)
       ).all()
-      ext_attrs = models.CustomAttributeDefinition.eager_query().all()
     with benchmark("Get attributes JSON: publish"):
       published = []
       for attr in attrs:
-        published.append(builder_json.publish(attr))
-      for attr in ext_attrs:
         published.append(builder_json.publish(attr))
       published = builder_json.publish_representation(published)
     with benchmark("Get attributes JSON: json"):
@@ -693,11 +685,10 @@ def get_all_attributes_json(load_custom_attributes=False):
     if load_custom_attributes:
       # get only GCA and exclude external CADs
       # external GCA should be deleted from internal GCA table
-      definitions = models.CustomAttributeDefinition.eager_query().filter(
-          ~models.CustomAttributeDefinition.definition_type.in_(
-              constants.GGRCQ_OBJ_TYPES_FOR_SYNC)).group_by(
+      definitions = models.CustomAttributeDefinition.eager_query().group_by(
           models.CustomAttributeDefinition.title,
-          models.CustomAttributeDefinition.definition_type)
+          models.CustomAttributeDefinition.definition_type,
+      )
       for attr in definitions:
         ca_cache[attr.definition_type].append(attr)
     for model in models.all_models.all_models:

--- a/test/integration/ggrc/views/test_get_attributes.py
+++ b/test/integration/ggrc/views/test_get_attributes.py
@@ -67,4 +67,4 @@ class TestGetAttributes(TestCase):
     attrs_json = json.loads(attrs_str)
     attrs_by_type = attrs_json["Control"]
     attrs = (attr["attr_name"] for attr in attrs_by_type)
-    self.assertNotIn(cad.title, attrs)
+    self.assertIn(cad.title, attrs)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

After deprecating scope objects and moving external CADs back to all other CADs, performance degradation of the whole application is being experienced. 

# Steps to test the changes

1. Apply DB dump from QA environment;
2. Log in in the application;
3. Open _"All objects"_ page;

Expected result: All object page should be opened no more than 5 seconds.

# Solution description

At the time we had external CADs stored separately, we had to make 2 DB queries to get custom attributes - one for internal ones and one for external ones.  

After moving external CADs back to the same table as all other CADs, the second query is no longer needed so all the methods and functions were adjusted accordingly. Except for the `get_attributes_json()` function which was mistakenly made to query all CADs instead of all external CADs (which no longer exist). It seems, this DB query for all CADs is the exact reason of performance degradation.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
