### PR TITLE
GGRC-8339 Message that Bulk Status change for Assessment was failed doesn't send

### DIFF
--- a/src/ggrc/bulk_operations/csvbuilder.py
+++ b/src/ggrc/bulk_operations/csvbuilder.py
@@ -18,7 +18,7 @@ class AssessmentStub(object):
     self.urls = []
     self.comments = []
     self.cavs = {}
-    self.slug = ""
+    self.slug = u""
     self.needs_verification = False
 
   def __str__(self):

--- a/src/ggrc/templates/notifications/bulk_complete.html
+++ b/src/ggrc/templates/notifications/bulk_complete.html
@@ -39,7 +39,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 font-size: 16px;
                 line-height: 1.6;
                 color: #000000;
-              ">Bulk Assesments update is finished successfully for the following Assessments.</h2>
+              ">Bulk Assessments update is finished successfully for the following Assessments.</h2>
           <ul  style="
                 margin: 0;
                 padding: 0;
@@ -80,7 +80,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 font-size: 16px;
                 line-height: 1.6;
                 color: #000000;
-              ">Bulk Assesments update is finished partitially for the following Assessments.</h2>
+              ">Bulk Assessments update is finished partially for the following Assessments.</h2>
           <ul  style="
                 margin: 0;
                 padding: 0;
@@ -121,7 +121,7 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
                 font-size: 16px;
                 line-height: 1.6;
                 color: #000000;
-              ">Bulk Assesments update has failed for the following Assessments.</h2>
+              ">Bulk Assessments update has failed for the following Assessments.</h2>
           <ul  style="
                 margin: 0;
                 padding: 0;
@@ -144,6 +144,43 @@ Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
               </li>
             {% endfor %}
           </ul>
+        </div>
+      </td>
+    </tr>
+    {% endif %}
+    {% if sync_data.deleted %}
+    <tr>
+      <td>
+        <div style="
+              padding: 20px;
+            ">
+          <h2  style="
+                margin: 0;
+                padding: 0;
+                margin-bottom: 10px;
+                font-weight: normal;
+                font-size: 16px;
+                line-height: 1.6;
+                color: #000000;
+              ">Assessments with following ids were deleted before or during Bulk Update:</h2>
+          <ul  style="
+                margin: 0;
+                padding: 0;
+                font-weight: normal;
+                font-size: 14px;
+                line-height: 1.6;
+              ">
+            {% for asmnt in sync_data.deleted %}
+              <li style="
+                    margin: 0;
+                    padding-top: 2px;
+                    padding-bottom: 2px;
+                    list-style-position: inside;
+                    list-style: none;
+                  ">
+                <a>{{ asmnt.id }}</a>
+              </li>
+            {% endfor %}
         </div>
       </td>
     </tr>

--- a/src/ggrc/views/bulk_operations.py
+++ b/src/ggrc/views/bulk_operations.py
@@ -218,7 +218,7 @@ def bulk_complete(task):
 @app.route("/_background_tasks/bulk_verify", methods=["POST"])
 @background_task.queued_task
 def bulk_verify(task):
-  """Process bulk complete"""
+  """Process bulk verify"""
 
   with benchmark("Create CsvBuilder"):
     builder = csvbuilder.CsvBuilder(task.parameters.get("data", {}))


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

If user opens bulk verify in one browser tab, selects multiple assessments to verify, then - without verificaton! - switches to another tab and deletes one of the selected assessments, then try to bulk verify - bulk verifies fails and pop-up appears.

# Steps to test the changes

1. Open any Audit
2. Create Assessment
3. Set current user as Verifier > move Assessment to In Review state
4. Open My Assessments
5. Click Bulk Verify button
6. Select created in the previous step Assessment
7. Open Created in the 2nd step Assessment in the new tab and Delete it
8. Open tab with Bulk Verify from the previous steps
9. Run Bulk Verify with selected Assessment (that was deleted before)

# Solution description

The problem arises when during import csvbuilder tries to interpret empty string as empty unicode string. By adding decode("utf-8") this problem was resolved.
In order to provide informative notifications for users, for assessments that were deleted before or during bulk verify operation, new notification is added. Now, if you choose Assessment for Bulk Verify in one browser tab and delete the same Assessment in another, bulk verify would finish successfully, user would receive an email with the following lines: “Assessments with following ids were deleted before or during Bulk Update:” and list of ids.

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [ ] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [ ] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
