### PR TITLE
GGRC-8329 Change log of Assessment represents the wrong status

### DIFF
--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -730,7 +730,8 @@ class ImportRowConverter(RowConverter):
           self.object_class, obj=self.obj, src={}, service=service_class)
     else:
       signals.Restful.model_put.send(
-          self.object_class, obj=self.obj, src={}, service=service_class)
+          self.object_class, obj=self.obj, src={}, service=service_class,
+          initial_state=self.initial_state)
 
   def insert_object(self):
     """Add the row object to the current database session."""

--- a/src/ggrc/models/hooks/assessment.py
+++ b/src/ggrc/models/hooks/assessment.py
@@ -213,7 +213,8 @@ def init_hook():  # noqa: ignore=C901
 
   # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(all_models.Assessment)
-  def handle_assessment_put(sender, obj=None, src=None, service=None):
+  def handle_assessment_put(sender, obj=None, src=None, service=None,
+                            initial_state=None):
     """Handles assessment update event."""
     del sender, src, service  # Unused
     common.ensure_field_not_changed(obj, 'audit')

--- a/src/ggrc/models/hooks/audit.py
+++ b/src/ggrc/models/hooks/audit.py
@@ -36,7 +36,8 @@ def init_hook():
   # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(all_models.Audit)
   @signals.Restful.model_deleted.connect_via(all_models.Audit)
-  def handle_audit_permission_put(sender, obj, src=None, service=None):
+  def handle_audit_permission_put(sender, obj, src=None, service=None,
+                                  initial_state=None):
     """Make sure admins cannot delete/update archived audits"""
     # pylint: disable=unused-argument
     if obj.archived and not db.inspect(
@@ -51,7 +52,8 @@ def init_hook():
   @signals.Restful.model_put.connect_via(all_models.Assessment)
   @signals.Restful.model_put.connect_via(all_models.AssessmentTemplate)
   @signals.Restful.model_put.connect_via(all_models.Snapshot)
-  def handle_archived_object(sender, obj=None, src=None, service=None):
+  def handle_archived_object(sender, obj=None, src=None, service=None,
+                             initial_state=None):
     """Make sure admins cannot delete/update archived audits"""
     # pylint: disable=unused-argument
     if obj.archived:

--- a/src/ggrc/models/hooks/issue.py
+++ b/src/ggrc/models/hooks/issue.py
@@ -14,7 +14,8 @@ def init_hook():
   """Initialize Issue-related hooks."""
   # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(all_models.Issue)
-  def handle_issue_put(sender, obj=None, src=None, service=None):
+  def handle_issue_put(sender, obj=None, src=None, service=None,
+                       initial_state=None):
     # pylint: disable=unused-argument
     common.ensure_field_not_changed(obj, "audit")
 

--- a/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
+++ b/src/ggrc/models/hooks/issue_tracker/assessment_integration.py
@@ -2784,7 +2784,9 @@ def _hook_audit_issue_post(sender, objects=None, sources=None):
       tracker_handler.handle_audit_create(audit, issue_info)
 
 
-def _hook_audit_issue_put(sender, obj=None, src=None, service=None):
+# pylint: disable=unused-variable
+def _hook_audit_issue_put(sender, obj=None, src=None, service=None,
+                          initial_state=None):
   """Handle updating audit issue related info."""
   del sender, service
 

--- a/src/ggrc/models/mixins/autostatuschangeable.py
+++ b/src/ggrc/models/mixins/autostatuschangeable.py
@@ -365,8 +365,10 @@ class AutoStatusChangeable(object):
       model: Class on which handlers will be set up.
     """
 
+    # pylint: disable=unused-variable
     @signals.Restful.model_put.connect_via(model)
-    def handle_object_put(sender, obj=None, src=None, service=None):
+    def handle_object_put(sender, obj=None, src=None, service=None,
+                          initial_state=None):
       """Handles object PUT operation
 
       Handles edit operation submitted to object.
@@ -417,8 +419,10 @@ class AutoStatusChangeable(object):
         target_object._need_status_reset = True
         target_object._reset_to_status = target_object.PROGRESS_STATE
 
+    # pylint: disable=unused-variable
     @signals.Restful.model_put.connect_via(evidence.Evidence)
-    def handle_evidence_relationship(sender, obj=None, src=None, service=None):
+    def handle_evidence_relationship(sender, obj=None, src=None, service=None,
+                                     initial_state=None):
       """Handle PUT of Evidence.
 
         See blinker library documentation for other parameters (all necessary).

--- a/src/ggrc/models/mixins/rest_handable.py
+++ b/src/ggrc/models/mixins/rest_handable.py
@@ -13,7 +13,7 @@ class WithPutHandable(object):
   """Mixin that adds PUT handler"""
   __lazy_init__ = True
 
-  def handle_put(self):
+  def handle_put(self, initial_state):
     """PUT handler"""
     raise NotImplementedError
 
@@ -24,7 +24,7 @@ class WithPutHandable(object):
     @signals.Restful.model_put.connect_via(model)
     def model_put(*args, **kwargs):
       """PUT handler"""
-      model.handle_put(kwargs["obj"])
+      model.handle_put(kwargs["obj"], kwargs["initial_state"])
 
 
 class WithPutAfterCommitHandable(object):

--- a/src/ggrc/models/mixins/with_sox_302.py
+++ b/src/ggrc/models/mixins/with_sox_302.py
@@ -14,7 +14,7 @@ from ggrc.models.mixins import rest_handable
 from ggrc.models.mixins import statusable
 
 
-class WithSOX302Flow(rest_handable.WithPutBeforeCommitHandable):
+class WithSOX302Flow(rest_handable.WithPutHandable):
   """Mixin which adds a support of SOX 302 flow."""
 
   @sa_declarative.declared_attr
@@ -118,11 +118,11 @@ class WithSOX302Flow(rest_handable.WithPutBeforeCommitHandable):
     ):
       self.status = statusable.Statusable.FINAL_STATE
 
-  def handle_put_before_commit(self, initial_state):
+  def handle_put(self, initial_state):
     # type: (collections.namedtuple) -> None
-    """Handle `model_put_before_commit` signals.
+    """Handle `model_put` signals.
 
-    This method is called after `model_put_before_commit` signal is being sent.
+    This method is called after `model_put` signal is being sent.
     Triggers SOX 302 status change flow.
 
     Args:

--- a/src/ggrc/models/proposal.py
+++ b/src/ggrc/models/proposal.py
@@ -255,7 +255,7 @@ class Proposal(mixins.person_relation_factory("applied_by"),
     self.decline_datetime = datetime.datetime.utcnow()
     self._add_comment_about(self.STATES.DECLINED, self.decline_reason)
 
-  def handle_put(self):
+  def handle_put(self, initial_state):
     """PUT handler."""
     if self.is_status_changed_to(self.STATES.APPLIED):
       self._apply_proposal()

--- a/src/ggrc/models/review.py
+++ b/src/ggrc/models/review.py
@@ -217,7 +217,7 @@ class Reviewable(rest_handable.WithPutHandable,
     from ggrc.snapshotter.rules import Types
     return bool(counterparty.type in Types.all)
 
-  def handle_put(self):
+  def handle_put(self, initial_state):
     self._update_status_on_attr()
     self._update_status_on_custom_attrs()
 
@@ -354,7 +354,7 @@ class Review(mixins.person_relation_factory("last_reviewed_by"),
     """Checks whether the status has changed."""
     return inspect(self).attrs.status.history.has_changes()
 
-  def handle_put(self):
+  def handle_put(self, initial_state):
     """Handle PUT request."""
     if not self.is_status_changed() and self.email_message:
       self._add_comment_about(self.email_message)

--- a/src/ggrc/notifications/notification_handlers.py
+++ b/src/ggrc/notifications/notification_handlers.py
@@ -460,8 +460,10 @@ def register_handlers():  # noqa: C901
           " Assessment: %s.\n Error: %s", obj.id, ex.message
       )
 
+  # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(models.Assessment)
-  def assignable_modified_listener(sender, obj=None, src=None, service=None):
+  def assignable_modified_listener(sender, obj=None, src=None, service=None,
+                                   initial_state=None):
     """Listener for modification of assessments."""
     try:
       handle_assignable_modified(obj)
@@ -494,8 +496,10 @@ def register_handlers():  # noqa: C901
           " Assessments: %s.\n Error: %s", object_ids, ex.message
       )
 
+  # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(models.Assessment)
-  def assessment_send_reminder(sender, obj=None, src=None, service=None):
+  def assessment_send_reminder(sender, obj=None, src=None, service=None,
+                               initial_state=None):
     """Assessment put listener."""
     reminder_type = src.get("reminderType", False)
     if reminder_type:

--- a/src/ggrc/services/common.py
+++ b/src/ggrc/services/common.py
@@ -713,7 +713,9 @@ class Resource(ModelView):
         obj.validate_acl()
     with benchmark("Send PUT event"):
       signals.Restful.model_put.send(
-          obj.__class__, obj=obj, src=src, service=self)
+          obj.__class__, obj=obj, src=src, service=self,
+          initial_state=initial_state
+      )
     with benchmark("Get modified objects"):
       modified_objects = get_modified_objects(db.session)
     with benchmark("Update custom attribute values"):

--- a/src/ggrc/services/signals.py
+++ b/src/ggrc/services/signals.py
@@ -62,6 +62,8 @@ class Restful(object):
         :obj: The model instance updated from the PUT JSON.
         :src: The original PUT JSON dictionary.
         :service: The instance of Resource handling the PUT request.
+        :initial_state: A named tuple of initial values of an object before
+          applying any change.
       """,
   )
   model_put_before_commit = signals.signal(

--- a/src/ggrc_workflows/__init__.py
+++ b/src/ggrc_workflows/__init__.py
@@ -533,7 +533,9 @@ def calculate_new_next_cycle_start_date(workflow):
 
 @signals.Restful.model_put.connect_via(models.TaskGroupTask)
 @signals.Restful.model_posted.connect_via(models.TaskGroupTask)
-def handle_task_group_task_put_post(sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+# noqa pylint: disable=unused-argument
+def handle_task_group_task_put_post(sender, obj=None, src=None, service=None,
+                                    initial_state=None):
   start_end_date_validator(obj)
 
   # If relative days were change we must update workflow next cycle start date
@@ -593,8 +595,10 @@ def handle_task_group_delete(sender, obj=None, src=None, service=None):  # noqa 
   calculate_new_next_cycle_start_date(workflow)
 
 
+# noqa pylint: disable=unused-argument
 @signals.Restful.model_put.connect_via(models.TaskGroup)
-def handle_task_group_put(sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+def handle_task_group_put(sender, obj=None, src=None, service=None,
+                          initial_state=None):
   if inspect(obj).attrs.contact.history.has_changes():
     obj.ensure_assignee_is_workflow_member()
   calculate_new_next_cycle_start_date(obj.workflow)
@@ -602,7 +606,7 @@ def handle_task_group_put(sender, obj=None, src=None, service=None):  # noqa pyl
 
 @signals.Restful.model_put.connect_via(models.CycleTaskGroupObjectTask)
 def handle_cycle_task_group_object_task_put(
-        sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+        sender, obj=None, src=None, service=None, initial_state=None):  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
     # TODO: check why update_cycle_object_parent_state destroys object history
     # when accepting the only task in a cycle. The listener below is a
@@ -637,7 +641,7 @@ def handle_cycle_object_status(
 
 @signals.Restful.model_put.connect_via(models.CycleTaskGroup)
 def handle_cycle_task_group_put(
-        sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+        sender, obj=None, src=None, service=None, initial_state=None):  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.status.history.has_changes():
     update_cycle_task_child_state(obj)
 
@@ -653,7 +657,7 @@ def update_workflow_state(workflow):
 
 @signals.Restful.model_put.connect_via(models.Cycle)
 def handle_cycle_put(
-        sender, obj=None, src=None, service=None):  # noqa pylint: disable=unused-argument
+        sender, obj=None, src=None, service=None, initial_state=None):  # noqa pylint: disable=unused-argument
   if inspect(obj).attrs.is_current.history.has_changes():
     update_workflow_state(obj.workflow)
 
@@ -679,7 +683,8 @@ def _validate_put_workflow_fields(workflow):
 
 # pylint: disable=unused-argument
 @signals.Restful.model_put.connect_via(models.Workflow)
-def handle_workflow_put(sender, obj=None, src=None, service=None):
+def handle_workflow_put(sender, obj=None, src=None, service=None,
+                        initial_state=None):
   """Define API put calls permissions for WF"""
   _validate_put_workflow_fields(obj)
   if (inspect(obj).attrs.recurrences.history.has_changes() and

--- a/src/ggrc_workflows/notification/__init__.py
+++ b/src/ggrc_workflows/notification/__init__.py
@@ -43,9 +43,10 @@ def contributed_notifications():
 
 
 def register_listeners():
-
+  # pylint: disable=unused-variable
   @signals.Restful.model_put.connect_via(Workflow)
-  def workflow_put_listener(sender, obj=None, src=None, service=None):
+  def workflow_put_listener(sender, obj=None, src=None, service=None,
+                            initial_state=None):
     handle_workflow_modify(sender, obj, src, service)
     if not inspect(obj).attrs.status.history.has_changes():
       return
@@ -56,16 +57,20 @@ def register_listeners():
       handle_cycle_created(obj.cycles[0], False)
 
   @signals.Restful.model_put.connect_via(CycleTaskGroupObjectTask)
+  # noqa pylint: disable=unused-argument
   def cycle_task_group_object_task_put_listener(
-          sender, obj=None, src=None, service=None):
+          sender, obj=None, src=None, service=None, initial_state=None):
     with benchmark("update notifications on CycleTask put"):
       handle_cycle_task_group_object_task_put(obj)
 
   @signals.Restful.model_put.connect_via(Cycle)
-  def cycle_put_listener(sender, obj=None, src=None, service=None):
+  # noqa pylint: disable=unused-argument
+  def cycle_put_listener(sender, obj=None, src=None, service=None,
+                         initial_state=None):
     handle_cycle_modify(obj)
 
   @signals.Restful.model_posted.connect_via(Cycle)
+  # noqa pylint: disable=unused-argument
   def cycle_post_listener(sender, obj=None, src=None, service=None):
     handle_cycle_created(obj, True)
 


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

The New Value in the Change log indicates that the status of the Assessment is 'In Review,' when in actuality it should state 'Completed (no verification)' as the result of all assessments being completed with affirmative answers in skip verify Assessment. The New Value in the Change log 

# Steps to test the changes

1. Create skip verify Assessment.
2. Assignee any Verifier to this Assessment.
3. Give affirmative answers and move Assessment in state 'Completed (no verification)'.

**Expected result:** The New Value in the Change log should be 'Completed (no verification)'.

# Solution description

Function for Execute skip verify Assessments status change flow was moved from handle_put_before_commit hook to handle_put hook. 

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
