### PR TITLE
GGRC-8256 User should not receive a message that Ticket update for …

### DIFF
--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -124,9 +124,9 @@ class ImportConverter(BaseConverter):
     self.csv_data = csv_data or []
     self._bulk_import = bulk_import
     self.indexer = get_indexer()
-    self.comment_created_notif_type = all_models.NotificationType.query. \
-        filter_by(name="comment_created").one().id
+
     super(ImportConverter, self).__init__(ie_job)
+
     self.exportable.update(get_importables())
     self.bulk_import = bulk_import
     self.failed_slugs = []

--- a/src/ggrc/converters/base.py
+++ b/src/ggrc/converters/base.py
@@ -100,6 +100,24 @@ class ImportConverter(BaseConverter):
       "status",
   ]
 
+  # pylint: disable=invalid-name
+  _TICKET_UPDATE_NOTIFICATION_MESSAGES = {
+      "success": {
+          "title": "Ticket(s) update for your Bulk update action was "
+                   "completed.",
+          "body": "The assessments from the Bulk update action that required "
+                  "ticket(s) updates have been successfully updated.",
+      },
+      "failure": {
+          "title": "There were some errors in updating ticket(s) for your "
+                   "Bulk update action.",
+          "body": "There were errors that prevented updates of some ticket(s) "
+                  "after the Bulk update action. The error may be due to your "
+                  "lack to sufficient access to generate/update the ticket(s)."
+                  " Here is the list of assessment(s) that was not updated.",
+      },
+  }
+
   def __init__(self, ie_job, dry_run=True, csv_data=None, bulk_import=False):
     self.user = login.get_current_user()
     self.dry_run = dry_run
@@ -158,7 +176,10 @@ class ImportConverter(BaseConverter):
   def _start_issuetracker_update(self, revision_ids):
     """Create or update issuetracker tickets for all imported instances."""
 
-    arg_list = {"revision_ids": revision_ids}
+    arg_list = {
+        "revision_ids": revision_ids,
+        "notification_messages": self._TICKET_UPDATE_NOTIFICATION_MESSAGES,
+    }
 
     filename = getattr(self.ie_job, "title", '')
     user_email = getattr(self.user, "email", '')

--- a/src/ggrc/converters/base_row.py
+++ b/src/ggrc/converters/base_row.py
@@ -606,10 +606,6 @@ class ImportRowConverter(RowConverter):
       people_mentions.handle_comment_mapped(obj=self.obj,
                                             comments=self.comments)
 
-  def _get_comment_created_notif_type(self):
-    """Get comment created notification type id"""
-    return self.block_converter.converter.comment_created_notif_type
-
   def create_comment_notifications(self):
     """Create comment notifications."""
     import datetime
@@ -619,7 +615,8 @@ class ImportRowConverter(RowConverter):
         notification = all_models.Notification(
             object=comment,
             send_on=datetime.datetime.utcnow(),
-            notification_type_id=self._get_comment_created_notif_type(),
+            notification_type_id=all_models.NotificationType.query.
+            filter_by(name="comment_created").one().id,
         )
         db.session.add(notification)
 

--- a/src/ggrc/views/__init__.py
+++ b/src/ggrc/views/__init__.py
@@ -273,6 +273,9 @@ def background_issues_update(task):
                                                                mail_data)
     update_errors = None
     if update_args.get("objects"):
+      if "notification_messages" in params:
+        update_args["notification_messages"] = params["notification_messages"]
+
       (_, update_errors) = bulk_updater.sync_issuetracker(update_args)
 
     create_args = integration_utils.build_created_objects_args(revision_ids,

--- a/test/integration/ggrc/converters/test_import_issuetracked_objects.py
+++ b/test/integration/ggrc/converters/test_import_issuetracked_objects.py
@@ -13,7 +13,7 @@ import mock
 from ggrc import db
 from ggrc import models
 from ggrc import settings
-from ggrc.converters import errors
+from ggrc.converters import errors, base
 from ggrc.converters.handlers import issue_tracker
 from ggrc.integrations import constants
 from ggrc.integrations import issuetracker_bulk_sync
@@ -1304,12 +1304,18 @@ class TestImportIssueTrackedNotif(ggrc.TestCase):
       response = self.import_data(*assessment_data)
 
     self._check_csv_response(response, {})
+
     it_bulk_updater = issuetracker_bulk_sync.IssueTrackerBulkUpdater
+
+    # pylint: disable=protected-access
+    converter_messages = \
+        base.ImportConverter._TICKET_UPDATE_NOTIFICATION_MESSAGES
+
     mocked_send_email.assert_called_with(
         self.current_user_email,
         it_bulk_updater.ISSUETRACKER_SYNC_TITLE,
         settings.EMAIL_BULK_SYNC_SUCCEEDED.render(sync_data={
-            "title": it_bulk_updater.SUCCESS_TITLE.format(filename=""),
-            "email_text": it_bulk_updater.SUCCESS_TEXT,
+            "title": converter_messages["success"]["title"],
+            "email_text": converter_messages["success"]["body"],
         }),
     )

--- a/test/unit/ggrc/integrations/test_issue_tracker_notifications_custom_messages.py
+++ b/test/unit/ggrc/integrations/test_issue_tracker_notifications_custom_messages.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+# pylint: disable=invalid-name, protected-access
+
+"""Test custom messages for issue tracker notifications during bulk verify."""
+
+import unittest
+from collections import namedtuple
+
+import mock
+
+from ggrc import settings
+from ggrc.integrations.issuetracker_bulk_sync import IssueTrackerBulkUpdater
+
+
+class TestImportConverterIssueTrackerUpdate(unittest.TestCase):
+  """
+      Test that bulk verify sets custom messages for
+      notifications which are sent when linked issue tracker
+      tickets are updated.
+  """
+
+  def setUp(self):
+    from ggrc.converters import base
+
+    self._converter = base.ImportConverter(
+        ie_job=None,
+        dry_run=True,
+        csv_data={},
+        bulk_import=False,
+    )
+    self._updater = IssueTrackerBulkUpdater()
+
+  @mock.patch("ggrc.views.background_update_issues")
+  def test_issues_update_is_called_with_custom_messages(self, bui_mock):
+    """
+        Test that ImportConverter passes custom messages to
+        IssueTrackerBulkUpdater to be used for issue update
+        notifications.
+    """
+
+    self._converter._start_issuetracker_update([1, 2, 3])
+
+    bui_mock.assert_called_once_with(parameters={
+        "revision_ids": [1, 2, 3],
+        'mail_data': {'user_email': '', 'filename': ''},
+        "notification_messages":
+            self._converter._TICKET_UPDATE_NOTIFICATION_MESSAGES,
+    })
+
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.group_objs_by_type"
+  )
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.handle_issuetracker_sync"
+  )
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.send_notification"
+  )
+  def test_sync_issue_tracker_call_with_exception(self, send_mock,
+                                                  his_mock, gobt_mock):
+    """
+      Test that custom error message is used even when exception is thrown
+      while processing issues to update.
+    """
+
+    his_mock.return_value = True, []
+    gobt_mock.return_value = {}
+
+    updater = IssueTrackerBulkUpdater()
+
+    updater.sync_issuetracker({
+        "objects": [],
+        "mail_data": {"user_email": "hello@world.com", "filename": "test.txt"},
+        "notification_messages":
+            self._converter._TICKET_UPDATE_NOTIFICATION_MESSAGES,
+    })
+
+    send_mock.assert_called_once_with(
+        "test.txt",
+        "hello@world.com",
+        failed=True,
+        notification_messages=self._converter.
+          _TICKET_UPDATE_NOTIFICATION_MESSAGES,  # noqa
+    )
+
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.group_objs_by_type"
+  )
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.handle_issuetracker_sync"
+  )
+  @mock.patch(
+      "ggrc.integrations.issuetracker_bulk_sync."
+      "IssueTrackerBulkUpdater.send_notification"
+  )
+  def test_sync_issue_tracker_call_without_exception(
+      self, send_mock, his_mock, gobt_mock
+  ):
+    """
+      Test that custom error message is used during normal processing of issues
+      to update.
+    """
+
+    his_mock.return_value = [True], []
+    gobt_mock.return_value = {}
+
+    self._updater.sync_issuetracker({
+        "objects": [],
+        "mail_data": {"user_email": "hello@world.com", "filename": "test.txt"},
+        "notification_messages":
+            self._converter._TICKET_UPDATE_NOTIFICATION_MESSAGES,
+    })
+
+    send_mock.assert_called_once_with(
+        "test.txt",
+        "hello@world.com",
+        errors=[],
+        notification_messages=self._converter.
+            _TICKET_UPDATE_NOTIFICATION_MESSAGES,  # noqa
+    )
+
+  @mock.patch("ggrc.notifications.common.send_email")
+  def test_send_notification_success(self, send_email_mock):
+    """
+      Test that email template shows custom messages after successful
+      processing.
+    """
+    self._updater.send_notification(
+        "test.txt",
+        "hello@world.com",
+        notification_messages=self._converter.
+            _TICKET_UPDATE_NOTIFICATION_MESSAGES,  # noqa
+    )
+
+    send_email_mock.assert_called_once_with(
+        "hello@world.com",
+        self._updater.ISSUETRACKER_SYNC_TITLE,
+        settings.EMAIL_BULK_SYNC_SUCCEEDED.render(
+            sync_data={
+                "title": "Ticket(s) update for your Bulk update action was "
+                         "completed.",
+                "email_text":
+                    "The assessments from the Bulk update action that "
+                    "required ticket(s) updates have been successfully "
+                    "updated."
+            }
+        )
+    )
+
+  @mock.patch("ggrc.notifications.common.send_email")
+  @mock.patch("ggrc.integrations.issuetracker_bulk_sync.get_object_url")
+  def test_send_notification_errors(self, gou_mock, send_email_mock):
+    """
+      Test that email template shows custom messages when some of issues
+      are not processed.
+    """
+    gou_mock.return_value = "/etc/hosts"
+
+    self._updater.send_notification(
+        "test.txt",
+        "hello@world.com",
+        errors=((namedtuple("Error", "slug title")(1, "Hello World"), False),),
+        notification_messages=self._converter.
+            _TICKET_UPDATE_NOTIFICATION_MESSAGES,  # noqa
+    )
+
+    sync_data = {
+        "title": "There were some errors in updating ticket(s) for your "
+                 "Bulk update action.",
+        "email_text":
+            "There were errors that prevented updates of some ticket(s) "
+            "after the Bulk update action. The error may be due to your "
+            "lack to sufficient access to generate/update the ticket(s)."
+            " Here is the list of assessment(s) that was not updated.",
+        "objects": [{
+            "url": "/etc/hosts",
+            "code": 1,
+            "title": "Hello World",
+        }]
+    }
+
+    send_email_mock.assert_called_once_with(
+        "hello@world.com",
+        self._updater.ISSUETRACKER_SYNC_TITLE,
+        settings.EMAIL_BULK_SYNC_FAILED.render(
+            sync_data=sync_data,
+        )
+    )
+
+  @mock.patch("ggrc.notifications.common.send_email")
+  @mock.patch("ggrc.integrations.issuetracker_bulk_sync.get_object_url")
+  def test_send_notification_exception(self, gou_mock, send_email_mock):
+    """
+      Test that email template shows custom messages when exception is
+      encountered.
+    """
+
+    gou_mock.return_value = "/etc/hosts"
+
+    self._updater.send_notification(
+        "test.txt",
+        "hello@world.com",
+        failed=True,
+        notification_messages=self._converter.
+            _TICKET_UPDATE_NOTIFICATION_MESSAGES,  # noqa
+    )
+
+    send_email_mock.assert_called_once_with(
+        "hello@world.com",
+        self._updater.ISSUETRACKER_SYNC_TITLE,
+        settings.EMAIL_BULK_SYNC_EXCEPTION.render(
+            sync_data={
+                "title":
+                    "There were some errors in updating ticket(s) for your "
+                    "Bulk update action.",
+                "email_text": self._updater.EXCEPTION_TEXT,
+            }
+        )
+    )


### PR DESCRIPTION
# Issue description

User received notification that ticket was updated via import, but import was not used for this action, this notification was occurs by completing Assessment using Bulk Verify feature

Steps to reproduce:
1. Open any Audit with Issue Tracker enabled
2. Create Assessment with enabled Issue Tracker
3. Add verifier and move Assessment to In Review state
4. Open My Assessments
5. Click Bulk Verify button
6. Find Created Assessment and select it
7. Click Bulk Verify button
8. Check sent emails

Actual: "Ticket update for your GGRC import was completed successfully." is displayed

# Solution description

Added simple support for custom messages when calling Issue Tracker sync from Import Converter.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
