### PR TITLE
GGRC-8331 LCA and answer is cut when added a Required comment

### DIFF
--- a/src/ggrc-client/js/components/object-list-item/comment-list-item.stache
+++ b/src/ggrc-client/js/components/object-list-item/comment-list-item.stache
@@ -33,7 +33,18 @@
       </div>
     </div>
     {{#if hasRevision}}
-      <div class="comment-list__ca-description">{{customAttributeData}}</div>
+      <tooltip-content
+        class="oneline"
+        placement:from="'bottom'"
+        content:from="customAttributeData"
+      >
+        <div
+          class="comment-list__ca-description"
+          data-trim-target="true"
+        >
+          {{customAttributeData}}
+        </div>
+      </tooltip-content>
     {{/if}}
     <div class="comment-object-item__text">
       <read-more


### PR DESCRIPTION
# Issue description
When the user responds with a negative answer to a question within the assessment, the question pertaining to this negative answer within the responses/comments section becomes cut off on the screen. As a result, the entire question is not visible in the responses/comments section. Solution: The user recommends text wrapping as the solution so that the question does not become cut off.

# Steps to test the changes 
1. Create Audit.
2. Create Assessment template with LCA dropdown which has long title.
3. Create Assessment with AT which was added at second step.
4. Fill dropdown.
5. Look and hover over the comment title.

**Actual Result**: The title is cropped.
**Expected result**:  The title is displayed cropped with three dots. After hovering, a tooltip with a full title is displayed.

# Solution description 
If LCA title length is longer than 1 row:  show one row of LCA title + 3 dots + on hover tooltip with full text of LCA.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".