### PR TITLE
GGRC-8265 Creator has access to view all comments from every object

### DIFF
--- a/src/ggrc/migrations/versions/20200127_d0f2f2dcde8d_update_propagation_tree_for_assessment.py
+++ b/src/ggrc/migrations/versions/20200127_d0f2f2dcde8d_update_propagation_tree_for_assessment.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""
+Update propagation tree for Primary and Secondary Contacts in Assessment
+
+Create Date: 2020-01-27 11:39:42.432174
+"""
+# disable Invalid constant name pylint warning for mandatory Alembic variables.
+# pylint: disable=invalid-name
+
+from ggrc.migrations.utils.acr_propagation import update_acr_propagation_tree
+
+
+# revision identifiers, used by Alembic.
+revision = 'd0f2f2dcde8d'
+down_revision = '14891a489a2d'
+
+
+EVIDENCE_COMMENTS_PERMISSIONS = {
+    "Relationship R": {
+        "Evidence RUD": {
+            "Relationship R": {
+                "Comment R": {}
+            },
+        },
+
+    },
+}
+
+NEW_ROLES_PROPAGATION = {
+    "Primary Contacts": EVIDENCE_COMMENTS_PERMISSIONS,
+    "Secondary Contacts": EVIDENCE_COMMENTS_PERMISSIONS,
+}
+
+CONTROL_PROPAGATION = {
+    "Assessment": NEW_ROLES_PROPAGATION
+}
+
+OLD_CONTROL_PROPAGATION = {
+    "Assessment": NEW_ROLES_PROPAGATION
+}
+
+
+def upgrade():
+  """Upgrade database schema and/or data, creating a new revision."""
+  update_acr_propagation_tree(OLD_CONTROL_PROPAGATION, CONTROL_PROPAGATION)
+
+
+def downgrade():
+  """Downgrade database schema and/or data back to the previous revision."""
+  raise NotImplementedError("Downgrade is not supported")


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

User logged as Global Creator can read the comments from all objects (via console) - even if he doesn't have access to objects.

# Steps to test the changes

For local testing:
1. Log in by Global Creator user
2. Use query from GGRC-8265
**Expected Result:** User can see only comments from objects that he has access to.

# Solution description

The function _get_comments_type_query has been added to the query construction, which builds a filter based on the comments available to the user.
The propagation tree for Primary and Secondary contacts in Assessment was also updated, because access of these roles to the Evidence comments was a bug.
After changes in this PR access is granted in the correct way.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
