### PR TITLE
QUICK-FIX Add migrationDate for Scope objects

### DIFF
--- a/src/ggrc-client/js/models/business-models/access-group.js
+++ b/src/ggrc-client/js/models/business-models/access-group.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/account-balance.js
+++ b/src/ggrc-client/js/models/business-models/account-balance.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/data-asset.js
+++ b/src/ggrc-client/js/models/business-models/data-asset.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/facility.js
+++ b/src/ggrc-client/js/models/business-models/facility.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/key-report.js
+++ b/src/ggrc-client/js/models/business-models/key-report.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/market.js
+++ b/src/ggrc-client/js/models/business-models/market.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/metric.js
+++ b/src/ggrc-client/js/models/business-models/metric.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   attributes: {
     context: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/org-group.js
+++ b/src/ggrc-client/js/models/business-models/org-group.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/process.js
+++ b/src/ggrc-client/js/models/business-models/process.js
@@ -29,6 +29,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/product-group.js
+++ b/src/ggrc-client/js/models/business-models/product-group.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   attributes: {
     context: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/product.js
+++ b/src/ggrc-client/js/models/business-models/product.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/project.js
+++ b/src/ggrc-client/js/models/business-models/project.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/system.js
+++ b/src/ggrc-client/js/models/business-models/system.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/models/business-models/technology-environment.js
+++ b/src/ggrc-client/js/models/business-models/technology-environment.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   attributes: {
     context: Stub,
     modified_by: Stub,

--- a/src/ggrc-client/js/models/business-models/vendor.js
+++ b/src/ggrc-client/js/models/business-models/vendor.js
@@ -23,6 +23,7 @@ export default Cacheable.extend({
     ChangeableExternally,
     DisableAddComments,
   ],
+  migrationDate: '02/24/2020',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {


### PR DESCRIPTION
# Solution description

Add migrationDate

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
