### PR TITLE
GGRC-5527 Invalid value in fields with autosuggest should be reset to last saved state on moving focus out

### DIFF
--- a/src/ggrc-client/js/models/business-models/audit.js
+++ b/src/ggrc-client/js/models/business-models/audit.js
@@ -12,6 +12,7 @@ import CaUpdate from '../mixins/ca-update';
 import IssueTracker from '../mixins/issue-tracker';
 import Stub from '../stub';
 import Program from './program';
+import {validateInputValue} from '../../plugins/utils/validation-utils';
 
 export default Cacheable.extend({
   root_object: 'audit',
@@ -133,6 +134,9 @@ export default Cacheable.extend({
       value: null,
       validate: {
         required: true,
+        validateAutosuggestFieldValue() {
+          return validateInputValue('program', this);
+        },
       },
     },
     issue_tracker: {
@@ -143,6 +147,11 @@ export default Cacheable.extend({
     },
     audit_firm: {
       value: null,
+      validate: {
+        validateAutosuggestFieldValue() {
+          return validateInputValue('audit_firm', this);
+        },
+      },
     },
   },
   clone: function (options) {

--- a/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
+++ b/src/ggrc-client/js/models/business-models/cycle-task-group-object-task.js
@@ -3,6 +3,7 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 */
 
+import canMap from 'can-map';
 import loOrderBy from 'lodash/orderBy';
 import loFilter from 'lodash/filter';
 import moment from 'moment';
@@ -19,6 +20,7 @@ import CycleTaskNotifications from '../mixins/notifications/cycle-task-notificat
 import Stub from '../stub';
 import {reify} from '../../plugins/utils/reify-utils';
 import {refreshAll} from '../../models/refresh-queue';
+import {validateInputValue} from '../../plugins/utils/validation-utils';
 
 function populateFromWorkflow(form, workflow) {
   if (!workflow || typeof workflow === 'string') {
@@ -55,9 +57,16 @@ function populateFromWorkflow(form, workflow) {
     activeCycleList = loOrderBy(
       activeCycleList, ['start_date'], ['desc']);
     activeCycle = activeCycleList[0];
-    form.attr('workflow', {id: workflow.id, type: 'Workflow'});
+    form.attr('workflow',
+      {id: workflow.id, type: 'Workflow', title: workflow.title});
     form.attr('context', {id: workflow.context.id, type: 'Context'});
     form.attr('cycle', {id: activeCycle.id, type: 'Cycle'});
+
+    if (!form._transient) {
+      form.attr('_transient', canMap());
+    }
+    form.attr('_transient.workflow',
+      {id: workflow.id, type: 'Workflow', title: workflow.title});
 
     // reset cycle task group after workflow updating
     form.attr('cycle_task_group', null);
@@ -208,6 +217,9 @@ export default Cacheable.extend({
       value: null,
       validate: {
         required: true,
+        validateAutosuggestFieldValue() {
+          return validateInputValue('workflow', this);
+        },
       },
     },
     cycle: {
@@ -220,6 +232,9 @@ export default Cacheable.extend({
       value: null,
       validate: {
         required: true,
+        validateAutosuggestFieldValue() {
+          return validateInputValue('cycle_task_group', this);
+        },
       },
     },
     start_date: {

--- a/src/ggrc-client/js/plugins/tests/utils/validation-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/utils/validation-utils_spec.js
@@ -7,7 +7,7 @@ import canMap from 'can-map/can-map';
 import canList from 'can-list/can-list';
 import canModel from 'can-model/src/can-model';
 
-import {isValidAttr, validateAttr} from '../../utils/validation-utils';
+import {isValidAttr, validateAttr, validateInputValue} from '../../utils/validation-utils';
 
 describe('validation utils', () => {
   describe('validateAttr util', () => {
@@ -156,5 +156,51 @@ describe('validation utils', () => {
         expect(result).toBeFalsy();
       }
     );
+  });
+
+  describe('validateInputValue() util', () => {
+    let instance;
+    let field;
+
+    beforeEach(() => {
+      instance = new canModel();
+      field = 'testField';
+    });
+
+    it('returns FALSE if instance doesn\'t have field', () => {
+      instance.attr(field, null);
+
+      const result = validateInputValue(field, instance);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns FALSE if instance doesn\'t have transient field', () => {
+      instance.attr(`_transient.${field}`, null);
+
+      const result = validateInputValue(field, instance);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns FALSE if title of field equals title of transient field',
+      () => {
+        instance.attr(`_transient.${field}`, {title: 'test_title'});
+        instance.attr(field, {title: 'test_title'});
+
+        const result = validateInputValue(field, instance);
+
+        expect(result).toBe(false);
+      });
+
+    it('returns TRUE if title of field doesn\'t equal' +
+      'title of transient field', () => {
+      instance.attr(`_transient.${field}`, {title: 'test_title'});
+      instance.attr(field, {title: 'test_title2'});
+
+      const result = validateInputValue(field, instance);
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/src/ggrc-client/js/plugins/utils/validation-utils.js
+++ b/src/ggrc-client/js/plugins/utils/validation-utils.js
@@ -80,7 +80,27 @@ const validateAttr = (instance, attribute) => {
   return propertyErrors;
 };
 
+/**
+ * A check that current value of validation field
+ * should be equal to the value from autocomplete input
+ * @param {String} fieldName - name of field for validation
+ * @param {canMap} instance - instance under validation
+ *
+ * @return {Boolean} return condition for displaying error
+ */
+const validateInputValue = (fieldName, instance) => {
+  const currentField = instance[fieldName];
+  const transientField = instance.attr(`_transient.${fieldName}`);
+
+  if (currentField && transientField) {
+    return currentField.title !== transientField.title;
+  } else {
+    return false;
+  }
+};
+
 export {
   isValidAttr,
   validateAttr,
+  validateInputValue,
 };

--- a/src/ggrc-client/js/plugins/validation-extensions.js
+++ b/src/ggrc-client/js/plugins/validation-extensions.js
@@ -100,6 +100,10 @@ validatejs.validators.validateUniqueTitle = (value,
   }
 };
 
+validatejs.validators.validateAutosuggestFieldValue = () => {
+  // Symbol ^ helps to discard attribute title in error message
+  return '^Invalid value. Please select a valid value from autosuggest.';
+};
 /*
  * Validate a comma-separated list of possible values defined by the
  * custom attribute definition.

--- a/src/ggrc-client/js/templates/cycle_task_group_object_tasks/modal-content.stache
+++ b/src/ggrc-client/js/templates/cycle_task_group_object_tasks/modal-content.stache
@@ -152,6 +152,7 @@
                 isQueryAutocompleteEnabled:from="true"
                 pathToField:from="'cycle_task_group.id'">
                 <input {{^if instance.cycle}}disabled{{/if}}
+                    {{#instance.computed_errors.workflow}}disabled{{/instance.computed_errors.workflow}}
                     class="input-block-level required"
                     name="{{pathToField}}"
                     data-lookup="CycleTaskGroup"


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Fields that will be affected:
1. Audit Firm (add/edit audit pop-up);
2. Program (add/edit audit pop-up);
3. Active Workflow (add/edit cycle-task pop-up);
4. Task Group (add/edit cycle-task pop-up).

User clicks 'Start New Audit' button on dashboard.
On 'Create' Audit pop-up, start typing existing name of program in 'Program' field and select it from autosuggest.
Move focus into 'Program' field and change the name of selected program to non-existing.
Move focus out of the field.
Actual result: invalid name of program is still displayed. When Audit is saved, it will be saved with program selected on step 2.
This behaviour is reproduced on cycle-task pop-up with workflow and task group fields.

# Steps to test the changes

1. Launch GGRC.
2. Click on "Start new Audit".
3. Add Program and Audit Firm
4. Edit this values.
Expected: Save button is in disabled state, error message "Invalid value. Please select a valid value from autosuggest" displays under the field.
1. Click on "Create a Task".
2. Add Workflow and Task Group.
3. Edit this values.
 Expected: Save button is in disabled state, error message "Invalid value. Please select a valid value from autosuggest" displays under the field.

# Solution description

Added validation for this fields, if we manually edit chosen value it will be displayed error message.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
