### PR TITLE
GGRC-8512 Confirm user cannot update Scope obj status

### DIFF
--- a/test/selenium/src/lib/page/widget/info_widget.py
+++ b/test/selenium/src/lib/page/widget/info_widget.py
@@ -6,6 +6,9 @@
 
 import re
 import time
+
+import inflection
+
 from lib import base
 from lib.app_entity_factory import entity_factory_common
 from lib.constants import (
@@ -98,7 +101,7 @@ class ReadOnlyInfoWidget(page_mixins.WithPageElements, base.Widget,
     """Returns object's status label element."""
     return page_elements.StatusLabel(
         self._root.element(class_name=re.compile("state-value state")),
-        with_inline_edit=(self.child_cls_name.lower()
+        with_inline_edit=(inflection.underscore(self.child_cls_name)
                           in objects.ALL_DISABLED_OBJECTS))
 
   def status(self):

--- a/test/selenium/src/tests/test_disabled_objects.py
+++ b/test/selenium/src/tests/test_disabled_objects.py
@@ -205,7 +205,8 @@ class TestDisabledObjects(base.Test):
         webui_facade.are_tabs_urls_equal(), "Tabs urls should be equal.")
     soft_assert.assert_expectations()
 
-  @pytest.mark.parametrize("obj", objects.SINGULAR_CONTROL_AND_RISK,
+  @pytest.mark.parametrize("obj", objects.SINGULAR_CONTROL_AND_RISK +
+                           [next(objects.SINGULAR_SCOPE_OBJS_ITERATOR)],
                            indirect=True)
   def test_cannot_upd_disabled_obj_status(self, obj, selenium):
     """Check that user cannot update disabled object status."""


### PR DESCRIPTION

# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #10545 

# Issue description

Confirm user cannot update Scope obj status

# Steps to test the changes

# Solution description

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
