### PR TITLE
GGRC-8021 LCA changes are not displayed in the Assessment template change log

### DIFF
--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -388,7 +388,7 @@ def prepare_content_full_diff(instance_meta_info, l_content, r_content):
       "custom_attribute_values",
       # `custom_attribute_definitions` is ignored since all possible obj
       # changes related with any change in CAD would be reflected in CAV.
-      "custom_attribute_definitions",
+      # "custom_attribute_definitions",
       # The following fields are ignored cause they may differ but revisions
       # still may represent objects of same state.
       "created_at",

--- a/src/ggrc/utils/revisions_diff/builder.py
+++ b/src/ggrc/utils/revisions_diff/builder.py
@@ -386,9 +386,6 @@ def prepare_content_full_diff(instance_meta_info, l_content, r_content):
       # already been calculated in `_construct_diff` function call.
       "access_control_list",
       "custom_attribute_values",
-      # `custom_attribute_definitions` is ignored since all possible obj
-      # changes related with any change in CAD would be reflected in CAV.
-      # "custom_attribute_definitions",
       # The following fields are ignored cause they may differ but revisions
       # still may represent objects of same state.
       "created_at",

--- a/test/integration/ggrc/models/mixins/test_customattributable.py
+++ b/test/integration/ggrc/models/mixins/test_customattributable.py
@@ -561,6 +561,33 @@ class TestCADUpdate(TestCase):
     )
     self.assert200(response)
 
+    cad = models.CustomAttributeDefinition.query.filter(
+        models.CustomAttributeDefinition.title == "test_lca"
+    ).first()
+    self.assertTrue(cad)
+
+  def test_delete_cad_via_put(self):
+    """Test removing CAD via PUT for Assessment Template"""
+    with factories.single_commit():
+      audit = factories.AuditFactory()
+      template = factories.AssessmentTemplateFactory(audit=audit)
+      factories.CustomAttributeDefinitionFactory(
+          definition_type='assessment_template',
+          title='test_lca',
+          definition_id=template.id,
+      )
+
+    response = self.api.put(
+        template,
+        {'custom_attribute_definitions': []}
+    )
+    self.assert200(response)
+
+    cad = models.CustomAttributeDefinition.query.filter(
+        models.CustomAttributeDefinition.title == "test_lca"
+    ).first()
+    self.assertFalse(cad)
+
   def test_no_changes_cad_id_add(self):
     """Test no changes CAD id when add CAD to Assessment Template"""
     with factories.single_commit():

--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -3,7 +3,7 @@
 
 """ Tests for ggrc.models.Revision """
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, too-many-public-methods
 
 from datetime import datetime
 
@@ -671,7 +671,7 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
     self.assertIn("created_by", revision.content)
     self.assertEqual(None, revision.content["created_by"])
 
-  def test_assessment_template(self):
+  def test_assessment_template_revision(self):
     """Test changes in revision for assessment template with lca"""
     with factories.single_commit():
       audit = factories.AuditFactory()
@@ -737,4 +737,3 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
     self.assertEqual(len(cad_from_revision), 2)
     self.assertGreaterEqual(cad_from_revision[0], lca_1)
     self.assertGreaterEqual(cad_from_revision[1], lca_2)
->>>>>>> Add LCA to assessment template revision


### PR DESCRIPTION
# Issue description

LCA changes are not displayed in the Assessment template change log.

# Steps to test the changes

1. Open any Audit
2. Create Assessment template with LCA
3. Open Assessment template and add any LCA e.g Text
4. Open revision in DB for edited Assessment template
**Expected result:** In revision content should be information about LCA.

# Solution description

Solution for this issue consists of two parts: BE and FE (#10569)

From BE part of solution was added to function `log_json` in file `src/ggrc/models/mixins/customattributable.py` checking of custom attribute definitions. What provides the addition of information about LCA to assessment template revision.
Also was changed `prepare_content_full_diff` from `src/ggrc/utils/revisions_diff/builder.py`, because changes in custom attribute definitions were ignored in step of building revision.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
