### PR TITLE
GGRC-8216 Add possibility to prevent close simple modal after clicking ESC button

### DIFF
--- a/src/ggrc-client/js/components/simple-modal/simple-modal.js
+++ b/src/ggrc-client/js/components/simple-modal/simple-modal.js
@@ -41,9 +41,23 @@ export default canComponent.extend({
     showHideModal(showModal) {
       const $modalWrapper = this.attr('modalWrapper');
       if (showModal) {
-        $modalWrapper.modal().on('hidden.bs.modal', this.hide.bind(this));
+        $modalWrapper
+        // current keyup handler should be hung before modal initialization,
+        // because the handler which close modal by pressing on escape hung during initialization,
+        // and the current handler that blocks modal closing
+        // should be in the queue of calling handlers before the modal closing handler
+          .on('keyup', this.disableEscape.bind(this))
+          .modal()
+          .on('hidden.bs.modal', this.hide.bind(this));
       } else {
         $modalWrapper.modal('hide').off('hidden.bs.modal');
+      }
+    },
+    disableEscape(event) {
+      if (event.code === 'Escape' && this.isDisabled) {
+        // should use "stopImmediatePropagation" because current handler
+        // should prevent calling other handlers hung on this element
+        event.stopImmediatePropagation();
       }
     },
   }),


### PR DESCRIPTION
# Issue description
Disable possibility closing modal by pressing escape when modal disabled.

# Steps to test the changes 
1. Create AT with dropdown that will have "EVIDENCE FILE REQUIRED" option.
2. Create Assessment with this AT.
3. Select option with "EVIDENCE FILE REQUIRED".
4. Upload file.
5. Press ESC when modal load file.
**Actual Result**: Modal will be closed.
**Expected result**: Modal will not be closed.

# Solution description 
Add handler of escape event which will cancel the closing.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".