### PR TITLE
GGRC-8574 Add test checking assessment detail page on bulk verify modal GGRC-8582 Add test checking opening of assessment in bulk verify modal

### DIFF
--- a/test/selenium/src/lib/base.py
+++ b/test/selenium/src/lib/base.py
@@ -738,13 +738,6 @@ class UnifiedMapperTreeView(TreeView):
     return MapperSetVisibleFieldsModal(self._driver, self.fields_to_set)
 
 
-class BulkUpdateTreeView(UnifiedMapperTreeView):
-  """Tree-View class for Bulk Update modal."""
-
-  def __init__(self, driver=None, obj_name=None):
-    super(BulkUpdateTreeView, self).__init__(driver, obj_name)
-
-
 class AdminTreeView(TreeView):
   """Class for representing Tree View list in Admin dashboard."""
   _locators = constants.locator.AdminTreeView

--- a/test/selenium/src/lib/page/modal/bulk_update.py
+++ b/test/selenium/src/lib/page/modal/bulk_update.py
@@ -2,7 +2,8 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 """Models for bulk update modals."""
 import re
-from lib import base, decorator
+
+from lib import base, decorator, browsers
 from lib.constants import objects, value_aliases
 from lib.element import page_elements
 
@@ -139,16 +140,7 @@ class SelectAssessmentsToVerifySection(page_elements.CollapsiblePanel):
 
   @property
   def tree_view(self):
-    return base.BulkUpdateTreeView(obj_name=objects.ASSESSMENTS)
-
-  @property
-  def tree_view_items(self):
-    """Returns assessment tree view items."""
-    tree_view_items = []
-    for scope in self.get_objs_scopes():
-      tree_view_items.append(
-          self.get_tree_view_item_by_title(title=scope["TITLE"]))
-    return tree_view_items
+    return BulkUpdateTreeView(obj_name=objects.ASSESSMENTS)
 
   def get_tree_view_item_by_title(self, title):
     """Gets assessment tree view item from tree view by its title."""
@@ -188,12 +180,37 @@ class SelectAssessmentsToVerifySection(page_elements.CollapsiblePanel):
     return scopes
 
 
-class AssessmentTreeViewItem(object):
+class BulkUpdateTreeView(base.UnifiedMapperTreeView):
+  """Tree-View class for Bulk Update modal."""
+
+  def __init__(self, driver=None, obj_name=None):
+    super(BulkUpdateTreeView, self).__init__(driver, obj_name)
+
+  def _init_tree_view_items(self):
+    """Init Tree View items as list of AssessmentTreeViewItem from current
+    widget.
+
+    Returns:
+      list of AssessmentTreeViewItem entities or empty list if no items found
+      in tree view.
+    """
+    self.wait_loading_after_actions()
+    self._tree_view_items = (
+        [] if self._browser.div(class_name="well well-small").exists else [
+            AssessmentTreeViewItem(element)
+            for element in self._browser.elements(
+                tag_name="mapper-results-item")])
+    return self._tree_view_items
+
+
+class AssessmentTreeViewItem(base.TreeViewItem):
   """Class represents Assessment item from Select Assessments section of
   Bulk update modal."""
   # pylint: disable=invalid-name
 
   def __init__(self, parent_element):
+    super(AssessmentTreeViewItem, self).__init__(
+        browsers.get_driver(), parent_element.wd)
     self._root = parent_element
     self.mapped_control_section = self._root.element(
         tag_name="collapsible-panel", text="Mapped Controls")

--- a/test/selenium/src/lib/service/webui_facade.py
+++ b/test/selenium/src/lib/service/webui_facade.py
@@ -615,14 +615,16 @@ def soft_assert_detailed_page_of_asmt_tree_view_item_is_readonly(
   verifies that it is False.
   """
   attrs = [attr for attr in dir(asmt_tree_view_item)
-           if not attr.startswith('__')]
-  for attr in attrs:
-    match = re.search(r"\bis_(.+?)_section_editable\b", attr)
-    if match:
+           if attr.endswith("_section_editable")]
+  if attrs:
+    for attr in attrs:
       soft_assert.expect(
           getattr(asmt_tree_view_item, attr) is False,
           '{} section should be not editable'.format(
-              match.group(1).replace('_', ' ').capitalize()))
+              re.search(r"\bis_(.+?)_section_editable\b", attr).group(1).
+              replace('_', ' ').capitalize()))
+  else:
+    raise ValueError("No needed attributes found.")
 
 
 def soft_assert_asmt_tree_view_items_on_bulk_verify_modal(
@@ -633,7 +635,9 @@ def soft_assert_asmt_tree_view_items_on_bulk_verify_modal(
   Firstly checks opening of assessment info page through open button, then
   checks that mapped controls section and evidence urls section from second
   tier are read-only."""
-  for asmt_tree_view_item in modal.select_assessments_section.tree_view_items:
+  for asmt_tree_view_item in (
+      modal.select_assessments_section.tree_view.tree_view_items()
+  ):
     asmt_tree_view_item.open()
     _, new_tab = browsers.get_browser().windows()
     test_utils.wait_for(lambda nt=new_tab: nt.url.endswith(url.Widget.INFO))

--- a/test/selenium/src/lib/service/webui_facade.py
+++ b/test/selenium/src/lib/service/webui_facade.py
@@ -605,6 +605,46 @@ def soft_assert_bulk_verify_filter_functionality(page, modal, exp_asmt,
       *exp_asmt.bulk_update_modal_tree_view_attrs_to_exclude)
 
 
+def soft_assert_detailed_page_of_asmt_tree_view_item_is_readonly(
+    soft_assert, asmt_tree_view_item
+):
+  """Soft assert detailed page of assessment tree view item is readonly.
+
+  Function checks attributes which matches pattern
+  "is_*section_name*_section_editable" of AssessmentTreeViewItem obj and
+  verifies that it is False.
+  """
+  attrs = [attr for attr in dir(asmt_tree_view_item)
+           if not attr.startswith('__')]
+  for attr in attrs:
+    match = re.search(r"\bis_(.+?)_section_editable\b", attr)
+    if match:
+      soft_assert.expect(
+          getattr(asmt_tree_view_item, attr) is False,
+          '{} section should be not editable'.format(
+              match.group(1).replace('_', ' ').capitalize()))
+
+
+def soft_assert_asmt_tree_view_items_on_bulk_verify_modal(
+    soft_assert, modal, exp_asmt
+):
+  """Checks assessment tree view items from bulk verify modal.
+
+  Firstly checks opening of assessment info page through open button, then
+  checks that mapped controls section and evidence urls section from second
+  tier are read-only."""
+  for asmt_tree_view_item in modal.select_assessments_section.tree_view_items:
+    asmt_tree_view_item.open()
+    _, new_tab = browsers.get_browser().windows()
+    test_utils.wait_for(lambda nt=new_tab: nt.url.endswith(url.Widget.INFO))
+    soft_assert.expect(
+        new_tab.url == exp_asmt.url + url.Widget.INFO,
+        '{} info page should be opened in new tab'.format(exp_asmt.title))
+    new_tab.close()
+    soft_assert_detailed_page_of_asmt_tree_view_item_is_readonly(
+        soft_assert, asmt_tree_view_item)
+
+
 def soft_assert_asmts_list_on_bulk_verify_modal(modal, soft_assert, exp_asmts):
   """Checks that assessments list is displayed on bulk verify modal with
   correct columns by default and that checkboxes are displayed near every

--- a/test/selenium/src/tests/test_asmts_bulk_update.py
+++ b/test/selenium/src/tests/test_asmts_bulk_update.py
@@ -141,7 +141,7 @@ class TestBulkVerify(base.Test):
     return asmts_not_for_bulk_verify_filter
 
   @pytest.fixture()
-  def asmts_to_include_by_bulk_verify_filter(
+  def asmt_to_include_by_bulk_verify_filter(
       self, control_mapped_to_program, audit, audit_w_auditor, second_creator
   ):
     """Creates assessment with 'In Review' state, map a comment, evidence url
@@ -223,10 +223,12 @@ class TestBulkVerify(base.Test):
   def test_bulk_verify_modal_filter(
       self, second_creator, login_as_creator, control_mapped_to_program,
       audit, asmts_to_exclude_by_bulk_verify_filter,
-      asmts_to_include_by_bulk_verify_filter, login_as_second_creator, page,
+      asmt_to_include_by_bulk_verify_filter, login_as_second_creator, page,
       soft_assert, selenium
   ):
-    """Check filter section of 'Bulk Verify' modal.
+    """Checks filter section of 'Bulk Verify' modal and assessment tree view
+    items on the modal.
+
     Precondition:
     - Audit 1 with mapped assessments in all statuses, 'In review' assessment
     has control snapshot, comment and evidence url.
@@ -235,7 +237,9 @@ class TestBulkVerify(base.Test):
     modal = page.open_bulk_verify_modal()
     webui_facade.soft_assert_bulk_verify_filter_ui_elements(modal, soft_assert)
     webui_facade.soft_assert_bulk_verify_filter_functionality(
-        page, modal, asmts_to_include_by_bulk_verify_filter, soft_assert)
+        page, modal, asmt_to_include_by_bulk_verify_filter, soft_assert)
+    webui_facade.soft_assert_asmt_tree_view_items_on_bulk_verify_modal(
+        soft_assert, modal, asmt_to_include_by_bulk_verify_filter)
     soft_assert.assert_expectations()
 
   @pytest.mark.parametrize('page', [audit_page, my_assessments_page])


### PR DESCRIPTION
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [x] #10616

# Solution description

Extends test test_bulk_verify_modal_filter with checks of opening assessment detail page and checks of expanded sections.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".
