### PR TITLE
GGRC-8594 Add populate_created_by method to Revision class

### DIFF
--- a/test/integration/ggrc/models/test_revision.py
+++ b/test/integration/ggrc/models/test_revision.py
@@ -638,3 +638,35 @@ class TestRevisions(query_helper.WithQueryApi, TestCase):
     self.assertFalse(revisions[0].is_empty)
     self.assertFalse(revisions[1].is_empty)
     self.assertTrue(revisions[2].is_empty)
+
+  def test_created_by_in_revision(self):
+    """Test revision for Risk contains created_by attr and its content."""
+    with factories.single_commit():
+      user = factories.PersonFactory()
+      risk = factories.RiskFactory(created_by=user)
+
+    revision = all_models.Revision.query.filter(
+        all_models.Revision.resource_id == risk.id,
+        all_models.Revision.resource_type == risk.type,
+    ).first()
+
+    expected_content = {u'context_id': None,
+                        u'href': u'/api/people/{}'.format(user.id),
+                        u'type': user.type,
+                        u'id': user.id,
+                        u'email': user.email}
+
+    self.assertIn("created_by", revision.content)
+    self.assertEqual(expected_content, revision.content["created_by"])
+
+  def test_created_by_none_in_revision(self):
+    """Test revision for Risk contains created_by attr and contains None."""
+    risk = factories.RiskFactory()
+
+    revision = all_models.Revision.query.filter(
+        all_models.Revision.resource_id == risk.id,
+        all_models.Revision.resource_type == risk.type,
+    ).first()
+
+    self.assertIn("created_by", revision.content)
+    self.assertEqual(None, revision.content["created_by"])

--- a/test/unit/ggrc/models/test_revision.py
+++ b/test/unit/ggrc/models/test_revision.py
@@ -246,6 +246,21 @@ class TestCheckPopulatedContent(unittest.TestCase):
     self.assertEqual(revision.populate_type(), {"type": "Program"})
 
   @ddt.data(
+      [{}, {"created_by": None}],
+      [{"created_by": "test_user"}, {}],
+      [{"created_by": None}, {}]
+  )
+  @ddt.unpack
+  def test_populate_created_by(self, content, expected_content):
+    """Test populate_created_by for Risk object."""
+    obj = mock.Mock()
+    obj.id = self.object_id
+    obj.__class__.__name__ = "Risk"
+
+    revision = all_models.Revision(obj, mock.Mock(), mock.Mock(), content)
+    self.assertEqual(revision.populate_created_by(), expected_content)
+
+  @ddt.data(
       [
           {"review_status": "a"},
           {"review_status": "a", "review_status_display_name": "a"},


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Created By attribute is not displayed in Change Log for Risks 

# Steps to test the changes

1.	Create Risk object on GGRCQ side
2.	Open created Risk on GGRC side
3.	Open Change Log tab
Expected: Created By attribute is displayed in Change log

# Solution description

Add populate_created_by method to Revision class.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
