### PR TITLE
GGRC-8605 FE: Cancel import button

### DIFF
--- a/src/ggrc-client/js/components/import-export/csv-import.js
+++ b/src/ggrc-client/js/components/import-export/csv-import.js
@@ -96,6 +96,15 @@ export default canComponent.extend({
           return getImportUrl();
         },
       },
+      isShowCancel: {
+        get() {
+          return [
+            jobStatuses.NOT_STARTED,
+            jobStatuses.ANALYSIS_FAILED,
+            jobStatuses.FAILED,
+          ].includes(this.attr('state'));
+        },
+      },
     },
     quickTips,
     importedObjectsCount: 0,
@@ -422,6 +431,19 @@ export default canComponent.extend({
             this.attr(`removeInProgressItems.${id}`, false);
           });
       }
+    },
+    onCancel() {
+      deleteImportJob(this.jobId)
+        .then(() => {
+          this.resetFile();
+        })
+        .catch((error) => {
+          if (error.status === 404) {
+            this.resetFile();
+            return;
+          }
+          handleAjaxError(error);
+        });
     },
   }),
   events: {

--- a/src/ggrc-client/js/components/import-export/templates/csv-import.stache
+++ b/src/ggrc-client/js/components/import-export/templates/csv-import.stache
@@ -126,6 +126,16 @@
       {{/switch}}
 
       <download-template></download-template>
+
+      {{#if isShowCancel}}
+        <button
+          type="button"
+          class="btn btn-small btn-white"
+          on:el:click="onCancel()"
+        >
+          Cancel
+        </button>
+      {{/if}}
     </div>
 
     {{#isImportStopped}}


### PR DESCRIPTION
# Issue description
Add Cancel button according to the mockup in the ticket [UX/UI] Cancel import.
User should be able to remove the results of previous import on the import page.

# Steps to test the changes 
1. Open import page.
2. Choose file.
**Actual Result**: The cancel button did not appear after analysis.
**Expected result**: The cancel button appeared after analysis.

# Solution description 
Add "Cancel" button for "Not Started", "Failed" and "Analysis failed" statuses.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".