### PR TITLE
GGRC-8285 remove the possibility of changing state from archived to unarchived for workflows via api put

### DIFF
--- a/src/ggrc_workflows/models/workflow.py
+++ b/src/ggrc_workflows/models/workflow.py
@@ -298,8 +298,20 @@ class Workflow(roleable.Roleable,
     if value is None:
       return self.is_verification_needed
     if self.status != self.DRAFT and value != self.is_verification_needed:
-      raise ValueError("is_verification_needed value isn't changeble "
+      raise ValueError("is_verification_needed value isn't changeable "
                        "on workflow with '{}' status".format(self.status))
+    return value
+
+  @orm.validates('recurrences')
+  def validate_recurrences(self, _, value):
+    # pylint: disable=unused-argument
+    """Validate recurrences field for Workflow.
+
+    It's not allowed to change recurrences flag for archived workflow.
+    """
+    if self.workflow_archived and value:
+      raise ValueError("recurrences value isn't changeable "
+                       "for archived workflow")
     return value
 
   @property

--- a/test/integration/ggrc/generator.py
+++ b/test/integration/ggrc/generator.py
@@ -75,13 +75,25 @@ class Generator(object):
         response_obj = None
     return response, response_obj
 
+  @staticmethod
+  def get_object_from_response(response, obj_class, obj_name):
+    """Try to get the object from response.
+
+    If response does not contain the object, return None
+    """
+    try:
+      return obj_class.query.get(response.json[obj_name]['id'])
+    except KeyError:
+      return None
+
   def modify(self, obj, obj_name, data):
     """Make a PUT request to modify `obj` with new fields in `data`."""
     obj_class = obj.__class__
     response = self.api.put(obj, data)
     response_obj = None
     if response.status_code == 200 and response.json:
-      response_obj = obj_class.query.get(response.json[obj_name]['id'])
+      response_obj = self.get_object_from_response(response, obj_class,
+                                                   obj_name)
     return response, response_obj
 
   def obj_to_dict(self, obj, model_name=None):

--- a/test/integration/ggrc_workflows/models/factories.py
+++ b/test/integration/ggrc_workflows/models/factories.py
@@ -21,6 +21,18 @@ class WorkflowFactory(TitledFactory):
   context = factory.SubFactory(ContextFactory)
 
 
+class WorkflowArchivedFactory(TitledFactory):
+
+  class Meta:
+    model = models.Workflow
+
+  context = factory.SubFactory(ContextFactory)
+  recurrences = False
+  unit = models.Workflow.WEEK_UNIT
+  repeat_every = 1
+  next_cycle_start_date = date.today()
+
+
 class TaskGroupFactory(TitledFactory):
 
   class Meta:

--- a/test/integration/ggrc_workflows/models/test_workflow.py
+++ b/test/integration/ggrc_workflows/models/test_workflow.py
@@ -247,6 +247,16 @@ class TestWorkflow(TestCase):
       workflow = all_models.Workflow.query.get(wf_id)
       self.assertEqual(all_models.Workflow.INACTIVE, workflow.status)
 
+  def test_unarchive_workflow_returns_status_400(self):  # noqa pylint: disable=invalid-name
+    """Archived workflow should prohibit activation"""
+    with freezegun.freeze_time("2017-08-10"):
+      workflow = factories.WorkflowArchivedFactory()
+
+      response, _ = self.generator.modify_workflow(workflow,
+                                                   {'recurrences': True})
+
+      self.assert400(response)
+
   @ddt.data(
       ('One time workflow', None, None),
       ('Daily workflow', all_models.Workflow.DAY_UNIT, 1),


### PR DESCRIPTION
# Issue description

Archived workflow can be unarchived via an API call. This is invalid behavior. Unarchiving should be prohibited

# Steps to test the changes

1. Create workflow
2. Archive workflow via UI
3. Send API GET request for Workflow from the previous step in Postman e.g **qa instance** /api/workflows/2141
4. Copy body of the request
5. Paste copied body in request body in Postman
6. Change "recurrences" value in body to "true" 
7. Change API method to PUT
8. Add the following headers
Content-Type:application/json
x-requested-by:GGRC
If-Unmodified-Since:{{last-modified}}
If-Match:{{etag}}
x-usertimezoneoffset:180
Accept-Encoding:gzip, deflate, br
9. Add the following script to the Pre-request Script tab:
pm.sendRequest(" **qa instance** /api/workflows/2141", function (err, response){
pm.globals.set("etag", response.headers.get("etag"));
pm.globals.set("last-modified", response.headers.get("last-modified"));
});
10. Send Request
12. Open Workflow ion UI and review
Actual Result: Workflow object was unarchived
Expected Result: Unarchiving Workflow should be prohibited via API

# Solution description

Added validation on `recurrences` field update. Validation fails when the field is being updated for an archived workflow. On failed validation HTTP 400 bad request with the message "recurrences value isn't changeable for archived workflow"

# Sanity checklist

- [ ] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->

# Suggestions

Currently, tests make multiple calls and have multiple assertions. This may lead to a single unit test having more than one responsibility. A good unit test, ideally, should prepare test data without making api calls. 
`test_unarchive_workflow` was written like `test_archive_workflow` and thus has it's pros and cons. We can create archived Workflow at the beginning of the test in a single step without API calls. This will speed up the test. A new factory class can be introduced for creating archived workflow so other TCMs could benefit from it. 

Let me know if you agree with my proposal.