### PR TITLE
GGRC-8117 List of proposals blinks when the second page is opened on Change Proposals tab for a Program

### DIFF
--- a/src/ggrc-client/js/components/related-objects/related-objects.js
+++ b/src/ggrc-client/js/components/related-objects/related-objects.js
@@ -100,8 +100,6 @@ export default canComponent.extend({
     async loadRelatedItems() {
       try {
         const params = this.getParams();
-        this.attr('isLoading', true);
-
         const data = await batchRequests(params);
 
         const relatedType = this.attr('relatedItemsType');
@@ -115,8 +113,6 @@ export default canComponent.extend({
         return result;
       } catch {
         return [];
-      } finally {
-        this.attr('isLoading', false);
       }
     },
     getSortingInfo: function () {
@@ -134,15 +130,20 @@ export default canComponent.extend({
         name: orderBy.attr('field'),
         desc: orderBy.attr('direction') === 'desc'}];
     },
-    setRelatedItems: async function () {
-      let items = await this.loadRelatedItems();
+    async setRelatedItems() {
+      try {
+        this.attr('isLoading', true);
+        let items = await this.loadRelatedItems();
 
-      this.attr('relatedObjects').replace(items);
+        this.attr('relatedObjects').replace(items);
 
-      this.attr('baseInstance').dispatch({
-        ...RELATED_REFRESHED,
-        model: this.attr('relatedItemsType'),
-      });
+        this.attr('baseInstance').dispatch({
+          ...RELATED_REFRESHED,
+          model: this.attr('relatedItemsType'),
+        });
+      } finally {
+        this.attr('isLoading', false);
+      }
     },
   }),
   init: function () {


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

While opening another page with proposals on program, related proposals after loading doesn't update immediately and old values is displaying throughout ~500 ms after the spinner disappeared.

# Steps to test the changes

1. Create a Program on GGRC
2. Make 6 proposals for the Program
3. Click on Change proposals tab
4. Click on the 2nd page of the proposals
Actual result: the first 5 proposals display for 1-2 sec as blinking on the second page where only the 6th proposal is placed
Expected result: the second page should open a list of proposals without blinking of the list of proposals from the first page

# Solution description

Hiding a spinner moved to point after rendering loaded proposals.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
