### PR TITLE
GGRC-8099 Remove "Open in new tab" option for Tasks

### DIFF
--- a/src/ggrc-client/js/components/tree/templates/tree-item-actions.stache
+++ b/src/ggrc-client/js/components/tree/templates/tree-item-actions.stache
@@ -20,17 +20,14 @@
         </li>
 
         {{^if showReducedOptions}}
-
-          {{#if instance.viewLink}}
-            {{#unless isSnapshot}}
-              <!-- Link for open instance on new Browser tab -->
-              <li>
-                <a href="{{instance.viewLink}}" target="_blank" on:el:click="openObject">
-                  <i class="fa fa-long-arrow-right"></i>
-                  Open in a new tab
-                </a>
-              </li>
-            {{/unless}}
+          {{#if isShowOpenInNewTab}}
+            <!-- Link for open instance on new Browser tab -->
+            <li>
+              <a href="{{instance.viewLink}}" target="_blank" on:el:click="openObject">
+                <i class="fa fa-long-arrow-right"></i>
+                Open in a new tab
+              </a>
+            </li>
           {{/if}}
 
           {{#if instance.constructor.isChangeableExternally}}

--- a/src/ggrc-client/js/components/tree/tree-item-actions.js
+++ b/src/ggrc-client/js/components/tree/tree-item-actions.js
@@ -111,6 +111,16 @@ const ViewModel = canDefineMap.extend({
       return !denyEditAndMap && !!mappingTypes.length;
     },
   },
+  isShowOpenInNewTab: {
+    type: 'boolean',
+    get() {
+      const instance = this.instance;
+
+      return instance.viewLink &&
+        !this.isSnapshot &&
+        (instance.type !== 'CycleTaskGroupObjectTask');
+    },
+  },
   maximizeObject(scope, el, ev) {
     ev.preventDefault();
     ev.stopPropagation();


### PR DESCRIPTION
# Issue description
We should remove Open in new tab option from tasks so as not to confuse the user with this option.

# Steps to test the changes 
1. Create any Workflow.
2. Open Task Group and map any object e.g Control.
3. Create Task.
4. Activate Workflow.
5. Open Active Cycles tab.
6. Open Task.
7. Click on object mapped to the Task.
8. Open Workflows Task tab.
9. Hover over the gear icon on the task created in the previous steps and click Open in new tab.

**Actual Result**: Control page is opened.
**Expected result**: Open in new tab option should be removed from the gear icon menu for tasks, because we do not have separate page for Task.

# Solution description 
Remove "Open in a new tab" option.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [ ] The changes fix the issue and don't cause any apparent regressions. 
- [ ] Labels and milestone are correctly set. 
- [ ] The solution description matches the changes in the code. 
- [ ] There is no apparent way to improve the performance & design of the new code. 
- [ ] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".