### PR TITLE
GGRC-8274 Mapping to Assessment is duplicated in Advanced Search

### DIFF
--- a/src/ggrc-client/js/components/tree-view-filter/tree-view-filter.js
+++ b/src/ggrc-client/js/components/tree-view-filter/tree-view-filter.js
@@ -231,12 +231,14 @@ const ViewModel = canDefineMap.extend({
     if (isObjectContextPage() && !advancedSearch.attr('parentInstance')) {
       advancedSearch.attr('parentInstance',
         AdvancedSearch.create.parentInstance(this.parentInstance));
+    }
 
-      // remove duplicates
+    // remove duplicates
+    if (advancedSearch.attr('parentInstance')) {
       const parentItems = filterParentItems(
         advancedSearch.attr('parentInstance'),
-        advancedSearch.attr('parentItems'));
-
+        advancedSearch.attr('parentItems')
+      );
       advancedSearch.attr('parentItems', parentItems);
     }
 


### PR DESCRIPTION
# Issue description
Mapping to Assessment is duplicated in Advanced Search.

# Steps to test the changes 
1. Open any Audit.
2. Create Assessment and open it in a new tab.
3. Open Audits tab.
4. Open Advanced search.
5. Add any Saved Search title and click Save Search button.
6. Copy Saved search link.
7. Open in a new tab.
8. Open Advanced Search and close it.
9. Open Advanced Search again.

**Actual Result**: Mapping to Assessment is duplicated in Advanced Search.
**Expected result**: Mapping to Assessment shouldn't duplicate in Advanced Search.

# Solution description 
Move filtering of duplicates to another condition.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".