### PR TITLE
GGRC-7389 Incorrect icons for people in Change Log tab in Assessment	

### DIFF
--- a/src/ggrc-client/js/components/revision-log/revision-page.stache
+++ b/src/ggrc-client/js/components/revision-log/revision-page.stache
@@ -11,7 +11,7 @@
   {{else}}
     {{#changeHistory}}
       <li {{#reviewWasChanged}} class="revision-log__status-{{reviewWasChanged}}" {{/reviewWasChanged}}>
-        <span class="person-label {{lowercase role }}"></span>
+        <role-avatar person:from="madeBy" roles:from="roles"/>
         <div class="w-status">
           <div class="entry-author">
             {{#if automapping}}

--- a/src/ggrc-client/js/components/revision-log/tests/revision-page_spec.js
+++ b/src/ggrc-client/js/components/revision-log/tests/revision-page_spec.js
@@ -8,6 +8,7 @@ import canMap from 'can-map';
 import {getComponentVM} from '../../../../js_specs/spec-helpers';
 import Component from '../revision-page';
 import Person from '../../../models/business-models/person';
+import * as ACLUtils from '../../../plugins/utils/acl-utils';
 
 describe('revision-page component', function () {
   let viewModel;
@@ -160,6 +161,7 @@ describe('revision-page component', function () {
 
     beforeEach(function () {
       spyOn(viewModel, '_objectCADiff').and.returnValue({});
+      spyOn(ACLUtils, 'getPersonRoleNames').and.returnValue([]);
     });
 
     beforeEach(function () {
@@ -218,7 +220,7 @@ describe('revision-page component', function () {
         };
 
         let result = viewModel._objectChangeDiff(rev1, rev2);
-        expect(result.role).toEqual('none');
+        expect(result.madeBy).toEqual('User 7');
       });
 
     it('dooes not include author\'s details ' +
@@ -236,7 +238,6 @@ describe('revision-page component', function () {
 
       let result = viewModel._objectChangeDiff(rev1, rev2);
       expect(result.madeBy).toBeNull();
-      expect(result.role).toEqual('none');
     });
 
     describe('with model attributes definitions defined', function () {
@@ -557,6 +558,7 @@ describe('revision-page component', function () {
 
   describe('_mappingChange() method', function () {
     beforeEach(function () {
+      spyOn(ACLUtils, 'getPersonRoleNames').and.returnValue([]);
       viewModel.attr('instance', {
         id: 123,
         type: 'ObjectFoo',
@@ -587,7 +589,7 @@ describe('revision-page component', function () {
 
       expect(result).toEqual({
         madeBy: 'User 17',
-        role: 'none',
+        roles: [],
         updatedAt: new Date('2015-05-17T17:24:01'),
         changes: {
           origVal: '—',
@@ -622,7 +624,7 @@ describe('revision-page component', function () {
 
       expect(result).toEqual({
         madeBy: 'User 17',
-        role: 'none',
+        roles: [],
         updatedAt: new Date('2015-05-17T17:24:01'),
         changes: {
           origVal: 'Created',
@@ -655,7 +657,7 @@ describe('revision-page component', function () {
 
       expect(result).toEqual({
         madeBy: null,
-        role: 'none',
+        roles: [],
         updatedAt: new Date('2015-05-17T17:24:01'),
         changes: {
           origVal: '—',
@@ -702,7 +704,7 @@ describe('revision-page component', function () {
 
       expect(result).toEqual({
         madeBy: 'User 17',
-        role: 'none',
+        roles: [],
         updatedAt: new Date('2015-05-17T17:24:01'),
         changes: {
           origVal: '—',
@@ -749,7 +751,7 @@ describe('revision-page component', function () {
           'DestinationType "DestinationTitle" to SourceType "SourceTitle")',
         },
         updatedAt: new Date('2015-05-17T17:24:01'),
-        role: 'none',
+        roles: [],
         changes: {
           origVal: '—',
           newVal: '',

--- a/src/ggrc-client/js/components/role-avatar/role-avatar.js
+++ b/src/ggrc-client/js/components/role-avatar/role-avatar.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+import canComponent from 'can-component';
+import canStache from 'can-stache';
+import loIncludes from 'lodash/includes';
+import canDefineMap from 'can-define/map/map';
+
+export default canComponent.extend({
+  tag: 'role-avatar',
+  view: canStache(
+    '<span class="person-label {{lowercase mainRole}}-avatar"></span>'
+  ),
+  leakScope: true,
+  viewModel: canDefineMap.extend({
+    roles: {
+      values: () => [],
+    },
+    person: {
+      value: null,
+    },
+    mainRole: {
+      value: 'none',
+    },
+    init() {
+      const roleImportanceOrder = ['Creators', 'Verifiers', 'Assignees'];
+      const mainRole = roleImportanceOrder.find((item) => {
+        return loIncludes(this.roles, item);
+      });
+      this.mainRole = mainRole || 'none';
+    },
+  }),
+});

--- a/src/ggrc-client/js/plugins/utils/acl-utils.js
+++ b/src/ggrc-client/js/plugins/utils/acl-utils.js
@@ -126,6 +126,22 @@ function isAuditor(audit, user) {
                  acl.person_id === user.id).length > 0;
 }
 
+/**
+ * Compute a list of role names that a person has.
+ *
+ * @param {Cacheable} instance - a model instance
+ * @param {Object} person - person object
+ *
+ * @return {Array} - list of role names
+ */
+function getPersonRoleNames(instance, person) {
+  const personRoleNames =
+    instance.attr('access_control_list')
+      .filter((item) => item.person_id === person.id)
+      .map((role) => getRoleById(role.ac_role_id).name);
+  return personRoleNames;
+}
+
 export {
   peopleWithRoleName,
   peopleWithRoleId,
@@ -133,4 +149,5 @@ export {
   getRole,
   getRoleById,
   isAuditor,
+  getPersonRoleNames,
 };

--- a/src/ggrc-client/styles/_modules.scss
+++ b/src/ggrc-client/styles/_modules.scss
@@ -42,3 +42,4 @@
 @import "modules/snapshot";
 @import "modules/dashboard-widget";
 @import "modules/snapshot-related-objects";
+@import "modules/role-avatars";

--- a/src/ggrc-client/styles/modules/_label-list.scss
+++ b/src/ggrc-client/styles/modules/_label-list.scss
@@ -23,10 +23,4 @@
     line-height: 20px;
     font-size: 12px;
   }
-  &.none {
-    background: $lightGray;
-    &:after {
-      content: "N";
-    }
-  }
 }

--- a/src/ggrc-client/styles/modules/_role-avatars.scss
+++ b/src/ggrc-client/styles/modules/_role-avatars.scss
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 Google Inc.
+ * Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+ */
+
+.assignees-avatar {
+    background: $olive;	
+    &:after {	
+      content: "A";	
+    }
+  }
+  .creators-avatar {
+    background: $orange;
+    &:after {
+      content: "C";
+    }
+  }
+  .verifiers-avatar {
+    background: $orange;
+    &:after {
+      content: "V";
+    }
+  }
+  .none-avatar {
+    background: $lightGray;
+    &:after {
+      content: "N";
+    }
+  }


### PR DESCRIPTION
# Issue description
Recently, we've had a logic, when a person associated with Assessment added a comment/file/url/mapping, there was a corresponding icon in Change Log tab, e.g.:

Assignee - "A";
Verifier - "V".
Currently, such logic is broken and 'N' icon is displayed for all the changes with Assessment screenshot-1.png.
# Steps to test the changes 
1. Open any assessment.
2. Assign yourself as Assessment assignee or verifier.
3. Leave a comment or add evidence url > Open Change Log tab.

**Actual Result**: 'N' icon is displayed.
**Expected Result**: 'A' (assignee) or 'V' (verifier) icon is displayed.
# Solution description 
Implement the display of different avatars according to the role. All changes were made based on PR #9629 when icons for roles were deleted.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".