### PR TITLE
GGRC-7533/GGRC-7531/GGRC-7595/GGRC-8004/GGRC-8212/GGRC-7943 Styles improving

### DIFF
--- a/src/ggrc-client/js/components/form/field-views/text-form-field-view.stache
+++ b/src/ggrc-client/js/components/form/field-views/text-form-field-view.stache
@@ -5,7 +5,9 @@
 
 <div class="view-wrapper">
   {{#if value}}
-    {{value}}
+    <read-more
+      text:from="value">
+    </read-more>
   {{else}}
     <span class="empty-message">None</span>
   {{/if}}

--- a/src/ggrc-client/js/components/saved-search/create-saved-search/create-saved-search.stache
+++ b/src/ggrc-client/js/components/saved-search/create-saved-search/create-saved-search.stache
@@ -3,7 +3,10 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<input type="text" placeholder="Type to Save Search" value:bind="searchName"/>
+<input  type="text"
+        placeholder="Type to Save Search"
+        value:bind="searchName"
+        class="saved-search-input" />
 <button type="button"
         class="btn btn-small btn-green {{#if isDisabled}}disabled{{/if}}"
         on:el:click="saveSearch()">

--- a/src/ggrc-client/js/models/business-models/risk.js
+++ b/src/ggrc-client/js/models/business-models/risk.js
@@ -23,7 +23,7 @@ export default Cacheable.extend({
     Reviewable,
     ChangeableExternally,
   ],
-  migrationDate: '06/13/2019',
+  migrationDate: '06/18/2019',
   is_custom_attributable: true,
   isRoleable: true,
   attributes: {

--- a/src/ggrc-client/js/templates/assessments/modal-content.stache
+++ b/src/ggrc-client/js/templates/assessments/modal-content.stache
@@ -97,56 +97,6 @@
             </div>
           </div>
 
-          {{#if new_object_form}}
-            <div class="ggrc-form-item">
-              <div class="ggrc-form-item__row">
-                <label class="ggrc-form-item__label assessment-template-dropdown">
-                  Select Assessment Template
-                  <i class="fa fa-question-circle"
-                    rel="tooltip"
-                    title="The following local custom attributes will be added to Assessment from chosen Assessment template.">
-                  </i>
-                </label>
-                <div class="template-select">
-                  <assessment-templates-dropdown
-                    instance:from="instance.audit"
-                    extraClassName:from="'template-select__dropdown'"
-                    on:vm:onTemplateChanged="onAssessmentTemplateChanged(scope.event)" />
-                  <spinner-component
-                    class="template-select__spinner"
-                    toggle:from="isInitialTemplateLoading" />
-                </div>
-              </div>
-            </div>
-            {{#if assessmentTemplate}}
-              {{#if assessmentTemplate.sox_302_enabled}}
-                <div class="ggrc-form-item">
-                  <div class="ggrc-form-item__row alert alert-nomargin">
-                    This assessment template enables “302 assessment workflow”:
-                    <p>
-                      - Assignees will have read only permissions upon assessment completion.
-                    </p>
-                    <p>
-                      - Verification step will be skipped if only positive answers are given for the assessment.
-                    </p>
-                  </div>
-                </div>
-              {{/if}}
-              <div class="ggrc-form-item">
-                <div class="ggrc-form-item__row">
-                    <label class="ggrc-form-item__label">
-                      Custom Attributes
-                    </label>
-                    <assessment-template-attributes
-                      instance:from="assessmentTemplate"
-                      fields:from="assessmentTemplate.custom_attribute_definitions"
-                      isLoading:from="isAttributesLoading"
-                      editMode:from="false" />
-                </div>
-              </div>
-            {{/if}}
-          {{/if}}
-
           <div class="ggrc-form-item">
             <div class="ggrc-form-item__row">
               <deferred-mapper class="width-100"
@@ -206,6 +156,56 @@
               </deferred-mapper>
             </div>
           </div>
+
+          {{#if new_object_form}}
+            <div class="ggrc-form-item">
+              <div class="ggrc-form-item__row">
+                <label class="ggrc-form-item__label assessment-template-dropdown">
+                  Select Assessment Template
+                  <i class="fa fa-question-circle"
+                    rel="tooltip"
+                    title="The following local custom attributes will be added to Assessment from chosen Assessment template.">
+                  </i>
+                </label>
+                <div class="template-select">
+                  <assessment-templates-dropdown
+                    instance:from="instance.audit"
+                    extraClassName:from="'template-select__dropdown'"
+                    on:vm:onTemplateChanged="onAssessmentTemplateChanged(scope.event)" />
+                  <spinner-component
+                    class="template-select__spinner"
+                    toggle:from="isInitialTemplateLoading" />
+                </div>
+              </div>
+            </div>
+            {{#if assessmentTemplate}}
+              {{#if assessmentTemplate.sox_302_enabled}}
+                <div class="ggrc-form-item">
+                  <div class="ggrc-form-item__row alert alert-nomargin">
+                    This assessment template enables “302 assessment workflow”:
+                    <p>
+                      - Assignees will have read only permissions upon assessment completion.
+                    </p>
+                    <p>
+                      - Verification step will be skipped if only positive answers are given for the assessment.
+                    </p>
+                  </div>
+                </div>
+              {{/if}}
+              <div class="ggrc-form-item">
+                <div class="ggrc-form-item__row">
+                    <label class="ggrc-form-item__label">
+                      Custom Attributes
+                    </label>
+                    <assessment-template-attributes
+                      instance:from="assessmentTemplate"
+                      fields:from="assessmentTemplate.custom_attribute_definitions"
+                      isLoading:from="isAttributesLoading"
+                      editMode:from="false" />
+                </div>
+              </div>
+            {{/if}}
+          {{/if}}
 
           <div class="additional-fields">
             <div class="expand-link">

--- a/src/ggrc-client/styles/components/saved-search-list/_saved-search-list.scss
+++ b/src/ggrc-client/styles/components/saved-search-list/_saved-search-list.scss
@@ -63,6 +63,10 @@ saved-search-list {
             margin-left: 6px;
             visibility: hidden;
           }
+
+          .fa-trash-o {
+            margin-bottom: 2px;
+          }
         }
 
         &.disabled {

--- a/src/ggrc-client/styles/modules/_audit-summary.scss
+++ b/src/ggrc-client/styles/modules/_audit-summary.scss
@@ -71,4 +71,8 @@
       }
     }
   }
+
+  svg > g > g:last-child {
+    pointer-events: none;
+  }
 }

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -183,7 +183,7 @@
     &.ui-disabled {
       @include disabled(0.5);
     }
-    input,
+    input:not(.saved-search-input),
     textarea,
     select {
       @include placeholder($footerBorder);


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

1. Input field in create-saved-search is not highlighted (Updated by BA: remove highlight from advanced search)
3. Incorrect layout of trash icon on Global Search
4. Select Assessment Template field should be below "Map Object" button on New assessment modal
5. Read more for dropdown LCA is not displayed
6. Pop up on Assessments diagram is blinking on hover
7. Incorrect date in UI message in Risk Change Log tab

# Steps to test the changes

1. Login GGRC app and open Advanced search
2. Save filter for any object type
3. Expected: `Type to save search` input doesn't highlighted
4. Hover over saved filter and look at the trash icon
5. Trash icon align on center
9. Open any Audit page
10. Open Assessments tab
11. Click Create button
12. Review Edit modal
13. Expected: Select Assessment Template field is displayed below the "Map Object" button
1. Open any Audit
2. Create Assessment template with Dropdown LCA with a big amount of text
3. Generate assessment using created in the previous steps template
4. Open generated Assessment
5. Expected: Read more for dropdown LCA is displayed
1. Hover over diagram so as to tooltip is over part of diagram, move cursor to this part of tooltip
2. Expected: Tooltip doesn't flickering
1. Open Risk Info page/pane
2. Click 'Change Log' tab
3. Check the date in the following message:
"The logs before and after migration to new UI on 06/18/2019 are available below."

# Solution description

Changed a styles

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
