### PR TITLE
GGRC-8674 Change list of default assignees, verifiers

### DIFF
--- a/src/ggrc/models/assessment_template.py
+++ b/src/ggrc/models/assessment_template.py
@@ -111,8 +111,6 @@ class AssessmentTemplate(assessment.AuditRelationship,
       ("Admin", "Object Admins"),
       ("Audit Lead", "Audit Captain"),
       ("Auditors", "Auditors"),
-      ("Principal Assignees", "Principal Assignees"),
-      ("Secondary Assignees", "Secondary Assignees"),
       ("Primary Contacts", "Primary Contacts"),
       ("Secondary Contacts", "Secondary Contacts"),
   ])

--- a/test/integration/ggrc/converters/test_export_assessment_templates.py
+++ b/test/integration/ggrc/converters/test_export_assessment_templates.py
@@ -6,7 +6,6 @@
 import ddt
 
 from ggrc.models.assessment_template import AssessmentTemplate
-from ggrc.models.assessment_template import _hint_verifier_assignees
 
 from integration.ggrc.models import factories
 from integration.ggrc import TestCase
@@ -83,10 +82,19 @@ class TestAssessmentTemplatesExport(TestCase):
     # pylint: disable=protected-access
 
     response = self.export_csv(self.EXPORT_ALL_FIELDS_DATA)
-    expected_description = _hint_verifier_assignees(
-        AssessmentTemplate._DEFAULT_PEOPLE_LABELS_ACTUAL,
-        AssessmentTemplate._DEFAULT_PEOPLE_LABELS_CONTROL,
-        AssessmentTemplate._DEFAULT_PEOPLE_LABELS_RISK
+    expected_description = (
+        "Allowed values are:\n"
+        "For all Assessment Types except of Control and Risk:"
+        "\nObject Admins\nAudit Captain\nAuditors\n"
+        "Primary Contacts\nSecondary Contacts\nuser@example.com\n"
+        "For Assessment type of Control:\n"
+        "Object Admins\nAudit Captain\nAuditors\nPrincipal Assignees\n"
+        "Secondary Assignees\nControl Operators\nControl Owners\n"
+        "Other Contacts\nuser@example.com\n"
+        "For Assessment type of Risk:\n"
+        "Object Admins\nAudit Captain\nAuditors\nPrincipal Assignees\n"
+        "Secondary Assignees\nRisk Owners\nOther Contacts\n"
+        "user@example.com"
     )
 
     self.assertEqual(response.status_code, 200)


### PR DESCRIPTION

# Issue description

Looks like Principal Assignees and Secondary Assignees are not applicable for Standard, Regulation, Requirement, Objective, Threat, Contract, Policy, Scope objects types.

# Steps to test the changes

Run application go to Import -> Download template -> Assessment Temaplate.
Look at description for "Default Assignees*" and "Default Verifiers" column

# Solution description 

Delete aliases for that roles from constant.

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [ ] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
