### PR TITLE
GGRC-6937 Align 'Hide' on 'Edit' and 'New' screens of all objects by right border of the field

### DIFF
--- a/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-folder-picker.stache
+++ b/src/ggrc-client/js/components/gdrive/templates/ggrc-gdrive-folder-picker.stache
@@ -3,13 +3,19 @@
     Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 }}
 
-<div>
+<div class="attachment-block__header">
   {{#unless hideLabel}}
     <label class="multi-type-label">
       Attachment
       <i class="fa fa-question-circle" rel="tooltip" data-original-title="If selected, all {{instance.constructor.title_singular}} attachments go here."></i>
     </label>
-    <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+    <a
+      href="javascript://"
+      class="attachment-block__hide field-hide"
+      tabindex="-1"
+    >
+      hide
+    </a>
   {{/unless}}
 </div>
 <div class="mapped-folder">

--- a/src/ggrc-client/js/templates/audits/modal-content.stache
+++ b/src/ggrc-client/js/templates/audits/modal-content.stache
@@ -100,7 +100,7 @@
 
           <div class="span6 hide-wrap hidable" data-hide-title="Audit Firm">
             <div class="row-fluid inner-hide">
-              <div class="span12 hidable" >
+              <div class="span7 hidable" >
                 <div class="objective-selector {{#instance.computed_errors.audit_firm}}field-failure{{/instance.computed_errors.audit_firm}}">
                   <object-loader path:from="instance.audit_firm">
                     <label>
@@ -113,12 +113,13 @@
                       pathToField:from="'audit_firm.title'">
                       <input
                         type="text"
-                        class="span8 search-icon"
+                        class="span12 search-icon"
                         name="{{pathToField}}"
                         value="{{loadedObject.title}}"
                         data-lookup="OrgGroup"
                         placeholder="Enter text to search for Audit Firm"
-                        tabindex="12">
+                        tabindex="12"
+                      />
                     </modal-autocomplete>
                   </object-loader>
                   {{#instance.computed_errors.audit_firm}}<label class="help-inline warning">{{this}}</label>{{/instance.computed_errors.audit_firm}}
@@ -199,12 +200,20 @@
                 isDisabled:from="isLoading"
                 on:createUrl="markDocumentForAddition(scope.event.payload)"
                 on:removeUrl="markDocumentForDeletion(scope.event.payload)">
-                <label>
-                  Evidence URL
-                  <i class="fa fa-question-circle" rel="tooltip" title="Web links to other references."></i>
-                  <spinner-component toggle:from="isDisabled"></spinner-component>
-                </label>
-                <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+                <div class="attachment-block__header">
+                  <label>
+                    Evidence URL
+                    <i class="fa fa-question-circle" rel="tooltip" title="Web links to other references."></i>
+                    <spinner-component toggle:from="isDisabled"></spinner-component>
+                  </label>
+                  <a 
+                    href="javascript://"
+                    class="attachment-block__hide field-hide"
+                    tabindex="-1"
+                  >
+                    hide
+                  </a>
+                </div>
               </related-urls>
             </related-documents>
           </deferred-mapper>

--- a/src/ggrc-client/js/templates/base_objects/modal-content-reference-urls.stache
+++ b/src/ggrc-client/js/templates/base_objects/modal-content-reference-urls.stache
@@ -20,12 +20,20 @@
         isDisabled:from="isLoading"
         on:createUrl="markDocumentForAddition(scope.event.payload)"
         on:removeUrl="markDocumentForDeletion(scope.event.payload)">
-        <label>
-          Reference URL
-          <i class="fa fa-question-circle" rel="tooltip" title="Web links to other references."></i>
-          <spinner-component toggle:from="isDisabled"></spinner-component>
-        </label>
-        <a href="javascript://" class="field-hide" tabindex="-1">hide</a>
+        <div class="attachment-block__header">
+          <label>
+            Reference URL
+            <i class="fa fa-question-circle" rel="tooltip" title="Web links to other references."></i>
+            <spinner-component toggle:from="isDisabled"></spinner-component>
+          </label>
+          <a 
+            href="javascript://"
+            class="attachment-block__hide field-hide"
+            tabindex="-1"
+          >
+            hide
+          </a>
+        </div>
       </related-urls>
     </related-documents>
   </deferred-mapper>

--- a/src/ggrc-client/js/templates/programs/modal-content.stache
+++ b/src/ggrc-client/js/templates/programs/modal-content.stache
@@ -60,12 +60,14 @@
         {{^new_object_form}}
           <access-control-list-roles-helper
             instance:from="instance"
+            isHidable:from="true"
             isNewInstance:from="new_object_form"
             readOnly:from="instance.readOnlyProgramRoles"
             includeRoles:from="instance.constructor.programRoles">
           </access-control-list-roles-helper>
           <access-control-list-roles-helper
             instance:from="instance"
+            isHidable:from="true"
             isNewInstance:from="new_object_form"
             excludeRoles:from="instance.constructor.programRoles">
           </access-control-list-roles-helper>

--- a/src/ggrc-client/styles/modules/_modal.scss
+++ b/src/ggrc-client/styles/modules/_modal.scss
@@ -403,6 +403,17 @@
       }
     }
 
+    .attachment-block {
+      &__header {
+        display: flex;
+      }
+
+      &__hide {
+        margin-top: 0;
+        margin-left: 5px;
+      }
+    }
+
     .custom-roles-modal {
       display: block;
       outline: none;


### PR DESCRIPTION
# Issue description
1. 'Hide' option is missed on some optional fields (people fields).
2. 'Hide' option is located far from the field.

# Steps to test the changes 
1. Open modals of objects that are listed  in "Solution description".
2. Look at the "hide" buttons and "Show/Hide all optional fields".

**Actual Result**:  Not displayed on all required fields.
**Expected Result**: Displayed on all required fields

# Solution description 
Add 'Hide' option to people fields at objects 'Edit' and 'New' screens for:
Programs'

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".