### PR TITLE
GGRC-8239 Correct letter in error message when a Program already exist

### DIFF
--- a/src/ggrc/models/exceptions.py
+++ b/src/ggrc/models/exceptions.py
@@ -44,10 +44,12 @@ def translate_message(exception):
       matches = pattern.search(message)
       if matches:
         logger.exception(exception)
+        key = field_lookup(matches.group(2))
         return (u"The value {value} is already used for another {key}. "
-                u"{key} values must be unique."
+                u"{capitalized_key} values must be unique."
                 .format(value=matches.group(1),
-                        key=field_lookup(matches.group(2))))
+                        key=key,
+                        capitalized_key=key.capitalize()))
     elif code == 1452:  # cannod set child row: a foreign key constraint fails
       pattern = re.compile(
           r"foreign key constraint fails \(`.+`.`(.+)`, CONSTRAINT `.+` "

--- a/test/integration/ggrc/models/test_program.py
+++ b/test/integration/ggrc/models/test_program.py
@@ -76,6 +76,19 @@ class TestProgram(TestCase):
         response.json[0][1]
     )
 
+  def test_program_error(self):
+    """Test rise error if program already exist"""
+    title1 = "Title 1"
+    with factories.single_commit():
+      factories.ProgramFactory(title=title1)
+    error = (u"The value 'Title 1' is already used for another title. "
+             u"Title values must be unique.")
+    response = self.api.post(
+        all_models.Program,
+        {"program": {"title": title1}}
+    )
+    self.assertEqual(error, response.json)
+
 
 @ddt.ddt
 class TestProgramVersionHistory(TestCase):


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Correct upper case in error message when a Program with already existing title

# Steps to test the changes

1. Create a program with already existing title 
2. Check the error message 

# Solution description

Letter has been corrected  from lowercase to upper case in error message when a Program already exist

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
