### PR TITLE
GGRC-8664 Newly created GCA's are appeared only after page refresh

### DIFF
--- a/src/ggrc-client/js/models/custom-attributes/custom-attribute-definition.js
+++ b/src/ggrc-client/js/models/custom-attributes/custom-attribute-definition.js
@@ -50,4 +50,17 @@ export default Cacheable.extend({
       value: '*',
     },
   },
+  init() {
+    this._super(...arguments);
+
+    this.bind('created', (event) => {
+      GGRC.custom_attr_defs.push(event.target.serialize());
+    });
+
+    this.bind('destroyed', (event) => {
+      const cads = GGRC.custom_attr_defs;
+      const index = cads.findIndex((cad) => cad.id === event.target.id);
+      cads.splice(index, 1);
+    });
+  },
 });


### PR DESCRIPTION
# Issue description
Newly created GCA's are appeared only after page refresh.

# Steps to test the changes 
1. Open Administration page
2. Open Custom Attributes Tab
3. Click e.g on Programs
4. Click + icon and any Attribute title and select any attribute type e.g Text
5. Click Save & Close button
6. Open LHN =>
7. Click Create button
**Actual Result**: Newly created attribute is not displayed in the Create new program modal.
**Expected result**: Newly created attribute is displayed in the Create new program modal.

# Solution description 
Add new GCA to global variable after creating.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [x] The changes fix the issue and don't cause any apparent regressions. 
- [x] Labels and milestone are correctly set. 
- [x] The solution description matches the changes in the code. 
- [x] There is no apparent way to improve the performance & design of the new code. 
- [x] The pull request is opened against the correct base branch. 
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".