### PR TITLE
[Matrix view] QUICK-FIX Match assessments with cads if cad is null

### DIFF
--- a/test/integration/ggrc/bulk_operations/test_matrix.py
+++ b/test/integration/ggrc/bulk_operations/test_matrix.py
@@ -405,3 +405,44 @@ class TestMatrix(ggrc.TestCase):
         "assessments": self._generate_assessment_response(self.asmt1),
     }
     self.assert_request(expected_response)
+
+  def test_assessment_no_cads(self):
+    """Test query assessment without local custom attributes"""
+    expected_response = {
+        "attributes": [],
+        "assessments": self._generate_assessment_response(self.asmt1),
+    }
+    self.assert_request(expected_response)
+
+  def test_two_assessments_one_no_cads(self):
+    # pylint: disable=invalid-name
+    """Test query two assessments where one has no any lca"""
+    with factories.single_commit():
+      cad = factories.CustomAttributeDefinitionFactory(
+          definition_id=self.asmt1.id,
+          **self._get_payload("Text")
+      )
+      asmt2 = factories.AssessmentFactory(
+          assessment_type="Control",
+          sox_302_enabled=True,
+      )
+    expected_response = {
+        "attributes": [{
+            "title": cad.title,
+            "mandatory": cad.mandatory,
+            "attribute_type": cad.attribute_type,
+            "default_value": cad.default_value,
+            "values": {
+                str(self.asmt1.id): {
+                    "value": None,
+                    "attribute_person_id": None,
+                    "definition_id": self.asmt1.id,
+                    "attribute_definition_id": cad.id,
+                    "multi_choice_options": cad.multi_choice_options,
+                    "multi_choice_mandatory": cad.multi_choice_mandatory,
+                }
+            },
+        }],
+        "assessments": self._generate_assessment_response(self.asmt1, asmt2),
+    }
+    self.assert_request(expected_response)


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

There is an empty response for cavs/search if assessments value in empty if assessment has no any LCA

# Steps to test the changes

1. Create audit
2. Create asmt template
3. Gen assessment
4. Run query:
_fetch("http://localhost:8080/api/bulk_operations/cavs/search", {"credentials":"include","headers":{"accept":"*/*","accept-language":"en-GB,en-US;q=0.9,en;q=0.8","cache-control":"max-age=0","content-type":"application/json","if-match":"undefined","if-unmodified-since":"undefined","sec-fetch-dest":"empty","sec-fetch-mode":"cors","sec-fetch-site":"same-origin","x-requested-by":"GGRC","x-requested-with":"XMLHttpRequest","x-usertimezoneoffset":"180"},"referrer":"http://localhost:8080/assessments_view","referrerPolicy":"no-referrer-when-downgrade","body":"[{\"object_name\":\"Assessment\",\"type\":\"ids\",\"fields\":[],\"filters\":{\"expression\":{\"left\":{\"left\":\"assignees\",\"op\":{\"name\":\"~\"},\"right\":\"user@example.com\"},\"op\":{\"name\":\"AND\"},\"right\":{\"left\":{\"left\":\"status\",\"op\":{\"name\":\"IN\"},\"right\":[\"Not Started\",\"In Progress\",\"Rework Needed\"]},\"op\":{\"name\":\"AND\"},\"right\":{\"left\":{\"left\":\"sox_302_enabled\",\"op\":{\"name\":\"=\"},\"right\":\"yes\"},\"op\":{\"name\":\"AND\"},\"right\":{\"left\":\"archived\",\"op\":{\"name\":\"=\"},\"right\":\"No\"}}}}}}]","method":"POST","mode":"cors"});_

# Solution description

Changed `_query_all_cads_asmt_matches` with full outerjoin of cads and assessments

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
