### PR TITLE
GGRC-7809 Rich text edit field overlays object border

### DIFF
--- a/src/ggrc-client/styles/components/form/_ggrc-form.scss
+++ b/src/ggrc-client/styles/components/form/_ggrc-form.scss
@@ -75,8 +75,11 @@
   }
 
   .ggrc-form-item {
-    margin-bottom: 20px;
     display: flex;
+
+    &:not(:last-child) {
+      margin-bottom: 20px;
+    }
 
     &.hidden {
       display: none;

--- a/src/ggrc-client/styles/components/inline-edit-control/_inline-edit-control.scss
+++ b/src/ggrc-client/styles/components/inline-edit-control/_inline-edit-control.scss
@@ -74,7 +74,7 @@ inline-edit-control {
 
       &.inline--hidden {
         opacity: 0;
-        max-height: 424px;
+        height: 130px;
       }
 
       &.inline--active {


### PR DESCRIPTION
# Issue description
Rich text edit field overlays object border.

# Steps to test the changes 
1. Login in the app.
2. Add Rich Text GCA to the any object, e.g Product.
3. Open any Product and edit created in the previous step field.

**Actual Result**:  Rich text edit field overlays object border.
**Expected Result**: Rich text edit field fits in object border.

# Solution description 
  Add space below.

# Sanity checklist 
- [x] I have clicked through the app to make sure my changes work and not break the app. 
- [x] I have applied the correct milestone and labels. 
- [x] My changes fix the issue described in the description (and do nothing else). 🤞 
- [ ] My changes are covered by tests. 
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..). 
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/sou..) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/sou..) guidelines. 
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/sou..).

# PR Review checklist 
- [ ] The changes fix the issue and don't cause any apparent regressions. 
- [ ] Labels and milestone are correctly set. 
- [ ] The solution description matches the changes in the code. 
- [ ] There is no apparent way to improve the performance & design of the new code. 
- [ ] The pull request is opened against the correct base branch. 
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".