### PR TITLE
GGRC-1863 "Superuser" role is shown while filter is applied for Creator in People tab on Administration page

### DIFF
--- a/src/ggrc/integrations/synchronization_jobs/__init__.py
+++ b/src/ggrc/integrations/synchronization_jobs/__init__.py
@@ -8,6 +8,12 @@ from ggrc.integrations.synchronization_jobs.assessment_sync_job import \
     sync_assessment_attributes
 from ggrc.integrations.synchronization_jobs.issue_sync_job import \
     sync_issue_attributes
+from ggrc.integrations.synchronization_jobs.superusers_sync_job import \
+    sync_superusers
 
 
-__all__ = ["sync_assessment_attributes", "sync_issue_attributes"]
+__all__ = [
+    "sync_assessment_attributes",
+    "sync_issue_attributes",
+    "sync_superusers",
+]

--- a/src/ggrc/integrations/synchronization_jobs/superusers_sync_job.py
+++ b/src/ggrc/integrations/synchronization_jobs/superusers_sync_job.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Superusers synchronization functionality via cron job."""
+
+import logging
+
+from ggrc import settings
+from ggrc import db
+from ggrc.models import all_models
+from ggrc.utils import user_generator
+from ggrc.utils import log_event
+from ggrc import login
+
+
+logger = logging.getLogger(__name__)
+
+
+def sync_superusers():
+  """Delete roles stored in database for superusers
+
+  Superuser role allows users full permissions, and it overrides the
+  role stored in the database.
+  Admin page filters the users by their roles in the database and displays
+  it on the UI, but if user has Superuser role than it will be used
+  """
+  users = all_models.Person.query.filter(
+      all_models.Person.email.in_(settings.BOOTSTRAP_ADMIN_USERS)
+  ).all()
+  logger.info("Syncing state of %d superusers.", len(users))
+  processed_ids_count = 0
+  user_id = login.get_current_user_id() or user_generator.get_migrator_id()
+  for user in all_models.Person.query.filter(
+      all_models.Person.email.in_(settings.BOOTSTRAP_ADMIN_USERS)
+  ):
+    for user_role in user.user_roles:
+      db.session.delete(user_role)
+      log_event.log_event(db.session, user_role, current_user_id=user_id)
+      processed_ids_count += 1
+  logger.info(
+      "Sync is done, %d superusers(s) were processed.",
+      processed_ids_count,
+  )
+  if processed_ids_count:
+    db.session.commit()

--- a/test/integration/ggrc/integrations/test_superusers_sync_job.py
+++ b/test/integration/ggrc/integrations/test_superusers_sync_job.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2020 Google Inc.
+# Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
+
+"""Integration test for Superusers persons sync cron job."""
+
+
+import mock
+
+from ggrc import settings
+from ggrc.models import all_models
+from ggrc.integrations import synchronization_jobs
+
+from integration import ggrc
+from integration.ggrc.models import factories
+from integration.ggrc_basic_permissions.models \
+    import factories as rbac_factories
+
+
+@mock.patch.object(
+    settings,
+    "BOOTSTRAP_ADMIN_USERS",
+    ["superuser@example.com"],
+)
+class TestSuperuserSyncJob(ggrc.TestCase):
+  """Test cron job for sync Superuser Person objects."""
+
+  def setUp(self):
+    super(TestSuperuserSyncJob, self).setUp()
+    with factories.single_commit():
+      role = all_models.Role.query.filter(
+          all_models.Role.name == "Administrator"
+      ).one()
+      self.admin = factories.PersonFactory(
+          email="test@example.com",
+          name="Test Test",
+      )
+      rbac_factories.UserRoleFactory(role=role, person=self.admin)
+      self.superuser = factories.PersonFactory(
+          email="superuser@example.com",
+          name="Super User",
+      )
+      rbac_factories.UserRoleFactory(role=role, person=self.superuser)
+
+  def test_superuser_role_deleted(self):
+    """Test superuser person with admin role set to no role"""
+    synchronization_jobs.sync_superusers()
+    admin = self.refresh_object(self.admin)
+    superuser = self.refresh_object(self.superuser)
+    self.assertNotEqual(admin.user_roles, [])
+    self.assertEqual(superuser.user_roles, [])


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Superuser has system wide roles stored in DB (Ex. Creator, Editor, Reader, Administrator).
Admin page filters the users by their roles in the database and displays it on the UI, but if user has Superuser role than it will be used

# Steps to test the changes

Steps to reproduce:
1. As admin go to Administration page> People tab
2. Set filter by role "Creator"
Active Results: "Superuser" role is shown while filter is applied for Creator
Expected Result: "Creator" role is shown while filter is applied for Creator

# Solution description

Cron job which removes roles stored in db for superusers

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
