### PR TITLE
GGRC-8815 Incorrect redirection link for all Scope Objects in ACTIVE state only

### DIFF
--- a/src/ggrc-client/js/components/redirects/external-control/external-control.js
+++ b/src/ggrc-client/js/components/redirects/external-control/external-control.js
@@ -7,13 +7,13 @@ import canStache from 'can-stache';
 import canMap from 'can-map';
 import canComponent from 'can-component';
 import template from './templates/external-control.stache';
-import {getQuestionsUrl} from '../../../plugins/utils/ggrcq-utils';
+import {getQuestionsAttrUrl} from '../../../plugins/utils/ggrcq-utils';
 
 const viewModel = canMap.extend({
   define: {
     link: {
       get() {
-        return getQuestionsUrl(this.attr('instance'));
+        return getQuestionsAttrUrl(this.attr('instance'));
       },
     },
   },

--- a/src/ggrc-client/js/plugins/tests/ggrcq-utils_spec.js
+++ b/src/ggrc-client/js/plugins/tests/ggrcq-utils_spec.js
@@ -10,6 +10,7 @@ import {
   getMappingUrl,
   getUnmappingUrl,
   getChangeLogUrl,
+  getQuestionsAttrUrl,
   isMappableExternally,
   getCreateObjectUrl,
 } from '../utils/ggrcq-utils';
@@ -451,6 +452,31 @@ describe('GGRCQ utils', () => {
     it('should return proper url for non-scope object', () => {
       const url = `${GGRC.GGRC_Q_INTEGRATION_URL}controls?action=create`;
       expect(getCreateObjectUrl(Control)).toBe(url);
+    });
+  });
+
+  describe('getQuestionsAttrUrl util', () => {
+    it('should return proper url for scope object in Active status', () => {
+      let instance = makeFakeInstance({model: TechnologyEnvironment})({
+        type: 'TechnologyEnvironment',
+        slug: 'TechnologyEnvironment-1',
+        status: 'Active',
+      });
+      const url = GGRC.GGRC_Q_INTEGRATION_URL +
+      'questionnaires/technology_environment=' +
+      'technologyenvironment-1/initialize';
+      expect(getQuestionsAttrUrl(instance)).toBe(url);
+    });
+
+    it('should return proper url for scope object in Draft status', () => {
+      let instance = makeFakeInstance({model: TechnologyEnvironment})({
+        type: 'TechnologyEnvironment',
+        slug: 'TechnologyEnvironment-1',
+        status: 'Draft',
+      });
+      const url = GGRC.GGRC_Q_INTEGRATION_URL +
+      'questionnaires/technology_environment=technologyenvironment-1';
+      expect(getQuestionsAttrUrl(instance)).toBe(url);
     });
   });
 });

--- a/src/ggrc-client/js/plugins/utils/ggrcq-utils.js
+++ b/src/ggrc-client/js/plugins/utils/ggrcq-utils.js
@@ -98,6 +98,19 @@ function getQuestionsUrl(instance) {
 }
 
 /**
+ * Get attribute url to page with questions
+ * @param {Object} instance - The model instance
+ * @return {String} Url to questions
+ */
+function getQuestionsAttrUrl(instance) {
+  const questionsUrl = getQuestionsUrl(instance);
+  if (instance.status === 'Active') {
+    return `${questionsUrl}/initialize`;
+  }
+  return questionsUrl;
+}
+
+/**
  * Get url to info view
  * @param {Object} instance - The model instance
  * @return {String} Url to info view
@@ -338,6 +351,7 @@ export {
   getReviewUrl,
   getMappingUrl,
   getUnmappingUrl,
+  getQuestionsAttrUrl,
   getCreateObjectUrl,
   getUrl,
   getProposalsUrl,


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Incorrect redirection link for all Scope Objects in ACTIVE state. User should be redirected to the Background Info page on Q side when Edit icon of any field is clicked of any ACTIVE Scope object on GGRC. Url should be the following `https://${urlToQ}/questionnaires/key_report=keyreport-57/initialize
`
# Steps to test the changes

1. Open any Scope object in Active status
2. Click on Edit icon for any fields
3. Verify that redirection url contains `/initialize` 
4. Verify that any Scope object in other status does not contain `/initialize`  in redirection url for fields. 

# Solution description

Added `getQuestionsAttrUrl` method to build url based on status

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [x] I have applied the correct milestone and labels.
- [x] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
- [ ] Upon merging, add 'check migration chain' and 'kokoro:force-run' labels to all open PRs with a label 'migration'
- [ ] Upon merging, update 'table structure changes' in weekly deployment documentation
-->

# PR Review checklist

- [x] The changes fix the issue and don't cause any apparent regressions.
- [x] Labels and milestone are correctly set.
- [x] The solution description matches the changes in the code.
- [x] There is no apparent way to improve the performance & design of the new code.
- [x] The pull request is opened against the correct base branch.
- [x] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

<!-- If your code is not finished yet can include a TODO check list
# TODO

- [ ] First item on the TODO
-->
